### PR TITLE
feat(macos): gate SCKit loopback behind opt-in `sckit-loopback` feature

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -120,10 +120,11 @@ dependencies = [
 
 [[package]]
 name = "apple-metal"
-version = "0.6.1"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c1b0238c7353ce2a000cb261e7168e1ea4e3b21ecb525caa9ea2e9e60a5aa3"
+checksum = "770ed47ba948122fc9ce0bc10a433cf9fabcf1c2ed6d44db5b7ad0d70ffede15"
 dependencies = [
+ "doom-fish-utils",
  "libc",
 ]
 
@@ -4339,7 +4340,6 @@ name = "recast"
 version = "0.0.0-0"
 dependencies = [
  "anyhow",
- "apple-metal",
  "ashpd",
  "base64 0.22.1",
  "chrono",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -91,32 +91,32 @@ device_query = "2.1"
 
 # macOS-only: native ScreenCaptureKit bindings for system-audio loopback
 # (and later screen capture). Eliminates the BlackHole virtual-driver
-# requirement that the FFmpeg fallback chain depends on. The crate has a
-# Swift bridge (`build.rs` invokes `swiftc`) so it only builds on a macOS
-# host — Tauri's CI macos-latest runner has Xcode preinstalled.
+# requirement that the FFmpeg fallback chain depends on.
 #
-# Why `screencapturekit` (the safe wrapper) rather than the lower-level
-# `objc2-screen-capture-kit`: the 6.x release line stabilised the API
-# (the earlier 0.2/0.3 module-path churn that caused us to back out is
-# resolved), exposes a plain Rust `SCStreamOutputTrait` for sample
-# callbacks (no `declare_class!` gymnastics), and has documented
-# Tauri integration examples. `objc2-screen-capture-kit` is still the
-# right escape hatch if we ever need API surface this crate doesn't
-# wrap.
+# **Opt-in feature `sckit-loopback`.** The `screencapturekit` 6.x crate
+# transitively pulls `apple-metal`, whose Swift bridge references macOS
+# 26 SDK symbols (`MTLSamplerReductionMode`) and macOS 14.4 SDK symbols
+# (`reactiveTextureUsage`) unconditionally — neither is available on the
+# GH Actions `macos-latest` runner's Xcode. Pinning `apple-metal` to
+# older versions doesn't help; the macOS 14.4 references go back to 0.6.x.
+# This is an upstream packaging bug in `apple-metal` (should be `#if
+# canImport(...)` compile-time gates, not runtime `#available` checks).
 #
-# `macos_13_0` feature enables SCStream audio loopback — the system-audio
-# capability shipped in macOS 13. We don't enable `macos_14_0`+ to avoid
-# accidentally depending on APIs that won't exist on the deployment
-# target.
+# Until upstream is fixed (or the runner gets a newer SDK), the dep is
+# gated behind the `sckit-loopback` feature so default builds stay green.
+# Builds with `--features sckit-loopback` against a Mac that has the
+# required SDK locally will exercise the native SCKit path; everyone else
+# falls through to the existing BlackHole / silence chain in
+# `audio/platform/ffmpeg_unix.rs`.
 [target.'cfg(target_os = "macos")'.dependencies]
-screencapturekit = { version = "6.0", default-features = false, features = ["macos_13_0"] }
-# Transitive dep of `screencapturekit`. The 0.8.x line started referencing
-# `MTLSamplerReductionMode` (a macOS 26 SDK symbol) in its Swift bridge,
-# which breaks compile on GH Actions' `macos-latest` runner (it ships an
-# Xcode SDK older than 26). Pin to the 0.6.x line — it predates the
-# macOS 26 references but is still within `screencapturekit`'s allowed
-# range (`>=0.6, <0.9`). Bump only after the runner's SDK catches up.
-apple-metal = { version = "=0.6.1", default-features = false }
+screencapturekit = { version = "6.0", default-features = false, features = ["macos_13_0"], optional = true }
+
+[features]
+default = []
+# Enables the native ScreenCaptureKit audio loopback path on macOS.
+# See `audio/platform/macos_sckit.rs` for the runtime smoke-test
+# checklist before flipping this on for a release build.
+sckit-loopback = ["dep:screencapturekit"]
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -95,7 +95,7 @@ device_query = "2.1"
 #
 # **Opt-in feature `sckit-loopback`.** The `screencapturekit` 6.x crate
 # transitively pulls `apple-metal`, whose Swift bridge references macOS
-# 26 SDK symbols (`MTLSamplerReductionMode`) and macOS 14.4 SDK symbols
+# 10.15 SDK symbols (`MTLSamplerReductionMode`) and macOS 14.4 SDK symbols
 # (`reactiveTextureUsage`) unconditionally — neither is available on the
 # GH Actions `macos-latest` runner's Xcode. Pinning `apple-metal` to
 # older versions doesn't help; the macOS 14.4 references go back to 0.6.x.

--- a/apps/desktop/src-tauri/src/audio/platform/macos_sckit.rs
+++ b/apps/desktop/src-tauri/src/audio/platform/macos_sckit.rs
@@ -6,7 +6,7 @@
 //! `try_start` returns `Err` and the caller falls through to the
 //! virtual-driver detection in `ffmpeg_unix::PlatformAudioSession`.
 //!
-//! ## How it works
+//! ## How it works (when enabled)
 //!
 //! 1. We discover the first available display via `SCShareableContent`
 //!    (SCKit needs *some* content filter even for an audio-only capture).
@@ -36,300 +36,330 @@
 //! SCKit requires the **Screen Recording** TCC permission — not "audio
 //! input", because the audio path is bolted onto the screen-capture
 //! API. The user grants this once via System Settings → Privacy &
-//! Security → Screen Recording. We add the `NSScreenCaptureUsageDescription`
-//! key via `tauri.conf.json`'s macOS Info.plist so macOS shows our
-//! human-readable explanation when prompting.
+//! Security → Screen Recording.
 //!
-//! ## Status
+//! ## Status — gated behind `sckit-loopback` Cargo feature
 //!
-//! **Compile-tested only.** This code was written from the
-//! `screencapturekit` 6.x docs and examples; it has not been run on
-//! macOS hardware yet. The runtime smoke-test checklist lives at the
-//! bottom of this file. Until that test pass lands, behaviour on real
-//! Macs is unverified — but the fallback chain in
-//! `ffmpeg_unix::PlatformAudioSession::start` already handles SCKit
-//! failure gracefully (logs an info line, then tries BlackHole, then
-//! silence), so a broken SCKit integration degrades rather than blocks.
+//! **Compile-tested only, and disabled by default.** The
+//! `screencapturekit` 6.x crate transitively pulls `apple-metal`, whose
+//! Swift bridge unconditionally references macOS 14.4 and macOS 26 SDK
+//! symbols (`reactiveTextureUsage`, `MTLSamplerReductionMode`) that
+//! aren't on the GH Actions `macos-latest` runner's Xcode. Until the
+//! upstream `apple-metal` packaging bug is fixed (should be
+//! `#if canImport(...)` compile-time gates, not runtime `#available`
+//! checks), enabling the dep would break our CI macOS compile.
+//!
+//! Build flow:
+//! - **Default**: `try_start` returns `Err` immediately; caller falls
+//!   through to BlackHole detection → silence. CI compiles green.
+//! - **`--features sckit-loopback`**: real SCKit integration; requires
+//!   a local Xcode SDK that has the missing symbols. Runtime smoke-test
+//!   checklist lives at the bottom of this file.
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
-use parking_lot::Mutex;
-use screencapturekit::prelude::*;
-// `AudioBufferList` is re-exported from the crate root but intentionally
-// not in the prelude (it's a less-common type). The buffer conversion
-// helper needs it for its function signature.
-use screencapturekit::AudioBufferList;
+use anyhow::Result;
 
-use crate::audio::wav::WavWriter;
+#[cfg(feature = "sckit-loopback")]
+pub use enabled::ScKitLoopback;
 
-const SAMPLE_RATE: u32 = 48_000;
-const CHANNELS: u16 = 2;
-const BITS_PER_SAMPLE: u16 = 16;
+#[cfg(not(feature = "sckit-loopback"))]
+pub use disabled::ScKitLoopback;
 
-pub struct ScKitLoopback {
-    /// The live capture stream. Stays alive for the duration of the
-    /// recording — dropping it would stop capture, but we always go
-    /// through `stop()` for an orderly shutdown.
-    stream: SCStream,
-    /// Shared with the audio handler. `Some(writer)` while open; the
-    /// handler appends samples through this. `stop()` takes it out and
-    /// finalises the WAV header.
-    wav_writer: Arc<Mutex<Option<WavWriter>>>,
-    /// Output path we promised the caller. Returned by `stop()` so the
-    /// recording manager can hand it to the muxer.
-    output_path: PathBuf,
-}
+#[cfg(not(feature = "sckit-loopback"))]
+mod disabled {
+    use super::*;
+    use anyhow::anyhow;
 
-impl ScKitLoopback {
-    /// Try to start a ScreenCaptureKit audio loopback session.
-    ///
-    /// Returns `Err` (and the caller falls back to virtual-driver
-    /// detection / silence) when:
-    /// - the host is macOS < 13 (SCKit audio API is unavailable),
-    /// - the user denied Screen Recording permission,
-    /// - no displays are present (SCKit can't build a content filter),
-    /// - the WAV output path can't be created.
-    pub fn try_start(output_path: PathBuf, pause_flag: Arc<AtomicBool>) -> Result<Self> {
-        // 1. Get shareable content. This call performs the TCC permission
-        //    check; if the user hasn't granted Screen Recording it returns
-        //    an error and we fall through to BlackHole detection.
-        let content = SCShareableContent::get()
-            .map_err(|e| anyhow!("SCShareableContent::get failed (permission denied?): {e:?}"))?;
-        let display = content
-            .displays()
-            .into_iter()
-            .next()
-            .context("no SCKit displays available")?;
-
-        // 2. Audio-only filter. We still bind to a display because SCKit
-        //    requires *some* content selection; the screen frames it emits
-        //    are drained by a no-op handler below.
-        let filter = SCContentFilter::create()
-            .with_display(&display)
-            .with_excluding_windows(&[])
-            .build();
-
-        // 3. Configure: audio enabled, exclude our own process so the
-        //    recording isn't a feedback loop, 48 kHz / 2 ch to match the
-        //    project's WAV format. Width/height are tiny because we don't
-        //    consume the video output — SCKit still allocates them, so
-        //    keeping them small minimises wasted GPU memory.
-        let config = SCStreamConfiguration::new()
-            .with_width(2)
-            .with_height(2)
-            .with_captures_audio(true)
-            .with_excludes_current_process_audio(true)
-            .with_sample_rate(SAMPLE_RATE as i32)
-            .with_channel_count(CHANNELS as i32);
-
-        // 4. WAV writer. Lives behind Arc<Mutex<Option<_>>> so the SCKit
-        //    audio callback can grab it from the dispatch queue and
-        //    `stop()` can take it out for finalisation.
-        let writer = WavWriter::new(&output_path, SAMPLE_RATE, CHANNELS, BITS_PER_SAMPLE)
-            .context("failed to create WAV writer for SCKit loopback")?;
-        let wav_writer = Arc::new(Mutex::new(Some(writer)));
-
-        // 5. Build handlers and start the stream.
-        let audio_handler = SckitAudioHandler {
-            wav_writer: wav_writer.clone(),
-            pause_flag: pause_flag.clone(),
-        };
-        let mut stream = SCStream::new(&filter, &config);
-        // Screen output: drain frames so the stream doesn't back-pressure.
-        stream.add_output_handler(NoopScreenHandler, SCStreamOutputType::Screen);
-        stream.add_output_handler(audio_handler, SCStreamOutputType::Audio);
-        stream
-            .start_capture()
-            .map_err(|e| anyhow!("SCStream::start_capture failed: {e:?}"))?;
-
-        log::info!("ScreenCaptureKit audio loopback started");
-
-        Ok(Self {
-            stream,
-            wav_writer,
-            output_path,
-        })
+    pub struct ScKitLoopback {
+        _placeholder: (),
     }
 
-    /// Stop the SCKit stream and finalise the WAV header. Returns the
-    /// output path the caller passed in at `try_start`.
-    pub fn stop(mut self) -> Result<PathBuf> {
-        // Stop capture before taking the writer — once stopped, the SCKit
-        // queue is guaranteed not to fire more callbacks, so the take()
-        // below races with nothing.
-        if let Err(e) = self.stream.stop_capture() {
-            log::warn!("SCStream::stop_capture errored (ignoring): {e:?}");
+    impl ScKitLoopback {
+        /// Always returns `Err` when the `sckit-loopback` feature is off —
+        /// the caller treats that as "skip SCKit, try the virtual-driver
+        /// chain next". The error message is informational; it lands in
+        /// the log at `info` level (not `warn`), since this is the
+        /// expected default-build behaviour, not a failure mode.
+        pub fn try_start(_output_path: PathBuf, _pause_flag: Arc<AtomicBool>) -> Result<Self> {
+            Err(anyhow!(
+                "ScreenCaptureKit loopback disabled (build with --features \
+                 sckit-loopback to enable; requires Xcode with macOS 14.4+ SDK)"
+            ))
         }
-        if let Some(writer) = self.wav_writer.lock().take() {
-            writer.finish().context("failed to finalise SCKit WAV")?;
+
+        /// Unreachable while `try_start` always errs. Kept so the type's
+        /// public surface matches what the caller would expect once the
+        /// real implementation lands.
+        pub fn stop(self) -> Result<PathBuf> {
+            unreachable!(
+                "ScKitLoopback::stop must not be called against the placeholder — \
+                 try_start always returns Err so no session ever exists"
+            )
         }
-        Ok(self.output_path)
     }
 }
 
-/// Audio sample-buffer handler. Called from SCKit's dispatch queue, not
-/// from the recording thread — every field has to be `Send + Sync` and
-/// the work has to be fast (a queue backup is observable as audio
-/// drift). We do a single fixed-point conversion + one mutex acquire
-/// per buffer; the WAV writer's `write_samples` is just `file.write_all`.
-struct SckitAudioHandler {
-    wav_writer: Arc<Mutex<Option<WavWriter>>>,
-    pause_flag: Arc<AtomicBool>,
-}
+#[cfg(feature = "sckit-loopback")]
+mod enabled {
+    use super::*;
+    use std::sync::atomic::Ordering;
 
-impl SCStreamOutputTrait for SckitAudioHandler {
-    fn did_output_sample_buffer(&self, sample: CMSampleBuffer, of_type: SCStreamOutputType) {
-        if of_type != SCStreamOutputType::Audio {
-            return;
+    use anyhow::{anyhow, Context};
+    use parking_lot::Mutex;
+    use screencapturekit::prelude::*;
+    // `AudioBufferList` is re-exported from the crate root but intentionally
+    // not in the prelude (it's a less-common type). The buffer conversion
+    // helper needs it for its function signature.
+    use screencapturekit::AudioBufferList;
+
+    use crate::audio::wav::WavWriter;
+
+    const SAMPLE_RATE: u32 = 48_000;
+    const CHANNELS: u16 = 2;
+    const BITS_PER_SAMPLE: u16 = 16;
+
+    pub struct ScKitLoopback {
+        /// The live capture stream. Stays alive for the duration of the
+        /// recording — dropping it would stop capture, but we always go
+        /// through `stop()` for an orderly shutdown.
+        stream: SCStream,
+        /// Shared with the audio handler. `Some(writer)` while open; the
+        /// handler appends samples through this. `stop()` takes it out and
+        /// finalises the WAV header.
+        wav_writer: Arc<Mutex<Option<WavWriter>>>,
+        /// Output path we promised the caller. Returned by `stop()` so the
+        /// recording manager can hand it to the muxer.
+        output_path: PathBuf,
+    }
+
+    impl ScKitLoopback {
+        /// Try to start a ScreenCaptureKit audio loopback session.
+        pub fn try_start(output_path: PathBuf, pause_flag: Arc<AtomicBool>) -> Result<Self> {
+            // 1. Permission gate. `SCShareableContent::get` performs the TCC
+            //    check; denial returns an error and we fall through to
+            //    BlackHole detection.
+            let content = SCShareableContent::get().map_err(|e| {
+                anyhow!("SCShareableContent::get failed (permission denied?): {e:?}")
+            })?;
+            let display = content
+                .displays()
+                .into_iter()
+                .next()
+                .context("no SCKit displays available")?;
+
+            // 2. Audio-only filter. We still bind to a display because SCKit
+            //    requires *some* content selection; the screen frames it emits
+            //    are drained by a no-op handler below.
+            let filter = SCContentFilter::create()
+                .with_display(&display)
+                .with_excluding_windows(&[])
+                .build();
+
+            // 3. Configure: audio enabled, exclude our own process so the
+            //    recording isn't a feedback loop, 48 kHz / 2 ch to match the
+            //    project's WAV format.
+            let config = SCStreamConfiguration::new()
+                .with_width(2)
+                .with_height(2)
+                .with_captures_audio(true)
+                .with_excludes_current_process_audio(true)
+                .with_sample_rate(SAMPLE_RATE as i32)
+                .with_channel_count(CHANNELS as i32);
+
+            // 4. WAV writer.
+            let writer = WavWriter::new(&output_path, SAMPLE_RATE, CHANNELS, BITS_PER_SAMPLE)
+                .context("failed to create WAV writer for SCKit loopback")?;
+            let wav_writer = Arc::new(Mutex::new(Some(writer)));
+
+            // 5. Build handlers and start the stream.
+            let audio_handler = SckitAudioHandler {
+                wav_writer: wav_writer.clone(),
+                pause_flag: pause_flag.clone(),
+            };
+            let mut stream = SCStream::new(&filter, &config);
+            stream.add_output_handler(NoopScreenHandler, SCStreamOutputType::Screen);
+            stream.add_output_handler(audio_handler, SCStreamOutputType::Audio);
+            stream
+                .start_capture()
+                .map_err(|e| anyhow!("SCStream::start_capture failed: {e:?}"))?;
+
+            log::info!("ScreenCaptureKit audio loopback started");
+
+            Ok(Self {
+                stream,
+                wav_writer,
+                output_path,
+            })
         }
-        if self.pause_flag.load(Ordering::Acquire) {
-            return;
+
+        /// Stop the SCKit stream and finalise the WAV header.
+        pub fn stop(mut self) -> Result<PathBuf> {
+            if let Err(e) = self.stream.stop_capture() {
+                log::warn!("SCStream::stop_capture errored (ignoring): {e:?}");
+            }
+            if let Some(writer) = self.wav_writer.lock().take() {
+                writer.finish().context("failed to finalise SCKit WAV")?;
+            }
+            Ok(self.output_path)
         }
-        let Some(list) = sample.audio_buffer_list() else {
-            return;
-        };
+    }
 
-        let s16_bytes = match convert_audio_buffer_list_to_s16le(&list) {
-            Some(b) if !b.is_empty() => b,
-            _ => return,
-        };
+    /// Audio sample-buffer handler. Called from SCKit's dispatch queue, not
+    /// from the recording thread — every field has to be `Send + Sync` and
+    /// the work has to be fast (a queue backup is observable as audio
+    /// drift). We do a single fixed-point conversion + one mutex acquire
+    /// per buffer; the WAV writer's `write_samples` is just `file.write_all`.
+    struct SckitAudioHandler {
+        wav_writer: Arc<Mutex<Option<WavWriter>>>,
+        pause_flag: Arc<AtomicBool>,
+    }
 
-        let mut guard = self.wav_writer.lock();
-        if let Some(writer) = guard.as_mut() {
-            if let Err(e) = writer.write_samples(&s16_bytes) {
-                log::warn!("SCKit WAV write failed (dropping sample): {e}");
+    impl SCStreamOutputTrait for SckitAudioHandler {
+        fn did_output_sample_buffer(&self, sample: CMSampleBuffer, of_type: SCStreamOutputType) {
+            if of_type != SCStreamOutputType::Audio {
+                return;
+            }
+            if self.pause_flag.load(Ordering::Acquire) {
+                return;
+            }
+            let Some(list) = sample.audio_buffer_list() else {
+                return;
+            };
+
+            let s16_bytes = match convert_audio_buffer_list_to_s16le(&list) {
+                Some(b) if !b.is_empty() => b,
+                _ => return,
+            };
+
+            let mut guard = self.wav_writer.lock();
+            if let Some(writer) = guard.as_mut() {
+                if let Err(e) = writer.write_samples(&s16_bytes) {
+                    log::warn!("SCKit WAV write failed (dropping sample): {e}");
+                }
             }
         }
     }
-}
 
-/// No-op screen handler. SCKit emits video sample buffers even when we
-/// only care about audio (it's a single stream); without a drain the
-/// queue eventually back-pressures.
-struct NoopScreenHandler;
+    /// No-op screen handler. SCKit emits video sample buffers even when we
+    /// only care about audio (it's a single stream); without a drain the
+    /// queue eventually back-pressures.
+    struct NoopScreenHandler;
 
-impl SCStreamOutputTrait for NoopScreenHandler {
-    fn did_output_sample_buffer(&self, _sample: CMSampleBuffer, _of_type: SCStreamOutputType) {
-        // Drop the buffer. The CMSampleBuffer's Drop releases the
-        // underlying CoreVideo image buffer, so GPU memory is freed
-        // every tick.
-    }
-}
-
-/// Convert a SCKit `AudioBufferList` (Float32 PCM) into interleaved
-/// `s16le` bytes, ready to feed `WavWriter::write_samples`.
-///
-/// SCKit's default audio format is `kAudioFormatLinearPCM` Float32. The
-/// list's layout depends on the format flags:
-///
-/// - **Interleaved** (rare for SCKit, but possible): 1 buffer with N
-///   channels' samples woven together — `L0 R0 L1 R1 …`.
-/// - **Non-interleaved / planar** (SCKit default): N buffers, each one
-///   channel's samples — `buffers[0] = L0 L1 L2 …`, `buffers[1] = R0 R1 R2 …`.
-///
-/// We detect by `num_buffers()`: 1 buffer ⇒ interleaved, ≥2 ⇒ planar.
-/// Mono (1-channel) source just falls through the interleaved path.
-fn convert_audio_buffer_list_to_s16le(list: &AudioBufferList) -> Option<Vec<u8>> {
-    let n = list.num_buffers();
-    if n == 0 {
-        return None;
+    impl SCStreamOutputTrait for NoopScreenHandler {
+        fn did_output_sample_buffer(&self, _sample: CMSampleBuffer, _of_type: SCStreamOutputType) {
+            // Drop the buffer. The CMSampleBuffer's Drop releases the
+            // underlying CoreVideo image buffer, so GPU memory is freed
+            // every tick.
+        }
     }
 
-    if n == 1 {
-        // Interleaved (or mono). Convert f32 chunks straight to s16.
-        let buf = list.get(0)?;
-        let bytes = buf.data();
-        let f32_count = bytes.len() / 4;
-        if f32_count == 0 {
+    /// Convert a SCKit `AudioBufferList` (Float32 PCM) into interleaved
+    /// `s16le` bytes, ready to feed `WavWriter::write_samples`.
+    ///
+    /// SCKit's default audio format is `kAudioFormatLinearPCM` Float32. The
+    /// list's layout depends on the format flags:
+    ///
+    /// - **Interleaved** (rare for SCKit, but possible): 1 buffer with N
+    ///   channels' samples woven together — `L0 R0 L1 R1 …`.
+    /// - **Non-interleaved / planar** (SCKit default): N buffers, each one
+    ///   channel's samples — `buffers[0] = L0 L1 L2 …`, `buffers[1] = R0 R1 R2 …`.
+    ///
+    /// We detect by `num_buffers()`: 1 buffer ⇒ interleaved, ≥2 ⇒ planar.
+    /// Mono (1-channel) source just falls through the interleaved path.
+    fn convert_audio_buffer_list_to_s16le(list: &AudioBufferList) -> Option<Vec<u8>> {
+        let n = list.num_buffers();
+        if n == 0 {
             return None;
         }
-        let mut out = Vec::with_capacity(f32_count * 2);
-        for chunk in bytes.chunks_exact(4) {
-            let f = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
-            let i = (f.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16;
-            out.extend_from_slice(&i.to_le_bytes());
-        }
-        return Some(out);
-    }
 
-    // Planar: interleave the first 2 channels (matching our 2 ch config).
-    // If SCKit hands us more channels, we discard the rest — the WAV
-    // header was committed to 2 ch at construction.
-    let l = list.get(0)?;
-    let r = list.get(1)?;
-    let l_bytes = l.data();
-    let r_bytes = r.data();
-    let samples_per_channel = l_bytes.len().min(r_bytes.len()) / 4;
-    if samples_per_channel == 0 {
-        return None;
+        if n == 1 {
+            // Interleaved (or mono). Convert f32 chunks straight to s16.
+            let buf = list.get(0)?;
+            let bytes = buf.data();
+            let f32_count = bytes.len() / 4;
+            if f32_count == 0 {
+                return None;
+            }
+            let mut out = Vec::with_capacity(f32_count * 2);
+            for chunk in bytes.chunks_exact(4) {
+                let f = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                let i = (f.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16;
+                out.extend_from_slice(&i.to_le_bytes());
+            }
+            return Some(out);
+        }
+
+        // Planar: interleave the first 2 channels (matching our 2 ch config).
+        let l = list.get(0)?;
+        let r = list.get(1)?;
+        let l_bytes = l.data();
+        let r_bytes = r.data();
+        let samples_per_channel = l_bytes.len().min(r_bytes.len()) / 4;
+        if samples_per_channel == 0 {
+            return None;
+        }
+        let mut out = Vec::with_capacity(samples_per_channel * 4);
+        for i in 0..samples_per_channel {
+            let off = i * 4;
+            let lf = f32::from_le_bytes([
+                l_bytes[off],
+                l_bytes[off + 1],
+                l_bytes[off + 2],
+                l_bytes[off + 3],
+            ]);
+            let rf = f32::from_le_bytes([
+                r_bytes[off],
+                r_bytes[off + 1],
+                r_bytes[off + 2],
+                r_bytes[off + 3],
+            ]);
+            let li = (lf.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16;
+            let ri = (rf.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16;
+            out.extend_from_slice(&li.to_le_bytes());
+            out.extend_from_slice(&ri.to_le_bytes());
+        }
+        Some(out)
     }
-    let mut out = Vec::with_capacity(samples_per_channel * 4); // 2 ch × 2 bytes
-    for i in 0..samples_per_channel {
-        let off = i * 4;
-        let lf = f32::from_le_bytes([
-            l_bytes[off],
-            l_bytes[off + 1],
-            l_bytes[off + 2],
-            l_bytes[off + 3],
-        ]);
-        let rf = f32::from_le_bytes([
-            r_bytes[off],
-            r_bytes[off + 1],
-            r_bytes[off + 2],
-            r_bytes[off + 3],
-        ]);
-        let li = (lf.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16;
-        let ri = (rf.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16;
-        out.extend_from_slice(&li.to_le_bytes());
-        out.extend_from_slice(&ri.to_le_bytes());
-    }
-    Some(out)
 }
 
 // =============================================================================
 // Runtime smoke-test checklist (for the Mac-having reviewer)
 // =============================================================================
 //
-// 1. Build with `pnpm --filter recast-desktop tauri build` on macOS 13+.
-//    Confirm Swift bridge compiles (build.rs in screencapturekit invokes
-//    swiftc — Xcode CLT must be present).
+// Build with `cargo tauri build --features sckit-loopback` on macOS 13+
+// against an Xcode SDK that has both macOS 14.4 (`reactiveTextureUsage`)
+// and macOS 26 (`MTLSamplerReductionMode`). Without the feature, the
+// stub branch above ships and SCKit is bypassed.
 //
-// 2. First-run permission: launch the bundled .app and start a recording.
+// 1. First-run permission: launch the .app and start a recording.
 //    macOS prompts "Recast wants to record this computer's screen". Grant.
 //    On denial, the log should show
 //      `ScreenCaptureKit loopback unavailable (...) — checking for a
 //       virtual loopback driver`
-//    and the rest of the recording proceeds (silent unless BlackHole is
-//    installed).
+//    and the recording proceeds (silent unless BlackHole is installed).
 //
-// 3. With permission granted, record while playing audio from any app
-//    (Music, YouTube, etc.). Stop the recording. Open the project's
-//    `.audio.wav` and verify:
+// 2. Record while playing audio from any app (Music, YouTube, etc.).
+//    Stop the recording. Open the project's `.audio.wav`:
 //      - non-zero duration
-//      - audio plays back at expected pitch (sample rate mismatch
-//        symptom: chipmunked/slowed playback)
-//      - both channels carry audio (mono symptom: silence in one ear)
+//      - audio plays back at expected pitch (sample-rate mismatch =
+//        chipmunked / slowed playback)
+//      - both channels carry audio (mono in one ear = planar/interleaved
+//        branch detection wrong)
 //
-// 4. Pause-mid-recording test: start recording, play audio, hit pause,
-//    play more audio, hit resume, stop. The resulting WAV should
-//    *concatenate* the pre-pause and post-pause audio with no audible
-//    gap (the WASAPI/Unix paths produce the same behaviour).
+// 3. Pause-mid-recording: start → play audio → pause → play more →
+//    resume → stop. WAV should concatenate with no audible gap.
 //
-// 5. Feedback-loop check: play audio from a tab in the *app's own*
-//    WebView (any /audio test page works). The recorded WAV should
-//    NOT contain the WebView audio — `excludes_current_process_audio`
-//    is doing its job.
+// 4. Feedback-loop check: play audio from a tab in the *app's own*
+//    WebView. The recorded WAV should NOT contain WebView audio —
+//    `excludes_current_process_audio` is doing its job.
 //
-// 6. Stress: 30-minute continuous recording. Watch Activity Monitor's
-//    "Recast" process — RAM should be flat, CPU under 5% for the audio
-//    thread. A leak symptom is monotonic RAM growth tied to capture
-//    duration.
+// 5. Stress: 30-minute continuous recording. Activity Monitor's "Recast"
+//    process should show flat RAM, CPU under 5% for the audio thread.
 //
-// If any of (3)-(6) fails, the buffer-conversion logic in
-// `convert_audio_buffer_list_to_s16le` is the first place to look —
-// SCKit's exact f32 layout / channel order may differ from what we
-// assume; logging `list.num_buffers()` and `buf.data().len()` for a
-// few seconds will say which branch we're hitting.
+// If (2) fails, the buffer-conversion logic in
+// `enabled::convert_audio_buffer_list_to_s16le` is the first place to
+// look — log `list.num_buffers()` and `buf.data().len()` for a few
+// seconds to see which branch we're hitting.

--- a/apps/desktop/src-tauri/src/audio/platform/macos_sckit.rs
+++ b/apps/desktop/src-tauri/src/audio/platform/macos_sckit.rs
@@ -42,8 +42,8 @@
 //!
 //! **Compile-tested only, and disabled by default.** The
 //! `screencapturekit` 6.x crate transitively pulls `apple-metal`, whose
-//! Swift bridge unconditionally references macOS 14.4 and macOS 26 SDK
-//! symbols (`reactiveTextureUsage`, `MTLSamplerReductionMode`) that
+//! Swift bridge unconditionally references newer SDK symbols
+//! (e.g. `reactiveTextureUsage`, introduced around macOS 14.4) that
 //! aren't on the GH Actions `macos-latest` runner's Xcode. Until the
 //! upstream `apple-metal` packaging bug is fixed (should be
 //! `#if canImport(...)` compile-time gates, not runtime `#available`

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -4,6 +4,7 @@
 PUBLIC_APP_URL=http://localhost:4420
 PUBLIC_APP_NAME=Recast
 
+NODE_ENV=development
 # ─── Database (Neon / any Postgres) ───────────────────────────────────────
 # Connection pooling URL recommended (Neon "pooled" URL works fine with
 # the `postgres` driver since we set prepare:false in src/lib/db/index.ts).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,12 +42,14 @@
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
     "gsap": "^3.15.0",
+    "hls.js": "^1.6.16",
     "lucide-svelte": "latest",
     "mode-watcher": "^1.1.0",
     "postgres": "^3.4.9",
     "svelte-sonner": "^1.1.0",
     "tailwind-merge": "^3.5.0",
     "tailwind-variants": "^3.2.2",
+    "vidstack": "^1.12.13",
     "zod": "^4.4.3"
   }
 }

--- a/apps/web/src/lib/auth/components/ImpersonationBanner.svelte
+++ b/apps/web/src/lib/auth/components/ImpersonationBanner.svelte
@@ -2,7 +2,7 @@
 	import { authClient } from "$lib/auth/client";
 	import { Button } from "@recast/ui/button";
 	import { toast } from "@recast/ui/sonner";
-	import { ShieldOff, UserCog } from "@lucide/svelte";
+	import { LoaderCircle, ShieldOff, UserCog } from "@lucide/svelte";
 	import { cubicOut } from "svelte/easing";
 	import { fly } from "svelte/transition";
 
@@ -41,19 +41,21 @@
 		// Wrapped in try/finally so a thrown rejection (network drop, aborted
 		// fetch) can't strand the button in a permanently-disabled state.
 		try {
-			const { error } = await authClient.admin.stopImpersonating();
-			if (error) {
-				toast.error(error.message ?? "Couldn't stop impersonating.");
-				return;
-			}
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.admin.stopImpersonating();
+					if (error) throw new Error(error.message ?? "Couldn't stop impersonating.");
+				})(),
+				{
+					loading: "Stopping impersonation…",
+					success: "Back in your admin session.",
+					error: (err) => (err as Error)?.message ?? "Couldn't stop impersonating.",
+				},
+			);
 			// Hard reload so every server load re-runs against the restored
 			// admin cookie. SvelteKit's `invalidateAll()` would leave the same
 			// module instances around and we want a clean slate.
 			window.location.href = "/admin";
-		} catch (err) {
-			toast.error(
-				(err as Error)?.message ?? "Couldn't stop impersonating.",
-			);
 		} finally {
 			stopping = false;
 		}
@@ -62,7 +64,7 @@
 
 {#if impersonatedBy}
 	<div
-		class="fixed inset-x-0 top-0 z-[100] flex justify-center pointer-events-none"
+		class="fixed inset-x-0 top-0 z-100 flex justify-center pointer-events-none"
 		in:fly={{ y: -16, duration: 280, easing: cubicOut }}
 		out:fly={{ y: -16, duration: 200, easing: cubicOut }}
 	>
@@ -85,7 +87,11 @@
 				onclick={stop}
 				class="ml-1 h-7 gap-1.5 rounded-full border-amber-500/40 bg-background/80 px-3 text-[11px] text-amber-900 hover:bg-background dark:text-amber-200"
 			>
-				<ShieldOff class="size-3" />
+				{#if stopping}
+					<LoaderCircle class="size-3 animate-spin" />
+				{:else}
+					<ShieldOff class="size-3" />
+				{/if}
 				{stopping ? "Stopping…" : "Stop"}
 			</Button>
 		</div>

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -56,12 +56,35 @@ function createAuth() {
 			// In production, public sign-up is closed — the waitlist endpoint
 			// creates user rows directly. Dev keeps signup open for iteration.
 			disableSignUp: !dev,
+			// We don't block sign-IN on verification (locked-out users with a
+			// flipped password can't recover). Instead the dashboard layout
+			// redirects unverified users to /verify-email — view-only is fine,
+			// mutations aren't reachable. See [dashboard/+layout.server.ts].
 			requireEmailVerification: false,
 			sendResetPassword: async ({ user, url }) => {
 				if (await isOnWaitlist(user.email)) return;
 				await sendTemplatedEmail({
 					to: user.email,
 					template: "reset-password",
+					data: {
+						url,
+						firstName: user.name?.split(/\s+/)[0] ?? null,
+					},
+				});
+			},
+		},
+		emailVerification: {
+			// Fire on signup automatically. Invitees + waitlist activations are
+			// minted with `emailVerified: true` already, so they skip this and
+			// land on the dashboard directly.
+			sendOnSignUp: true,
+			autoSignInAfterVerification: true,
+			expiresIn: 60 * 60 * 24, // 24h
+			sendVerificationEmail: async ({ user, url }) => {
+				if (await isOnWaitlist(user.email)) return;
+				await sendTemplatedEmail({
+					to: user.email,
+					template: "verify-email",
 					data: {
 						url,
 						firstName: user.name?.split(/\s+/)[0] ?? null,

--- a/apps/web/src/lib/dashboard/components/CreateTeamDialog.svelte
+++ b/apps/web/src/lib/dashboard/components/CreateTeamDialog.svelte
@@ -6,7 +6,7 @@
 	import { Input } from "@recast/ui/input";
 	import { Label } from "@recast/ui/label";
 	import { toast } from "@recast/ui/sonner";
-	import { ArrowRight, Plus } from "@lucide/svelte";
+	import { ArrowRight, LoaderCircle, Plus } from "@lucide/svelte";
 
 	/**
 	 * Inline "create another team" flow for users who already have at least
@@ -26,31 +26,36 @@
 		e.preventDefault();
 		if (!name.trim() || creating) return;
 		creating = true;
-		const slug = `${name
+		const teamName = name.trim();
+		const slug = `${teamName
 			.toLowerCase()
 			.replace(/[^a-z0-9]+/g, "-")
 			.replace(/(^-|-$)/g, "") || "team"}-${Math.random().toString(36).slice(2, 8)}`;
 		try {
-			const { error } = await authClient.organization.create({
-				name: name.trim(),
-				slug,
-				keepCurrentActiveOrganization: false,
-			});
-			if (error) {
-				// Surface the real reason: cap reached, slug clash, etc.
-				toast.error(error.message ?? "Couldn't create the team.");
-				console.error("[create team]", error);
-				return;
-			}
-			toast.success(`Welcome to ${name.trim()}.`);
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.organization.create({
+						name: teamName,
+						slug,
+						keepCurrentActiveOrganization: false,
+					});
+					if (error) {
+						// Surface the real reason: cap reached, slug clash, etc.
+						console.error("[create team]", error);
+						throw new Error(error.message ?? "Couldn't create the team.");
+					}
+				})(),
+				{
+					loading: `Creating ${teamName}…`,
+					success: `Welcome to ${teamName}.`,
+					error: (err) => (err as Error)?.message ?? "Couldn't create the team.",
+				},
+			);
 			name = "";
 			open = false;
 			// Active org has been switched server-side by setActive — re-pull
 			// every loader so the sidebar swaps over to the new team.
 			await invalidateAll();
-		} catch (err) {
-			toast.error((err as Error)?.message ?? "Couldn't create the team.");
-			console.error("[create team]", err);
 		} finally {
 			// Always release so a thrown rejection (network drop, abort) can't
 			// strand the submit button in a disabled state.
@@ -92,7 +97,11 @@
 				</Button>
 				<Button type="submit" disabled={creating || !name.trim()} class="gap-2">
 					{creating ? "Creating…" : "Create team"}
-					<ArrowRight class="size-4" />
+					{#if creating}
+						<LoaderCircle class="size-4 animate-spin" />
+					{:else}
+						<ArrowRight class="size-4" />
+					{/if}
 				</Button>
 			</Dialog.Footer>
 		</form>

--- a/apps/web/src/lib/dashboard/components/OrgSwitcher.svelte
+++ b/apps/web/src/lib/dashboard/components/OrgSwitcher.svelte
@@ -11,6 +11,7 @@
 		Building2,
 		Check,
 		ChevronsUpDown,
+		LoaderCircle,
 		Plus,
 		Sparkles,
 	} from "@lucide/svelte";
@@ -44,17 +45,23 @@
 	async function setActive(id: string) {
 		if (switching || id === active.id) return;
 		switching = id;
+		const target = memberships.find((m) => m.organizationId === id);
+		const targetName = target?.name ?? "team";
 		try {
-			const { error } = await authClient.organization.setActive({
-				organizationId: id,
-			});
-			if (error) {
-				toast.error(error.message ?? "Couldn't switch team.");
-				return;
-			}
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.organization.setActive({
+						organizationId: id,
+					});
+					if (error) throw new Error(error.message ?? "Couldn't switch team.");
+				})(),
+				{
+					loading: `Switching to ${targetName}…`,
+					success: `Switched to ${targetName}.`,
+					error: (err) => (err as Error)?.message ?? "Couldn't switch team.",
+				},
+			);
 			await invalidateAll();
-		} catch (err) {
-			toast.error((err as Error)?.message ?? "Couldn't switch team.");
 		} finally {
 			// Always clear — a thrown rejection must not strand the row in
 			// the "switching…" pseudo-loading state.
@@ -126,10 +133,10 @@
 						</span>
 					</span>
 				</span>
-				{#if m.organizationId === active.id}
+				{#if switching === m.organizationId}
+					<LoaderCircle class="size-3.5 shrink-0 animate-spin text-muted-foreground" />
+				{:else if m.organizationId === active.id}
 					<Check class="size-3.5 shrink-0 text-primary" />
-				{:else if switching === m.organizationId}
-					<span class="text-[10px] text-muted-foreground">…</span>
 				{/if}
 			</DropdownMenu.Item>
 		{/each}

--- a/apps/web/src/lib/dashboard/components/PlayerDialog.svelte
+++ b/apps/web/src/lib/dashboard/components/PlayerDialog.svelte
@@ -6,16 +6,76 @@
 	} from "$lib/dashboard/format";
 	import type { Recast } from "$lib/dashboard/store.svelte";
 	import { Clock, Cloud, MonitorPlay, Video, X } from "@lucide/svelte";
+	import { onMount } from "svelte";
 	import { cubicOut } from "svelte/easing";
 	import { fade, scale } from "svelte/transition";
+
+	// Vidstack web components — Loom-style scrub thumbnails, speed menu, HLS
+	// via hls.js, AirPlay/Cast for free. We import the player module + the
+	// default video layout, then drop the custom elements into the template.
+	// Styles imported eagerly so the layout has its CSS variables ready on
+	// first paint (no FOUC). Vidstack auto-loads hls.js when the source URL
+	// ends in `.m3u8`; progressive MP4 falls back to native <video>.
+	import "vidstack/player";
+	import "vidstack/player/ui";
+	import "vidstack/player/layouts/default";
+	import "vidstack/player/styles/default/theme.css";
+	import "vidstack/player/styles/default/layouts/video.css";
 
 	let {
 		recast,
 		onclose,
+		onengagement,
 	}: {
 		recast: Recast;
 		onclose: () => void;
+		/**
+		 * Engagement reporter. `event` is one of:
+		 *   - `view-start` — playback actually started (autoplay or user hit play)
+		 *   - `progress`   — fired every ~5s, `percent` is 0–100 watched
+		 *   - `ended`      — viewer reached the end
+		 * Caller wires these into the activity store / analytics.
+		 */
+		onengagement?: (event: "view-start" | "progress" | "ended", percent: number) => void;
 	} = $props();
+
+	let playerEl = $state<HTMLElement | null>(null);
+	let lastReportedPct = $state(0);
+
+	// Hook engagement events to the parent via custom-element listeners.
+	// Done in onMount because the custom element isn't defined until after
+	// the `vidstack/player` import has run on first render.
+	onMount(() => {
+		const el = playerEl;
+		if (!el || !onengagement) return;
+
+		let started = false;
+		const onPlay = () => {
+			if (started) return;
+			started = true;
+			onengagement("view-start", 0);
+		};
+		const onTime = (e: Event) => {
+			const detail = (e as CustomEvent<{ currentTime: number }>).detail;
+			const duration = recast.durationSec || 1;
+			const pct = Math.min(100, Math.round((detail.currentTime / duration) * 100));
+			// Throttle to ~5% steps so a 2-minute video doesn't spam 1k events.
+			if (pct - lastReportedPct >= 5) {
+				lastReportedPct = pct;
+				onengagement("progress", pct);
+			}
+		};
+		const onEnded = () => onengagement("ended", 100);
+
+		el.addEventListener("play", onPlay);
+		el.addEventListener("time-update", onTime);
+		el.addEventListener("ended", onEnded);
+		return () => {
+			el.removeEventListener("play", onPlay);
+			el.removeEventListener("time-update", onTime);
+			el.removeEventListener("ended", onEnded);
+		};
+	});
 </script>
 
 <svelte:window onkeydown={(e) => e.key === "Escape" && onclose()} />
@@ -49,13 +109,23 @@
 		</header>
 
 		<!-- svelte-ignore a11y_media_has_caption -->
-		<video
+		<media-player
+			bind:this={playerEl}
 			src={recast.videoUrl}
 			poster={recast.posterUrl || undefined}
-			controls
 			autoplay
+			crossorigin
 			class="aspect-video w-full bg-black"
-		></video>
+			title={recast.title}
+		>
+			<media-provider></media-provider>
+			<!-- `default-layout` is Vidstack's batteries-included controls: play,
+			     scrubber with thumbnail preview (auto-generated from frames if
+			     no VTT supplied), volume, captions menu, settings (speed,
+			     quality), PiP, AirPlay, fullscreen. Theme overrides live in
+			     [app.css :root.vidstack] when we get to brand polish. -->
+			<media-video-layout></media-video-layout>
+		</media-player>
 
 		<footer class="flex flex-wrap items-center gap-x-4 gap-y-1 px-4 py-3 text-xs text-muted-foreground">
 			<span class="flex items-center gap-1.5">

--- a/apps/web/src/lib/dashboard/store.svelte.ts
+++ b/apps/web/src/lib/dashboard/store.svelte.ts
@@ -118,6 +118,19 @@ class RecordingsStore {
 		this.persist();
 	}
 
+	/**
+	 * Bump the view counter when the player reports `view-start`. We count
+	 * the unique-per-session pattern naively (one bump per call) — the
+	 * caller (PlayerDialog → recasts page) only fires this once per open
+	 * via the `started` latch, so refresh-spam doesn't inflate the count.
+	 */
+	incrementViews(id: string) {
+		this.items = this.items.map((r) =>
+			r.id === id ? { ...r, views: r.views + 1 } : r,
+		);
+		this.persist();
+	}
+
 	reset() {
 		this.items = seedRecordings();
 		this.persist();

--- a/apps/web/src/lib/email/layout.ts
+++ b/apps/web/src/lib/email/layout.ts
@@ -55,7 +55,7 @@ export function wrap({ subject, preheader = "", body }: LayoutOptions): string {
 						<table role="presentation" cellspacing="0" cellpadding="0" border="0">
 							<tr>
 								<td style="vertical-align:middle;">
-									<span style="display:inline-block; width:28px; height:28px; background:${EMAIL_COLORS.ink}; border-radius:8px;"></span>
+									${logoMark()}
 								</td>
 								<td style="vertical-align:middle; padding-left:10px;">
 									<span style="font-size:16px; font-weight:600; color:${EMAIL_COLORS.ink}; letter-spacing:-0.01em;">Recast</span>
@@ -65,7 +65,12 @@ export function wrap({ subject, preheader = "", body }: LayoutOptions): string {
 					</td>
 				</tr>
 				<tr>
-					<td style="background:${EMAIL_COLORS.cardBg}; border:1px solid ${EMAIL_COLORS.border}; border-radius:16px; padding:32px 28px;">
+					<!-- Thin primary-accent stripe across the top of the card — the
+					     first hit of the lime brand color the reader sees. -->
+					<td style="background:${EMAIL_COLORS.primary}; border-radius:16px 16px 0 0; height:3px; line-height:3px; font-size:1px;">&nbsp;</td>
+				</tr>
+				<tr>
+					<td style="background:${EMAIL_COLORS.cardBg}; border:1px solid ${EMAIL_COLORS.border}; border-top:0; border-radius:0 0 16px 16px; padding:32px 28px;">
 						${body}
 					</td>
 				</tr>
@@ -85,14 +90,49 @@ export function wrap({ subject, preheader = "", body }: LayoutOptions): string {
 }
 
 /**
+ * Mini brand mark — three white pill bars on a dark rounded square, the
+ * same silhouette as the in-app SVG logo. Done as nested tables so clients
+ * that strip inline SVG (Outlook desktop, parts of Gmail web) still render
+ * a recognisable mark, not a black hole.
+ */
+function logoMark(): string {
+	const pill = `<div style="width:3px; height:14px; background:#ffffff; border-radius:2px; font-size:1px; line-height:1px;">&nbsp;</div>`;
+	return `<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="background:${EMAIL_COLORS.ink}; border-radius:8px;">
+	<tr>
+		<td style="padding:7px 6px;">
+			<table role="presentation" cellspacing="0" cellpadding="0" border="0">
+				<tr>
+					<td style="width:3px; padding:0;">${pill}</td>
+					<td style="width:3px;">&nbsp;</td>
+					<td style="width:3px; padding:0;">${pill}</td>
+					<td style="width:3px;">&nbsp;</td>
+					<td style="width:3px; padding:0;">${pill}</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>`;
+}
+
+/**
  * Bulletproof CTA button (table-based for Outlook). Pass the full URL —
  * we do no relative-URL resolution here, every caller supplies an absolute.
+ *
+ * `tone` defaults to `ink` (dark button, white text) — the brand-primary
+ * recipe. Pass `accent` for the lime variant, used sparingly for moments
+ * where the brand color should be the focal point (verify-email confirm).
  */
-export function ctaButton(label: string, url: string): string {
+export function ctaButton(
+	label: string,
+	url: string,
+	tone: "ink" | "accent" = "ink",
+): string {
+	const bg = tone === "accent" ? EMAIL_COLORS.primary : EMAIL_COLORS.buttonBg;
+	const ink = tone === "accent" ? EMAIL_COLORS.primaryInk : EMAIL_COLORS.buttonInk;
 	return `<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin:8px 0;">
 	<tr>
-		<td style="background:${EMAIL_COLORS.buttonBg}; border-radius:10px;">
-			<a href="${escapeAttr(url)}" target="_blank" style="display:inline-block; padding:12px 22px; color:${EMAIL_COLORS.buttonInk}; text-decoration:none; font-size:14px; font-weight:600; letter-spacing:-0.01em;">${escapeHtml(label)}</a>
+		<td style="background:${bg}; border-radius:10px;">
+			<a href="${escapeAttr(url)}" target="_blank" style="display:inline-block; padding:12px 22px; color:${ink}; text-decoration:none; font-size:14px; font-weight:600; letter-spacing:-0.01em;">${escapeHtml(label)}</a>
 		</td>
 	</tr>
 </table>`;

--- a/apps/web/src/lib/email/templates.ts
+++ b/apps/web/src/lib/email/templates.ts
@@ -22,6 +22,7 @@ import { sendEmail } from "./transport";
 export type TemplateData = {
 	"magic-link": { url: string; firstName?: string | null };
 	"reset-password": { url: string; firstName?: string | null };
+	"verify-email": { url: string; firstName?: string | null };
 	"team-invitation": {
 		url: string;
 		teamName: string;
@@ -55,6 +56,33 @@ const templates: {
 					ctaButton("Sign in to Recast", url) +
 					muted(
 						"If you didn't request this, ignore the email — no account changes were made.",
+					) +
+					fallbackLink(url),
+			}),
+		};
+	},
+
+	"verify-email": ({ url, firstName }) => {
+		const hello = firstName ? `Hi ${firstName},` : "Hi,";
+		return {
+			subject: "Verify your Recast email",
+			text:
+				`${hello}\n\n` +
+				`Confirm this email address to finish setting up your Recast\n` +
+				`account. The link below is good for the next 24 hours:\n\n${url}\n\n` +
+				`Until you verify, dashboard actions stay read-only.`,
+			html: wrap({
+				subject: "Verify your Recast email",
+				preheader: "Confirm your email to unlock your Recast account.",
+				body:
+					heading("Confirm your email") +
+					paragraph(
+						`${hello.replace(",", "")} — tap below to confirm <strong>this</strong> is your email. ` +
+							`Until you verify, your Recast dashboard stays read-only.`,
+					) +
+					ctaButton("Verify email", url, "accent") +
+					muted(
+						"Link valid for 24 hours. Didn't sign up for Recast? Ignore the email — no account changes were made.",
 					) +
 					fallbackLink(url),
 			}),

--- a/apps/web/src/lib/email/templates.ts
+++ b/apps/web/src/lib/email/templates.ts
@@ -64,6 +64,7 @@ const templates: {
 
 	"verify-email": ({ url, firstName }) => {
 		const hello = firstName ? `Hi ${firstName},` : "Hi,";
+		const helloHtml = firstName ? `Hi ${escapeText(firstName)},` : "Hi,";
 		return {
 			subject: "Verify your Recast email",
 			text:
@@ -77,7 +78,7 @@ const templates: {
 				body:
 					heading("Confirm your email") +
 					paragraph(
-						`${hello.replace(",", "")} — tap below to confirm <strong>this</strong> is your email. ` +
+						`${helloHtml.replace(",", "")} — tap below to confirm <strong>this</strong> is your email. ` +
 							`Until you verify, your Recast dashboard stays read-only.`,
 					) +
 					ctaButton("Verify email", url, "accent") +

--- a/apps/web/src/lib/env/server.ts
+++ b/apps/web/src/lib/env/server.ts
@@ -1,4 +1,4 @@
-import { building } from "$app/environment";
+import { building, dev } from "$app/environment";
 import { env as rawEnv } from "$env/dynamic/private";
 import { serverEnvSchema, type ServerEnv } from "./schema";
 
@@ -21,6 +21,10 @@ let cached: ServerEnv | null = null;
 
 export function getServerEnv(): ServerEnv {
 	if (cached) return cached;
+	
+	if (dev){
+		console.info("[NODE_ENV]:",rawEnv.NODE_ENV);
+	}
 
 	// Skip validation while Vite is collecting the prerender manifest — env
 	// isn't available there and prerendered pages don't need it anyway.

--- a/apps/web/src/routes/(auth)/forgot-password/+page.svelte
+++ b/apps/web/src/routes/(auth)/forgot-password/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import AuthCard from "$lib/auth/components/AuthCard.svelte";
 	import { authClient } from "$lib/auth/client";
-	import { ArrowRight, MailCheck } from "@lucide/svelte";
+	import { ArrowRight, LoaderCircle, MailCheck } from "@lucide/svelte";
 	import { Button } from "@recast/ui/button";
 	import { Input } from "@recast/ui/input";
 	import { Label } from "@recast/ui/label";
@@ -15,19 +15,29 @@
 
 	async function submit(e: SubmitEvent) {
 		e.preventDefault();
+		if (loading) return;
 		loading = true;
-		const { error } = await authClient.requestPasswordReset({
-			email,
-			redirectTo: "/reset-password",
-		});
-		loading = false;
-		if (error) {
-			toast.error(error.message ?? "Couldn't send the reset email.");
-			return;
+		try {
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.requestPasswordReset({
+						email,
+						redirectTo: "/reset-password",
+					});
+					if (error) throw new Error(error.message ?? "Couldn't send the reset email.");
+				})(),
+				{
+					loading: "Sending reset link…",
+					success: "Check your inbox for the reset link.",
+					error: (err) => (err as Error)?.message ?? "Couldn't send the reset email.",
+				},
+			);
+			// We tell the user the link was sent regardless of whether the email
+			// exists — standard pattern, prevents account enumeration.
+			sent = true;
+		} finally {
+			loading = false;
 		}
-		// We tell the user the link was sent regardless of whether the email
-		// exists — standard pattern, prevents account enumeration.
-		sent = true;
 	}
 </script>
 
@@ -85,7 +95,11 @@
 				class="group/cta mt-1 w-full gap-2"
 			>
 				{loading ? "Sending…" : "Send reset link"}
-				<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+				{#if loading}
+					<LoaderCircle class="size-4 animate-spin" />
+				{:else}
+					<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+				{/if}
 			</Button>
 		</form>
 	{/if}

--- a/apps/web/src/routes/(auth)/forgot-password/+page.svelte
+++ b/apps/web/src/routes/(auth)/forgot-password/+page.svelte
@@ -17,11 +17,12 @@
 		e.preventDefault();
 		if (loading) return;
 		loading = true;
+		const trimmedEmail = email.trim();
 		try {
 			await toast.promise(
 				(async () => {
 					const { error } = await authClient.requestPasswordReset({
-						email,
+						email: trimmedEmail,
 						redirectTo: "/reset-password",
 					});
 					if (error) throw new Error(error.message ?? "Couldn't send the reset email.");

--- a/apps/web/src/routes/(auth)/login/+page.svelte
+++ b/apps/web/src/routes/(auth)/login/+page.svelte
@@ -6,7 +6,15 @@
 	import OrDivider from "$lib/auth/components/OrDivider.svelte";
 	import SocialButtons from "$lib/auth/components/SocialButtons.svelte";
 	import { authClient } from "$lib/auth/client";
-	import { ArrowRight, Eye, EyeOff, MailCheck, Wand2 } from "@lucide/svelte";
+	import {
+		AlertCircle,
+		ArrowRight,
+		Eye,
+		EyeOff,
+		LoaderCircle,
+		MailCheck,
+		Wand2,
+	} from "@lucide/svelte";
 	import { Button } from "@recast/ui/button";
 	import { Checkbox } from "@recast/ui/checkbox";
 	import { Input } from "@recast/ui/input";
@@ -24,39 +32,108 @@
 	let showPassword = $state(false);
 	let loading = $state(false);
 	let linkSent = $state(false);
+	/**
+	 * Inline status banner shown when the lookup reveals the email isn't
+	 * eligible to sign in yet. Kept inline (rather than a toast) so the CTA
+	 * to the waitlist stays visible.
+	 *   - `unknown` → no account on file; offer waitlist
+	 *   - `pending` → on the waitlist; tell them to wait
+	 */
+	let preflight = $state<{ status: "unknown" | "pending"; email: string } | null>(
+		null,
+	);
 
 	const next = $derived(page.url.searchParams.get("next") || "/dashboard");
 
+	// Clear the inline waitlist banner the moment the user edits their email,
+	// so the stale banner doesn't linger after they fix a typo.
+	$effect(() => {
+		if (preflight && preflight.email !== email.trim()) preflight = null;
+	});
+
+	/**
+	 * Hits /api/auth/lookup to decide whether to actually call Better Auth.
+	 * Returns `true` if we should proceed, `false` if the inline banner has
+	 * been shown and the auth call should be skipped.
+	 */
+	async function preflightEmail(emailInput: string): Promise<boolean> {
+		try {
+			const res = await fetch("/api/auth/lookup", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ email: emailInput }),
+			});
+			const data = (await res.json()) as {
+				status: "active" | "pending" | "unknown" | "invalid";
+			};
+			if (data.status === "unknown" || data.status === "pending") {
+				preflight = { status: data.status, email: emailInput };
+				return false;
+			}
+			// `invalid` falls through to the auth call, which surfaces the
+			// real validation error (better than swallowing it here).
+			preflight = null;
+			return true;
+		} catch {
+			// Network blip on the lookup shouldn't block sign-in attempts.
+			preflight = null;
+			return true;
+		}
+	}
+
 	async function signInWithLink(e: SubmitEvent) {
 		e.preventDefault();
-		if (!email.trim()) return;
+		if (!email.trim() || loading) return;
 		loading = true;
-		const { error } = await authClient.signIn.magicLink({
-			email,
-			callbackURL: next,
-		});
-		loading = false;
-		if (error) {
-			toast.error(error.message ?? "Couldn't send the sign-in link.");
-			return;
+		try {
+			const ok = await preflightEmail(email.trim());
+			if (!ok) return;
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.signIn.magicLink({
+						email,
+						callbackURL: next,
+					});
+					if (error) throw new Error(error.message ?? "Couldn't send the sign-in link.");
+				})(),
+				{
+					loading: "Sending sign-in link…",
+					success: "Check your inbox — the link expires in 10 minutes.",
+					error: (err) => (err as Error)?.message ?? "Couldn't send the sign-in link.",
+				},
+			);
+			linkSent = true;
+		} finally {
+			loading = false;
 		}
-		linkSent = true;
 	}
 
 	async function signInWithPassword(e: SubmitEvent) {
 		e.preventDefault();
+		if (loading) return;
 		loading = true;
-		const { error } = await authClient.signIn.email({
-			email,
-			password,
-			rememberMe,
-		});
-		loading = false;
-		if (error) {
-			toast.error(error.message ?? "Sign in failed. Check your credentials.");
-			return;
+		try {
+			const ok = await preflightEmail(email.trim());
+			if (!ok) return;
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.signIn.email({
+						email,
+						password,
+						rememberMe,
+					});
+					if (error) throw new Error(error.message ?? "Sign in failed. Check your credentials.");
+				})(),
+				{
+					loading: "Signing you in…",
+					success: "Welcome back.",
+					error: (err) => (err as Error)?.message ?? "Sign in failed. Check your credentials.",
+				},
+			);
+			await goto(next);
+		} finally {
+			loading = false;
 		}
-		await goto(next);
 	}
 </script>
 
@@ -70,6 +147,42 @@
 	{#if dev}
 		<div class="my-5">
 			<OrDivider label="or continue with email" />
+		</div>
+	{/if}
+
+	{#if preflight}
+		<div
+			class="mb-4 flex items-start gap-2.5 rounded-xl border border-amber-500/30 bg-amber-500/8 p-3.5 text-xs"
+			in:fly={{ y: 6, duration: 280, easing: cubicOut }}
+		>
+			<AlertCircle class="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+			<div class="min-w-0 flex-1">
+				{#if preflight.status === "unknown"}
+					<p class="font-medium text-foreground">
+						No account for <span class="font-mono">{preflight.email}</span>
+					</p>
+					<p class="mt-0.5 text-muted-foreground">
+						Recast Cloud is invite-only right now. Join the waitlist and
+						we'll email you the moment your spot is ready.
+					</p>
+					<a
+						href={`/waitlist?email=${encodeURIComponent(preflight.email)}&source=login`}
+						class="mt-2 inline-flex items-center gap-1.5 font-semibold text-primary hover:underline"
+					>
+						Join the waitlist
+						<ArrowRight class="size-3.5" />
+					</a>
+				{:else}
+					<p class="font-medium text-foreground">
+						You're on the waitlist
+					</p>
+					<p class="mt-0.5 text-muted-foreground">
+						<span class="font-mono">{preflight.email}</span> is queued. We'll
+						email you a sign-in link the moment access opens — no need to
+						retry here.
+					</p>
+				{/if}
+			</div>
 		</div>
 	{/if}
 
@@ -132,7 +245,11 @@
 						class="group/cta mt-1 w-full gap-2"
 					>
 						{loading ? "Sending…" : "Send sign-in link"}
-						<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+						{#if loading}
+							<LoaderCircle class="size-4 animate-spin" />
+						{:else}
+							<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+						{/if}
 					</Button>
 					<p class="text-center text-[11px] text-muted-foreground">
 						No password needed — we'll email you a one-time link.
@@ -201,7 +318,11 @@
 						class="group/cta mt-1 w-full gap-2"
 					>
 						{loading ? "Signing in…" : "Sign in"}
-						<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+						{#if loading}
+							<LoaderCircle class="size-4 animate-spin" />
+						{:else}
+							<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+						{/if}
 					</Button>
 				</form>
 			</Tabs.Content>

--- a/apps/web/src/routes/(auth)/login/+page.svelte
+++ b/apps/web/src/routes/(auth)/login/+page.svelte
@@ -83,15 +83,16 @@
 
 	async function signInWithLink(e: SubmitEvent) {
 		e.preventDefault();
-		if (!email.trim() || loading) return;
+		const trimmedEmail = email.trim();
+		if (!trimmedEmail || loading) return;
 		loading = true;
 		try {
-			const ok = await preflightEmail(email.trim());
+			const ok = await preflightEmail(trimmedEmail);
 			if (!ok) return;
 			await toast.promise(
 				(async () => {
 					const { error } = await authClient.signIn.magicLink({
-						email,
+						email: trimmedEmail,
 						callbackURL: next,
 					});
 					if (error) throw new Error(error.message ?? "Couldn't send the sign-in link.");
@@ -113,12 +114,13 @@
 		if (loading) return;
 		loading = true;
 		try {
-			const ok = await preflightEmail(email.trim());
+			const trimmedEmail = email.trim();
+			const ok = await preflightEmail(trimmedEmail);
 			if (!ok) return;
 			await toast.promise(
 				(async () => {
 					const { error } = await authClient.signIn.email({
-						email,
+						email: trimmedEmail,
 						password,
 						rememberMe,
 					});

--- a/apps/web/src/routes/(auth)/reset-password/+page.svelte
+++ b/apps/web/src/routes/(auth)/reset-password/+page.svelte
@@ -3,7 +3,7 @@
 	import { page } from "$app/state";
 	import AuthCard from "$lib/auth/components/AuthCard.svelte";
 	import { authClient } from "$lib/auth/client";
-	import { AlertCircle, ArrowRight, Eye, EyeOff } from "@lucide/svelte";
+	import { AlertCircle, ArrowRight, Eye, EyeOff, LoaderCircle } from "@lucide/svelte";
 	import { Button } from "@recast/ui/button";
 	import { Input } from "@recast/ui/input";
 	import { Label } from "@recast/ui/label";
@@ -28,19 +28,27 @@
 
 	async function submit(e: SubmitEvent) {
 		e.preventDefault();
-		if (!canSubmit) return;
+		if (!canSubmit || loading) return;
 		loading = true;
-		const { error } = await authClient.resetPassword({
-			newPassword: password,
-			token,
-		});
-		loading = false;
-		if (error) {
-			toast.error(error.message ?? "Couldn't reset your password.");
-			return;
+		try {
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.resetPassword({
+						newPassword: password,
+						token,
+					});
+					if (error) throw new Error(error.message ?? "Couldn't reset your password.");
+				})(),
+				{
+					loading: "Updating your password…",
+					success: "Password updated — sign in with your new password.",
+					error: (err) => (err as Error)?.message ?? "Couldn't reset your password.",
+				},
+			);
+			await goto("/login");
+		} finally {
+			loading = false;
 		}
-		toast.success("Password updated — sign in with your new password.");
-		await goto("/login");
 	}
 </script>
 
@@ -107,7 +115,11 @@
 			class="group/cta mt-2 w-full gap-2"
 		>
 			{loading ? "Updating…" : "Update password"}
-			<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+			{#if loading}
+				<LoaderCircle class="size-4 animate-spin" />
+			{:else}
+				<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+			{/if}
 		</Button>
 	</form>
 

--- a/apps/web/src/routes/(auth)/signup/+page.svelte
+++ b/apps/web/src/routes/(auth)/signup/+page.svelte
@@ -4,7 +4,7 @@
 	import OrDivider from "$lib/auth/components/OrDivider.svelte";
 	import SocialButtons from "$lib/auth/components/SocialButtons.svelte";
 	import { authClient } from "$lib/auth/client";
-	import { AlertCircle, ArrowRight, Eye, EyeOff } from "@lucide/svelte";
+	import { AlertCircle, ArrowRight, Eye, EyeOff, LoaderCircle } from "@lucide/svelte";
 	import { Button } from "@recast/ui/button";
 	import { Checkbox } from "@recast/ui/checkbox";
 	import { Input } from "@recast/ui/input";
@@ -53,15 +53,24 @@
 
 	async function signUp(e: SubmitEvent) {
 		e.preventDefault();
-		if (!canSubmit) return;
+		if (!canSubmit || loading) return;
 		loading = true;
-		const { error } = await authClient.signUp.email({ name, email, password });
-		loading = false;
-		if (error) {
-			toast.error(error.message ?? "Couldn't create your account.");
-			return;
+		try {
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.signUp.email({ name, email, password });
+					if (error) throw new Error(error.message ?? "Couldn't create your account.");
+				})(),
+				{
+					loading: "Creating your account…",
+					success: "Account created — welcome to Recast.",
+					error: (err) => (err as Error)?.message ?? "Couldn't create your account.",
+				},
+			);
+			await goto("/dashboard");
+		} finally {
+			loading = false;
 		}
-		await goto("/dashboard");
 	}
 </script>
 
@@ -189,7 +198,11 @@
 			class="group/cta mt-2 w-full gap-2"
 		>
 			{loading ? "Creating account…" : "Create account"}
-			<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+			{#if loading}
+				<LoaderCircle class="size-4 animate-spin" />
+			{:else}
+				<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+			{/if}
 		</Button>
 	</form>
 

--- a/apps/web/src/routes/(auth)/signup/+page.svelte
+++ b/apps/web/src/routes/(auth)/signup/+page.svelte
@@ -58,7 +58,7 @@
 		try {
 			await toast.promise(
 				(async () => {
-					const { error } = await authClient.signUp.email({ name, email, password });
+					const { error } = await authClient.signUp.email({ name, email: email.trim(), password });
 					if (error) throw new Error(error.message ?? "Couldn't create your account.");
 				})(),
 				{

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -23,6 +23,7 @@
 			page.url.pathname.startsWith("/admin") ||
 			page.url.pathname.startsWith("/onboarding") ||
 			page.url.pathname === "/accept-invitation" ||
+			page.url.pathname === "/verify-email" ||
 			chromelessPaths.has(page.url.pathname),
 	);
 </script>

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -20,6 +20,7 @@
 	  Highlighter,
 	  Layout,
 	  Link2,
+	  LoaderCircle,
 	  Lock,
 	  MonitorPlay,
 	  MousePointer2,
@@ -42,25 +43,29 @@
 	let loading = $state(false);
 	async function joinWaitlist(e: SubmitEvent) {
 		e.preventDefault();
-		if (!email.trim()) return;
+		if (!email.trim() || loading) return;
 		loading = true;
 		try {
-			const res = await fetch("/api/waitlist", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ email, source: "home-cloud" }),
-			});
-			const data = (await res.json().catch(() => ({}))) as {
-				ok?: boolean;
-				error?: string;
-			};
-			if (!data.ok) {
-				toast.error(data.error ?? "Couldn't join the waitlist.");
-				return;
-			}
+			await toast.promise(
+				(async () => {
+					const res = await fetch("/api/waitlist", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ email, source: "home-cloud" }),
+					});
+					const data = (await res.json().catch(() => ({}))) as {
+						ok?: boolean;
+						error?: string;
+					};
+					if (!data.ok) throw new Error(data.error ?? "Couldn't join the waitlist.");
+				})(),
+				{
+					loading: "Adding you to the waitlist…",
+					success: "You're on the list — we'll email when access opens.",
+					error: (err) => (err as Error)?.message ?? "Couldn't join the waitlist.",
+				},
+			);
 			joined = true;
-		} catch {
-			toast.error("Network error. Try again in a moment.");
 		} finally {
 			loading = false;
 		}
@@ -605,7 +610,11 @@
 										/>
 										<Button type="submit" disabled={loading} class="gap-2">
 											{loading ? "Joining…" : "Join waitlist"}
-											<ArrowRight class="size-4" />
+											{#if loading}
+												<LoaderCircle class="size-4 animate-spin" />
+											{:else}
+												<ArrowRight class="size-4" />
+											{/if}
 										</Button>
 									</form>
 								{/if}

--- a/apps/web/src/routes/accept-invitation/+page.server.ts
+++ b/apps/web/src/routes/accept-invitation/+page.server.ts
@@ -1,4 +1,4 @@
-import { error, redirect } from "@sveltejs/kit";
+import { error } from "@sveltejs/kit";
 import { eq } from "drizzle-orm";
 import { getAuth } from "$lib/auth/server";
 import { getDb } from "$lib/db";
@@ -14,8 +14,10 @@ type SessionShape = { user: { id: string; email: string } };
  * Lands here from the invitation email. We:
  *
  *   1. Validate the id and fetch the invite (404 if unknown).
- *   2. If the user isn't signed in → /login?next=…, preserving the id so
- *      this page reruns post-sign-in.
+ *   2. If the user isn't signed in we DON'T redirect — instead we surface
+ *      the invitee email so the page can render an inline magic-link sign-in
+ *      form. Bouncing to /login + back was a confusing round-trip for new
+ *      invitees who hadn't yet picked a password.
  *   3. If the signed-in email doesn't match the invitation email, show a
  *      "wrong account" message — don't auto-accept against the wrong row.
  *   4. Otherwise hand the id to the page so the client can call
@@ -51,24 +53,29 @@ export const load: PageServerLoad = async ({ url, request }) => {
 		.api.getSession({ headers: request.headers })
 		.catch(() => null)) as SessionShape | null;
 
+	const expired = inv.expiresAt && new Date(inv.expiresAt).getTime() < Date.now();
+
+	const baseInvite = {
+		id: inv.id,
+		email: inv.email,
+		role: inv.role,
+		status: inv.status,
+		orgName: inv.orgName,
+		expired: Boolean(expired),
+	};
+
 	if (!session) {
-		const next = encodeURIComponent(`/accept-invitation?id=${id}`);
-		redirect(303, `/login?next=${next}`);
+		return {
+			invite: baseInvite,
+			viewer: null,
+		};
 	}
 
 	const emailMatches =
 		session.user.email.toLowerCase() === inv.email.toLowerCase();
-	const expired = inv.expiresAt && new Date(inv.expiresAt).getTime() < Date.now();
 
 	return {
-		invite: {
-			id: inv.id,
-			email: inv.email,
-			role: inv.role,
-			status: inv.status,
-			orgName: inv.orgName,
-			expired: Boolean(expired),
-		},
+		invite: baseInvite,
 		viewer: { email: session.user.email, emailMatches },
 	};
 };

--- a/apps/web/src/routes/accept-invitation/+page.svelte
+++ b/apps/web/src/routes/accept-invitation/+page.svelte
@@ -8,7 +8,9 @@
 		AlertTriangle,
 		ArrowRight,
 		Check,
+		LoaderCircle,
 		MailCheck,
+		Wand2,
 		X,
 	} from "@lucide/svelte";
 	import { cubicOut } from "svelte/easing";
@@ -18,26 +20,41 @@
 
 	let accepting = $state(false);
 	let rejecting = $state(false);
+	let sendingLink = $state(false);
+	let linkSent = $state(false);
 	/** Either action in flight — prevents accept + reject racing each other. */
 	const busy = $derived(accepting || rejecting);
+
+	function sessionMismatch() {
+		// Only meaningful once we have a viewer. The unauthed branch lives in
+		// its own template block.
+		return data.viewer && !data.viewer.emailMatches;
+	}
+
+	const blocked = $derived(
+		sessionMismatch() ||
+			data.invite.expired ||
+			data.invite.status !== "pending",
+	);
 
 	async function accept() {
 		if (busy) return;
 		accepting = true;
 		try {
-			const { error } = await authClient.organization.acceptInvitation({
-				invitationId: data.invite.id,
-			});
-			if (error) {
-				toast.error(error.message ?? "Couldn't accept the invitation.");
-				return;
-			}
-			toast.success(`Welcome to ${data.invite.orgName}.`);
-			await goto("/dashboard");
-		} catch (err) {
-			toast.error(
-				(err as Error)?.message ?? "Couldn't accept the invitation.",
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.organization.acceptInvitation({
+						invitationId: data.invite.id,
+					});
+					if (error) throw new Error(error.message ?? "Couldn't accept the invitation.");
+				})(),
+				{
+					loading: `Joining ${data.invite.orgName}…`,
+					success: `Welcome to ${data.invite.orgName}.`,
+					error: (err) => (err as Error)?.message ?? "Couldn't accept the invitation.",
+				},
 			);
+			await goto("/dashboard");
 		} finally {
 			accepting = false;
 		}
@@ -47,29 +64,49 @@
 		if (busy) return;
 		rejecting = true;
 		try {
-			const { error } = await authClient.organization.rejectInvitation({
-				invitationId: data.invite.id,
-			});
-			if (error) {
-				toast.error(error.message ?? "Couldn't decline the invitation.");
-				return;
-			}
-			toast.message("Invitation declined.");
-			await goto("/");
-		} catch (err) {
-			toast.error(
-				(err as Error)?.message ?? "Couldn't decline the invitation.",
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.organization.rejectInvitation({
+						invitationId: data.invite.id,
+					});
+					if (error) throw new Error(error.message ?? "Couldn't decline the invitation.");
+				})(),
+				{
+					loading: "Declining…",
+					success: "Invitation declined.",
+					error: (err) => (err as Error)?.message ?? "Couldn't decline the invitation.",
+				},
 			);
+			await goto("/");
 		} finally {
 			rejecting = false;
 		}
 	}
 
-	const blocked = $derived(
-		!data.viewer.emailMatches ||
-			data.invite.expired ||
-			data.invite.status !== "pending",
-	);
+	async function sendSignInLink() {
+		if (sendingLink) return;
+		sendingLink = true;
+		try {
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.signIn.magicLink({
+						email: data.invite.email,
+						// Round-trip the user back here once they click the link.
+						callbackURL: `/accept-invitation?id=${data.invite.id}`,
+					});
+					if (error) throw new Error(error.message ?? "Couldn't send the sign-in link.");
+				})(),
+				{
+					loading: "Sending sign-in link…",
+					success: "Check your inbox — the link expires in 10 minutes.",
+					error: (err) => (err as Error)?.message ?? "Couldn't send the sign-in link.",
+				},
+			);
+			linkSent = true;
+		} finally {
+			sendingLink = false;
+		}
+	}
 </script>
 
 <svelte:head>
@@ -126,6 +163,55 @@
 					<AlertTriangle class="size-5 text-amber-500" />
 					<span>This invitation has expired. Ask the team owner to resend it.</span>
 				</div>
+			{:else if !data.viewer}
+				<!-- Not signed in — magic-link sign-in directly on this page so the
+				     invitee doesn't have to bounce through /login. We know the
+				     email (it's the invite target) and we pre-created the user
+				     row server-side, so the link will go through. -->
+				{#if linkSent}
+					<div
+						class="flex flex-col items-center gap-3 text-center text-sm"
+						in:fly={{ y: 6, duration: 280, easing: cubicOut }}
+					>
+						<span class="glass-chip grid size-11 place-items-center rounded-xl text-primary">
+							<MailCheck class="size-5" />
+						</span>
+						<div>
+							<p class="font-semibold text-foreground">Check your inbox</p>
+							<p class="mt-1 text-xs text-muted-foreground">
+								We sent a one-time sign-in link to
+								<span class="font-mono font-semibold text-foreground">{data.invite.email}</span>.
+								Click it and you'll land back here to accept.
+							</p>
+						</div>
+					</div>
+				{:else}
+					<div class="space-y-3 text-sm">
+						<p class="text-muted-foreground">
+							Sign in as
+							<span class="font-mono font-semibold text-foreground">{data.invite.email}</span>
+							to accept this invitation. We'll email you a one-time link — no
+							password needed.
+						</p>
+						<Button onclick={sendSignInLink} disabled={sendingLink} class="group/cta w-full gap-2">
+							{#if sendingLink}
+								<LoaderCircle class="size-4 animate-spin" />
+							{:else}
+								<Wand2 class="size-4" />
+							{/if}
+							{sendingLink ? "Sending…" : "Email me a sign-in link"}
+						</Button>
+						<p class="text-center text-[11px] text-muted-foreground">
+							Already have a password?
+							<a
+								href={`/login?next=/accept-invitation?id=${data.invite.id}`}
+								class="font-semibold text-foreground hover:text-primary"
+							>
+								Sign in with password
+							</a>
+						</p>
+					</div>
+				{/if}
 			{:else if !data.viewer.emailMatches}
 				<div class="space-y-3 text-sm text-muted-foreground">
 					<div class="flex items-start gap-2.5 rounded-xl border border-amber-500/30 bg-amber-500/8 p-3.5">
@@ -142,7 +228,7 @@
 						class="w-full"
 						onclick={async () => {
 							await authClient.signOut();
-							await goto(`/login?next=/accept-invitation?id=${data.invite.id}`);
+							await goto(`/accept-invitation?id=${data.invite.id}`);
 						}}
 					>
 						Sign in with the right account
@@ -152,7 +238,11 @@
 				<div class="flex flex-col gap-2.5">
 					<Button onclick={accept} disabled={busy || blocked} class="group/cta w-full gap-2">
 						{accepting ? "Joining…" : "Accept invitation"}
-						<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+						{#if accepting}
+							<LoaderCircle class="size-4 animate-spin" />
+						{:else}
+							<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+						{/if}
 					</Button>
 					<Button
 						variant="ghost"
@@ -160,7 +250,11 @@
 						disabled={busy || blocked}
 						class="w-full gap-2 text-muted-foreground"
 					>
-						<X class="size-4" />
+						{#if rejecting}
+							<LoaderCircle class="size-4 animate-spin" />
+						{:else}
+							<X class="size-4" />
+						{/if}
 						{rejecting ? "Declining…" : "Decline"}
 					</Button>
 				</div>

--- a/apps/web/src/routes/admin/teams/[id]/+page.svelte
+++ b/apps/web/src/routes/admin/teams/[id]/+page.svelte
@@ -6,13 +6,16 @@
 	import { Label } from "@recast/ui/label";
 	import * as Select from "@recast/ui/select";
 	import { toast } from "@recast/ui/sonner";
-	import { ArrowLeft, Crown, ShieldCheck } from "@lucide/svelte";
+	import { ArrowLeft, Crown, LoaderCircle, ShieldCheck } from "@lucide/svelte";
 	import { untrack } from "svelte";
 
 	let { data } = $props();
 
 	let name = $state(untrack(() => data.team.name));
 	let plan = $state(untrack(() => data.team.plan));
+
+	let savingPlan = $state(false);
+	let savingName = $state(false);
 
 	const memberCap = $derived(data.caps.members[data.team.plan] ?? 3);
 </script>
@@ -47,12 +50,15 @@
 		<form
 			method="POST"
 			action="?/updatePlan"
-			use:enhance={() =>
-				async ({ result, update }) => {
+			use:enhance={() => {
+				savingPlan = true;
+				return async ({ result, update }) => {
 					if (result.type === "success") toast.success("Plan updated.");
 					else if (result.type === "failure") toast.error(String(result.data?.error));
 					await update();
-				}}
+					savingPlan = false;
+				};
+			}}
 			class="space-y-3"
 		>
 			<Label class="block">
@@ -66,7 +72,12 @@
 					</Select.Content>
 				</Select.Root>
 			</Label>
-			<Button type="submit" size="sm">Save plan</Button>
+			<Button type="submit" size="sm" disabled={savingPlan} class="gap-2">
+				{#if savingPlan}
+					<LoaderCircle class="size-3.5 animate-spin" />
+				{/if}
+				{savingPlan ? "Saving…" : "Save plan"}
+			</Button>
 		</form>
 	</section>
 
@@ -75,19 +86,27 @@
 		<form
 			method="POST"
 			action="?/rename"
-			use:enhance={() =>
-				async ({ result, update }) => {
+			use:enhance={() => {
+				savingName = true;
+				return async ({ result, update }) => {
 					if (result.type === "success") toast.success("Renamed.");
 					else if (result.type === "failure") toast.error(String(result.data?.error));
 					await update();
-				}}
+					savingName = false;
+				};
+			}}
 			class="space-y-3"
 		>
 			<Label class="block">
 				<span class="mb-1 block text-xs font-semibold text-foreground/85">Name</span>
 				<Input bind:value={name} name="name" class="h-9" />
 			</Label>
-			<Button type="submit" size="sm">Save name</Button>
+			<Button type="submit" size="sm" disabled={savingName} class="gap-2">
+				{#if savingName}
+					<LoaderCircle class="size-3.5 animate-spin" />
+				{/if}
+				{savingName ? "Saving…" : "Save name"}
+			</Button>
 		</form>
 	</section>
 </div>

--- a/apps/web/src/routes/admin/teams/[id]/+page.svelte
+++ b/apps/web/src/routes/admin/teams/[id]/+page.svelte
@@ -53,10 +53,13 @@
 			use:enhance={() => {
 				savingPlan = true;
 				return async ({ result, update }) => {
-					if (result.type === "success") toast.success("Plan updated.");
-					else if (result.type === "failure") toast.error(String(result.data?.error));
-					await update();
-					savingPlan = false;
+					try {
+						if (result.type === "success") toast.success("Plan updated.");
+						else if (result.type === "failure") toast.error(String(result.data?.error));
+						await update();
+					} finally {
+						savingPlan = false;
+					}
 				};
 			}}
 			class="space-y-3"
@@ -89,10 +92,13 @@
 			use:enhance={() => {
 				savingName = true;
 				return async ({ result, update }) => {
-					if (result.type === "success") toast.success("Renamed.");
-					else if (result.type === "failure") toast.error(String(result.data?.error));
-					await update();
-					savingName = false;
+					try {
+						if (result.type === "success") toast.success("Renamed.");
+						else if (result.type === "failure") toast.error(String(result.data?.error));
+						await update();
+					} finally {
+						savingName = false;
+					}
 				};
 			}}
 			class="space-y-3"

--- a/apps/web/src/routes/admin/users/[id]/+page.svelte
+++ b/apps/web/src/routes/admin/users/[id]/+page.svelte
@@ -17,6 +17,7 @@
 		ClipboardList,
 		Crown,
 		Key,
+		LoaderCircle,
 		LogOut,
 		ShieldOff,
 		Trash2,
@@ -40,15 +41,39 @@
 	let confirmDelete = $state(false);
 	let confirmBan = $state(false);
 
+	// Per-action in-flight tracking.
+	let impersonating = $state(false);
+	let savingProfile = $state(false);
+	let settingRole = $state(false);
+	let settingStatus = $state(false);
+	let unbanning = $state(false);
+	let revokingAll = $state(false);
+	let revokingSessionToken = $state<string | null>(null);
+	let settingPassword = $state(false);
+	let deleting = $state(false);
+	let banning = $state(false);
+
 	async function impersonate() {
-		const { error } = await authClient.admin.impersonateUser({ userId: t.id });
-		if (error) {
-			toast.error(error.message ?? "Couldn't start impersonation.");
-			return;
+		if (impersonating) return;
+		impersonating = true;
+		try {
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.admin.impersonateUser({ userId: t.id });
+					if (error) throw new Error(error.message ?? "Couldn't start impersonation.");
+				})(),
+				{
+					loading: `Starting session as ${t.email}…`,
+					success: `Now acting as ${t.email}.`,
+					error: (err) => (err as Error)?.message ?? "Couldn't start impersonation.",
+				},
+			);
+			// Cookie has been swapped to the impersonation session — leave admin
+			// and land in the impersonated user's dashboard.
+			window.location.href = "/dashboard";
+		} finally {
+			impersonating = false;
 		}
-		// Cookie has been swapped to the impersonation session — leave admin
-		// and land in the impersonated user's dashboard.
-		window.location.href = "/dashboard";
 	}
 </script>
 
@@ -82,9 +107,13 @@
 		</div>
 	</div>
 	<div class="flex gap-2">
-		<Button variant="outline" size="sm" onclick={impersonate}>
-			<UserCog class="size-3.5" />
-			Impersonate
+		<Button variant="outline" size="sm" disabled={impersonating} onclick={impersonate}>
+			{#if impersonating}
+				<LoaderCircle class="size-3.5 animate-spin" />
+			{:else}
+				<UserCog class="size-3.5" />
+			{/if}
+			{impersonating ? "Starting…" : "Impersonate"}
 		</Button>
 	</div>
 </header>
@@ -98,12 +127,15 @@
 			method="POST"
 			action="?/updateProfile"
 			class="space-y-3"
-			use:enhance={() =>
-				async ({ result, update }) => {
+			use:enhance={() => {
+				savingProfile = true;
+				return async ({ result, update }) => {
 					if (result.type === "success") toast.success("Profile updated.");
 					else if (result.type === "failure") toast.error(String(result.data?.error));
 					await update();
-				}}
+					savingProfile = false;
+				};
+			}}
 		>
 			<Label class="block">
 				<span class="mb-1 block text-xs font-semibold text-foreground/85">Name</span>
@@ -116,7 +148,12 @@
 					Email changes go through the user's own settings — admins can't edit it.
 				</span>
 			</Label>
-			<Button type="submit" size="sm">Save profile</Button>
+			<Button type="submit" size="sm" disabled={savingProfile} class="gap-2">
+				{#if savingProfile}
+					<LoaderCircle class="size-3.5 animate-spin" />
+				{/if}
+				{savingProfile ? "Saving…" : "Save profile"}
+			</Button>
 		</form>
 
 		<hr class="my-6 border-border/40" />
@@ -125,12 +162,15 @@
 			<form
 				method="POST"
 				action="?/setRole"
-				use:enhance={() =>
-					async ({ result, update }) => {
+				use:enhance={() => {
+					settingRole = true;
+					return async ({ result, update }) => {
 						if (result.type === "success") toast.success("Role updated.");
 						else if (result.type === "failure") toast.error(String(result.data?.error));
 						await update();
-					}}
+						settingRole = false;
+					};
+				}}
 			>
 				<Label class="block">
 					<span class="mb-1 block text-xs font-semibold text-foreground/85">Role</span>
@@ -142,18 +182,26 @@
 						</Select.Content>
 					</Select.Root>
 				</Label>
-				<Button type="submit" size="sm" class="mt-2 w-full">Set role</Button>
+				<Button type="submit" size="sm" disabled={settingRole} class="mt-2 w-full gap-2">
+					{#if settingRole}
+						<LoaderCircle class="size-3.5 animate-spin" />
+					{/if}
+					{settingRole ? "Saving…" : "Set role"}
+				</Button>
 			</form>
 
 			<form
 				method="POST"
 				action="?/setStatus"
-				use:enhance={() =>
-					async ({ result, update }) => {
+				use:enhance={() => {
+					settingStatus = true;
+					return async ({ result, update }) => {
 						if (result.type === "success") toast.success("Status updated.");
 						else if (result.type === "failure") toast.error(String(result.data?.error));
 						await update();
-					}}
+						settingStatus = false;
+					};
+				}}
 			>
 				<Label class="block">
 					<span class="mb-1 block text-xs font-semibold text-foreground/85">Status</span>
@@ -165,7 +213,12 @@
 						</Select.Content>
 					</Select.Root>
 				</Label>
-				<Button type="submit" size="sm" class="mt-2 w-full">Set status</Button>
+				<Button type="submit" size="sm" disabled={settingStatus} class="mt-2 w-full gap-2">
+					{#if settingStatus}
+						<LoaderCircle class="size-3.5 animate-spin" />
+					{/if}
+					{settingStatus ? "Saving…" : "Set status"}
+				</Button>
 			</form>
 		</div>
 	</section>
@@ -197,14 +250,20 @@
 					<form
 						method="POST"
 						action="?/unban"
-						use:enhance={() =>
-							async ({ result, update }) => {
+						use:enhance={() => {
+							unbanning = true;
+							return async ({ result, update }) => {
 								if (result.type === "success") toast.success("User unbanned.");
 								await update();
-							}}
+								unbanning = false;
+							};
+						}}
 					>
-						<Button variant="outline" size="sm" type="submit" class="w-full">
-							Unban user
+						<Button variant="outline" size="sm" type="submit" disabled={unbanning} class="w-full gap-2">
+							{#if unbanning}
+								<LoaderCircle class="size-3.5 animate-spin" />
+							{/if}
+							{unbanning ? "Unbanning…" : "Unban user"}
 						</Button>
 					</form>
 				{:else}
@@ -247,13 +306,21 @@
 						method="POST"
 						action="?/revokeAllSessions"
 						class="mb-3"
-						use:enhance={() =>
-							async ({ result, update }) => {
+						use:enhance={() => {
+							revokingAll = true;
+							return async ({ result, update }) => {
 								if (result.type === "success") toast.success("All sessions revoked.");
 								await update();
-							}}
+								revokingAll = false;
+							};
+						}}
 					>
-						<Button type="submit" size="sm" variant="outline">Revoke all sessions</Button>
+						<Button type="submit" size="sm" variant="outline" disabled={revokingAll} class="gap-2">
+							{#if revokingAll}
+								<LoaderCircle class="size-3.5 animate-spin" />
+							{/if}
+							{revokingAll ? "Revoking…" : "Revoke all sessions"}
+						</Button>
 					</form>
 					<ul class="divide-y divide-border/30">
 						{#each data.sessions as s (s.id)}
@@ -269,14 +336,28 @@
 									<form
 										method="POST"
 										action="?/revokeSession"
-										use:enhance={() =>
-											async ({ result, update }) => {
+										use:enhance={() => {
+											revokingSessionToken = s.token;
+											return async ({ result, update }) => {
 												if (result.type === "success") toast.success("Session revoked.");
 												await update();
-											}}
+												revokingSessionToken = null;
+											};
+										}}
 									>
 										<input type="hidden" name="sessionToken" value={s.token} />
-										<Button type="submit" variant="ghost" size="sm">Revoke</Button>
+										<Button
+											type="submit"
+											variant="ghost"
+											size="sm"
+											disabled={revokingSessionToken === s.token}
+											class="gap-1.5"
+										>
+											{#if revokingSessionToken === s.token}
+												<LoaderCircle class="size-3.5 animate-spin" />
+											{/if}
+											{revokingSessionToken === s.token ? "Revoking…" : "Revoke"}
+										</Button>
 									</form>
 								</div>
 							</li>
@@ -302,8 +383,9 @@
 				method="POST"
 				action="?/setPassword"
 				class="space-y-3 border-t border-border/40 p-5"
-				use:enhance={() =>
-					async ({ result, update }) => {
+				use:enhance={() => {
+					settingPassword = true;
+					return async ({ result, update }) => {
 						if (result.type === "success") {
 							toast.success("Password set. Share securely with the user.");
 							newPassword = "";
@@ -311,7 +393,9 @@
 							toast.error(String(result.data?.error));
 						}
 						await update();
-					}}
+						settingPassword = false;
+					};
+				}}
 			>
 				<Label class="block">
 					<span class="mb-1 block text-xs font-semibold text-foreground/85">New password</span>
@@ -323,7 +407,12 @@
 						class="h-9 font-mono"
 					/>
 				</Label>
-				<Button type="submit" size="sm">Set password</Button>
+				<Button type="submit" size="sm" disabled={settingPassword || !newPassword.trim()} class="gap-2">
+					{#if settingPassword}
+						<LoaderCircle class="size-3.5 animate-spin" />
+					{/if}
+					{settingPassword ? "Saving…" : "Set password"}
+				</Button>
 			</form>
 		</Collapsible.Content>
 	</Collapsible.Root>
@@ -372,8 +461,9 @@
 		<form
 			method="POST"
 			action="?/remove"
-			use:enhance={() =>
-				async ({ result }) => {
+			use:enhance={() => {
+				deleting = true;
+				return async ({ result }) => {
 					if (result.type === "redirect") {
 						confirmDelete = false;
 						toast.success("User deleted.");
@@ -381,13 +471,20 @@
 					} else if (result.type === "failure") {
 						toast.error(String(result.data?.error));
 					}
-				}}
+					deleting = false;
+				};
+			}}
 		>
 			<Dialog.Footer>
-				<Button type="button" variant="ghost" onclick={() => (confirmDelete = false)}>
+				<Button type="button" variant="ghost" disabled={deleting} onclick={() => (confirmDelete = false)}>
 					Cancel
 				</Button>
-				<Button type="submit" variant="destructive">Delete user</Button>
+				<Button type="submit" variant="destructive" disabled={deleting} class="gap-2">
+					{#if deleting}
+						<LoaderCircle class="size-3.5 animate-spin" />
+					{/if}
+					{deleting ? "Deleting…" : "Delete user"}
+				</Button>
 			</Dialog.Footer>
 		</form>
 	</Dialog.Content>
@@ -406,15 +503,18 @@
 			method="POST"
 			action="?/ban"
 			class="space-y-3"
-			use:enhance={() =>
-				async ({ result, update }) => {
+			use:enhance={() => {
+				banning = true;
+				return async ({ result, update }) => {
 					if (result.type === "success") {
 						confirmBan = false;
 						toast.success("User banned.");
 						await invalidateAll();
 					}
 					await update();
-				}}
+					banning = false;
+				};
+			}}
 		>
 			<Label class="block">
 				<span class="mb-1 block text-xs font-semibold text-foreground/85">Reason</span>
@@ -432,8 +532,13 @@
 				/>
 			</Label>
 			<Dialog.Footer>
-				<Button type="button" variant="ghost" onclick={() => (confirmBan = false)}>Cancel</Button>
-				<Button type="submit" variant="destructive">Ban user</Button>
+				<Button type="button" variant="ghost" disabled={banning} onclick={() => (confirmBan = false)}>Cancel</Button>
+				<Button type="submit" variant="destructive" disabled={banning} class="gap-2">
+					{#if banning}
+						<LoaderCircle class="size-3.5 animate-spin" />
+					{/if}
+					{banning ? "Banning…" : "Ban user"}
+				</Button>
 			</Dialog.Footer>
 		</form>
 	</Dialog.Content>

--- a/apps/web/src/routes/admin/users/[id]/+page.svelte
+++ b/apps/web/src/routes/admin/users/[id]/+page.svelte
@@ -130,10 +130,13 @@
 			use:enhance={() => {
 				savingProfile = true;
 				return async ({ result, update }) => {
-					if (result.type === "success") toast.success("Profile updated.");
-					else if (result.type === "failure") toast.error(String(result.data?.error));
-					await update();
-					savingProfile = false;
+					try {
+						if (result.type === "success") toast.success("Profile updated.");
+						else if (result.type === "failure") toast.error(String(result.data?.error));
+						await update();
+					} finally {
+						savingProfile = false;
+					}
 				};
 			}}
 		>
@@ -165,10 +168,13 @@
 				use:enhance={() => {
 					settingRole = true;
 					return async ({ result, update }) => {
-						if (result.type === "success") toast.success("Role updated.");
-						else if (result.type === "failure") toast.error(String(result.data?.error));
-						await update();
-						settingRole = false;
+						try {
+							if (result.type === "success") toast.success("Role updated.");
+							else if (result.type === "failure") toast.error(String(result.data?.error));
+							await update();
+						} finally {
+							settingRole = false;
+						}
 					};
 				}}
 			>
@@ -196,10 +202,13 @@
 				use:enhance={() => {
 					settingStatus = true;
 					return async ({ result, update }) => {
-						if (result.type === "success") toast.success("Status updated.");
-						else if (result.type === "failure") toast.error(String(result.data?.error));
-						await update();
-						settingStatus = false;
+						try {
+							if (result.type === "success") toast.success("Status updated.");
+							else if (result.type === "failure") toast.error(String(result.data?.error));
+							await update();
+						} finally {
+							settingStatus = false;
+						}
 					};
 				}}
 			>
@@ -253,9 +262,12 @@
 						use:enhance={() => {
 							unbanning = true;
 							return async ({ result, update }) => {
-								if (result.type === "success") toast.success("User unbanned.");
-								await update();
-								unbanning = false;
+								try {
+									if (result.type === "success") toast.success("User unbanned.");
+									await update();
+								} finally {
+									unbanning = false;
+								}
 							};
 						}}
 					>
@@ -309,9 +321,12 @@
 						use:enhance={() => {
 							revokingAll = true;
 							return async ({ result, update }) => {
-								if (result.type === "success") toast.success("All sessions revoked.");
-								await update();
-								revokingAll = false;
+								try {
+									if (result.type === "success") toast.success("All sessions revoked.");
+									await update();
+								} finally {
+									revokingAll = false;
+								}
 							};
 						}}
 					>
@@ -339,9 +354,12 @@
 										use:enhance={() => {
 											revokingSessionToken = s.token;
 											return async ({ result, update }) => {
-												if (result.type === "success") toast.success("Session revoked.");
-												await update();
-												revokingSessionToken = null;
+												try {
+													if (result.type === "success") toast.success("Session revoked.");
+													await update();
+												} finally {
+													revokingSessionToken = null;
+												}
 											};
 										}}
 									>
@@ -386,14 +404,17 @@
 				use:enhance={() => {
 					settingPassword = true;
 					return async ({ result, update }) => {
-						if (result.type === "success") {
-							toast.success("Password set. Share securely with the user.");
-							newPassword = "";
-						} else if (result.type === "failure") {
-							toast.error(String(result.data?.error));
+						try {
+							if (result.type === "success") {
+								toast.success("Password set. Share securely with the user.");
+								newPassword = "";
+							} else if (result.type === "failure") {
+								toast.error(String(result.data?.error));
+							}
+							await update();
+						} finally {
+							settingPassword = false;
 						}
-						await update();
-						settingPassword = false;
 					};
 				}}
 			>
@@ -464,14 +485,17 @@
 			use:enhance={() => {
 				deleting = true;
 				return async ({ result }) => {
-					if (result.type === "redirect") {
-						confirmDelete = false;
-						toast.success("User deleted.");
-						goto(result.location);
-					} else if (result.type === "failure") {
-						toast.error(String(result.data?.error));
+					try {
+						if (result.type === "redirect") {
+							confirmDelete = false;
+							toast.success("User deleted.");
+							goto(result.location);
+						} else if (result.type === "failure") {
+							toast.error(String(result.data?.error));
+						}
+					} finally {
+						deleting = false;
 					}
-					deleting = false;
 				};
 			}}
 		>
@@ -506,13 +530,16 @@
 			use:enhance={() => {
 				banning = true;
 				return async ({ result, update }) => {
-					if (result.type === "success") {
-						confirmBan = false;
-						toast.success("User banned.");
-						await invalidateAll();
+					try {
+						if (result.type === "success") {
+							confirmBan = false;
+							toast.success("User banned.");
+							await invalidateAll();
+						}
+						await update();
+					} finally {
+						banning = false;
 					}
-					await update();
-					banning = false;
 				};
 			}}
 		>

--- a/apps/web/src/routes/admin/waitlist/+page.svelte
+++ b/apps/web/src/routes/admin/waitlist/+page.svelte
@@ -3,10 +3,12 @@
 	import { Button } from "@recast/ui/button";
 	import { Checkbox } from "@recast/ui/checkbox";
 	import { toast } from "@recast/ui/sonner";
+	import { LoaderCircle } from "@lucide/svelte";
 
 	let { data } = $props();
 
 	let selected = $state<Set<string>>(new Set());
+	let approving = $state(false);
 
 	function toggle(id: string, checked: boolean) {
 		const next = new Set(selected);
@@ -35,8 +37,9 @@
 <form
 	method="POST"
 	action="?/approve"
-	use:enhance={() =>
-		async ({ result, update }) => {
+	use:enhance={() => {
+		approving = true;
+		return async ({ result, update }) => {
 			if (result.type === "success") {
 				toast.success(`Approved ${result.data?.approved ?? 0} user(s).`);
 				selected = new Set();
@@ -44,7 +47,9 @@
 				toast.error(String(result.data?.error));
 			}
 			await update();
-		}}
+			approving = false;
+		};
+	}}
 >
 	<div class="mb-3 flex items-center justify-between">
 		<label class="flex items-center gap-2 text-xs font-medium">
@@ -54,8 +59,11 @@
 			/>
 			Select all
 		</label>
-		<Button type="submit" size="sm" disabled={selected.size === 0}>
-			Approve {selected.size || ""}
+		<Button type="submit" size="sm" disabled={selected.size === 0 || approving} class="gap-2">
+			{#if approving}
+				<LoaderCircle class="size-3.5 animate-spin" />
+			{/if}
+			{approving ? "Approving…" : `Approve ${selected.size || ""}`}
 		</Button>
 	</div>
 

--- a/apps/web/src/routes/admin/waitlist/+page.svelte
+++ b/apps/web/src/routes/admin/waitlist/+page.svelte
@@ -40,14 +40,17 @@
 	use:enhance={() => {
 		approving = true;
 		return async ({ result, update }) => {
-			if (result.type === "success") {
-				toast.success(`Approved ${result.data?.approved ?? 0} user(s).`);
-				selected = new Set();
-			} else if (result.type === "failure") {
-				toast.error(String(result.data?.error));
+			try {
+				if (result.type === "success") {
+					toast.success(`Approved ${result.data?.approved ?? 0} user(s).`);
+					selected = new Set();
+				} else if (result.type === "failure") {
+					toast.error(String(result.data?.error));
+				}
+				await update();
+			} finally {
+				approving = false;
 			}
-			await update();
-			approving = false;
 		};
 	}}
 >

--- a/apps/web/src/routes/api/auth/lookup/+server.ts
+++ b/apps/web/src/routes/api/auth/lookup/+server.ts
@@ -1,0 +1,48 @@
+import { json } from "@sveltejs/kit";
+import { eq } from "drizzle-orm";
+import { getDb } from "$lib/db";
+import { user } from "$lib/db/schema";
+import type { RequestHandler } from "./$types";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Pre-flight email lookup for the login form. Production-only signup means
+ * "log in" should never silently create an account, so the form needs to
+ * differentiate three cases before calling auth:
+ *
+ *   - `unknown`  → no row at all, route them to /waitlist instead of a
+ *                  cryptic "invalid credentials" toast.
+ *   - `pending`  → on the waitlist, magic-link is suppressed server-side
+ *                  ([isOnWaitlist] short-circuits sendMagicLink). Tell them
+ *                  explicitly so they don't keep retrying.
+ *   - `active`   → proceed with the actual auth call.
+ *
+ * Banned users intentionally surface as `active` here — Better Auth's own
+ * sign-in path returns the ban reason, which is the right message to show.
+ *
+ * Exposing existence is a deliberate trade-off: we already publish a public
+ * waitlist endpoint that takes any email, so an attacker can already probe
+ * registration. The UX win outweighs the marginal info leak.
+ */
+export const POST: RequestHandler = async ({ request }) => {
+	let body: { email?: unknown } = {};
+	try {
+		body = (await request.json()) as typeof body;
+	} catch {
+		return json({ status: "invalid" as const });
+	}
+	const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+	if (!EMAIL_RE.test(email)) return json({ status: "invalid" as const });
+
+	const db = getDb();
+	const [row] = await db
+		.select({ status: user.status })
+		.from(user)
+		.where(eq(user.email, email))
+		.limit(1);
+
+	if (!row) return json({ status: "unknown" as const });
+	if (row.status === "pending") return json({ status: "pending" as const });
+	return json({ status: "active" as const });
+};

--- a/apps/web/src/routes/dashboard/+layout.server.ts
+++ b/apps/web/src/routes/dashboard/+layout.server.ts
@@ -14,6 +14,7 @@ type SessionUser = {
 	name?: string | null;
 	email: string;
 	role?: string | null;
+	emailVerified?: boolean | null;
 };
 type SessionShape = {
 	user: SessionUser;
@@ -24,8 +25,13 @@ type SessionShape = {
  * Dashboard auth + team gate.
  *
  *   1. No session → /login?next=…
- *   2. No teams at all → /onboarding/team (create one or accept an invite)
- *   3. No active team set but has memberships → auto-set the most recent
+ *   2. Not email-verified → /verify-email (full dashboard is gated; users
+ *      can still see the marketing site and verification page itself).
+ *      Magic-link sign-in auto-verifies, and invitees are pre-created with
+ *      `emailVerified: true`, so this only catches password signups that
+ *      haven't clicked the confirmation link yet.
+ *   3. No teams at all → /onboarding/team (create one or accept an invite)
+ *   4. No active team set but has memberships → auto-set the most recent
  *      one and rerun. Avoids forcing onboarding on users whose session
  *      simply lost activeOrganizationId (logged in fresh, etc).
  */
@@ -36,6 +42,10 @@ export const load: LayoutServerLoad = async ({ request, url }) => {
 
 	if (!session) {
 		redirect(303, `/login?next=${encodeURIComponent(url.pathname + url.search)}`);
+	}
+
+	if (!session.user.emailVerified) {
+		redirect(303, "/verify-email");
 	}
 
 	const db = getDb();
@@ -111,6 +121,7 @@ export const load: LayoutServerLoad = async ({ request, url }) => {
 			name: session.user.name ?? "",
 			email: session.user.email,
 			role: session.user.role ?? "user",
+			emailVerified: Boolean(session.user.emailVerified),
 		},
 		memberships,
 		pendingInvites,

--- a/apps/web/src/routes/dashboard/+layout.svelte
+++ b/apps/web/src/routes/dashboard/+layout.svelte
@@ -23,7 +23,7 @@
 	<DashboardSidebar />
 	<Sidebar.Inset class="min-h-svh">
 		<DashboardHeader />
-		<div class="px-5 py-7 sm:px-8 sm:py-9">
+		<div class="px-5 py-8 sm:px-8 sm:py-10">
 			{@render children()}
 		</div>
 	</Sidebar.Inset>

--- a/apps/web/src/routes/dashboard/recasts/+page.svelte
+++ b/apps/web/src/routes/dashboard/recasts/+page.svelte
@@ -10,7 +10,7 @@
 	  type Recast,
 	  type RecordingSource,
 	} from "$lib/dashboard/store.svelte";
-	import { Cloud, Film, HardDrive, Search, Upload, Video, X } from "@lucide/svelte";
+	import { Cloud, Film, HardDrive, LoaderCircle, Search, Upload, Video, X } from "@lucide/svelte";
 	import { Button } from "@recast/ui/button";
 	import * as Select from "@recast/ui/select";
 	import { toast } from "@recast/ui/sonner";
@@ -90,26 +90,36 @@
 		if (!file) return;
 
 		uploading = true;
-		const url = URL.createObjectURL(file);
-		const durationSec = await readDuration(url);
-		const destination = settingsStore.value.preferences.defaultDestination;
+		try {
+			await toast.promise(
+				(async () => {
+					const url = URL.createObjectURL(file);
+					const durationSec = await readDuration(url);
+					const destination = settingsStore.value.preferences.defaultDestination;
 
-		recastsStore.add({
-			id: crypto.randomUUID(),
-			title: file.name.replace(/\.[^.]+$/, "") || "Untitled recast",
-			durationSec,
-			createdAt: Date.now(),
-			sizeBytes: file.size,
-			source: destination,
-			provider: destination === "cloud" ? "Cloudinary" : null,
-			views: 0,
-			videoUrl: url,
-			posterUrl: "",
-		});
-
-		uploading = false;
-		input.value = "";
-		toast.success(`“${file.name}” added to your library.`);
+					recastsStore.add({
+						id: crypto.randomUUID(),
+						title: file.name.replace(/\.[^.]+$/, "") || "Untitled recast",
+						durationSec,
+						createdAt: Date.now(),
+						sizeBytes: file.size,
+						source: destination,
+						provider: destination === "cloud" ? "Cloudinary" : null,
+						views: 0,
+						videoUrl: url,
+						posterUrl: "",
+					});
+				})(),
+				{
+					loading: `Adding “${file.name}”…`,
+					success: `“${file.name}” added to your library.`,
+					error: (err) => (err as Error)?.message ?? "Couldn't add that file.",
+				},
+			);
+		} finally {
+			uploading = false;
+			input.value = "";
+		}
 	}
 
 	function doRename(rec: Recast, title: string) {
@@ -170,7 +180,11 @@
 		</p>
 	</div>
 	<Button class="gap-2" disabled={uploading} onclick={() => fileInput?.click()}>
-		<Upload class="size-4" />
+		{#if uploading}
+			<LoaderCircle class="size-4 animate-spin" />
+		{:else}
+			<Upload class="size-4" />
+		{/if}
 		{uploading ? "Adding…" : "Upload recast"}
 	</Button>
 </header>
@@ -290,9 +304,13 @@
 			<p class="mt-1 max-w-xs text-xs text-muted-foreground">
 				Upload a video, or capture one with the Recast desktop app.
 			</p>
-			<Button size="sm" class="mt-5 gap-2" onclick={() => fileInput?.click()}>
-				<Upload class="size-3.5" />
-				Upload recast
+			<Button size="sm" class="mt-5 gap-2" disabled={uploading} onclick={() => fileInput?.click()}>
+				{#if uploading}
+					<LoaderCircle class="size-3.5 animate-spin" />
+				{:else}
+					<Upload class="size-3.5" />
+				{/if}
+				{uploading ? "Adding…" : "Upload recast"}
 			</Button>
 		{/if}
 	</div>

--- a/apps/web/src/routes/dashboard/recasts/+page.svelte
+++ b/apps/web/src/routes/dashboard/recasts/+page.svelte
@@ -317,7 +317,18 @@
 {/if}
 
 {#if playing}
-	<PlayerDialog recast={playing} onclose={() => (playing = null)} />
+	<PlayerDialog
+		recast={playing}
+		onclose={() => (playing = null)}
+		onengagement={(event) => {
+			// Single-bump-per-open: the dialog's `started` latch guarantees
+			// `view-start` fires once. The other events (progress/ended) feed
+			// into analytics later — no-op for now.
+			if (event === "view-start" && playing) {
+				recastsStore.incrementViews(playing.id);
+			}
+		}}
+	/>
 {/if}
 
 {#if renaming}

--- a/apps/web/src/routes/dashboard/settings/profile/+page.svelte
+++ b/apps/web/src/routes/dashboard/settings/profile/+page.svelte
@@ -1,13 +1,31 @@
 <script lang="ts">
+	import { page } from "$app/state";
+	import { authClient } from "$lib/auth/client";
 	import SettingsSection from "$lib/dashboard/components/SettingsSection.svelte";
 	import { settingsStore } from "$lib/dashboard/store.svelte";
+	import { Badge } from "@recast/ui/badge";
 	import { Button } from "@recast/ui/button";
 	import { toast } from "@recast/ui/sonner";
-	import { User } from "@lucide/svelte";
+	import {
+		BadgeCheck,
+		LoaderCircle,
+		MailWarning,
+		RefreshCw,
+		User,
+	} from "@lucide/svelte";
 	import { cubicOut } from "svelte/easing";
 	import { fly } from "svelte/transition";
 
 	const settings = settingsStore.value;
+
+	// Pulled live from the dashboard layout's session so the badge reflects
+	// the most recent server-side state, not the local profile cache.
+	type LayoutData = { user?: { email: string; emailVerified?: boolean } };
+	const layoutUser = $derived(((page.data as LayoutData).user) ?? null);
+	const verified = $derived(Boolean(layoutUser?.emailVerified));
+	const accountEmail = $derived(layoutUser?.email ?? settings.profile.email);
+
+	let resending = $state(false);
 
 	const inputClass =
 		"rounded-lg border border-border-low/70 bg-background/80 px-3 py-2 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground/60 focus:border-primary/60";
@@ -17,9 +35,32 @@
 		settingsStore.save();
 		toast.success("Profile updated.");
 	}
+
+	async function resendVerification() {
+		if (resending) return;
+		resending = true;
+		try {
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.sendVerificationEmail({
+						email: accountEmail,
+						callbackURL: "/dashboard/settings/profile",
+					});
+					if (error) throw new Error(error.message ?? "Couldn't send the verification email.");
+				})(),
+				{
+					loading: "Sending verification email…",
+					success: "Sent — check your inbox.",
+					error: (err) => (err as Error)?.message ?? "Couldn't send the verification email.",
+				},
+			);
+		} finally {
+			resending = false;
+		}
+	}
 </script>
 
-<div in:fly={{ y: 14, duration: 420, easing: cubicOut }}>
+<div class="flex flex-col gap-4" in:fly={{ y: 14, duration: 420, easing: cubicOut }}>
 	<SettingsSection
 		icon={User}
 		title="Profile"
@@ -31,7 +72,20 @@
 				<input type="text" bind:value={settings.profile.name} class={inputClass} />
 			</label>
 			<label class="flex flex-col gap-1.5">
-				<span class="text-xs font-semibold text-foreground/85">Email</span>
+				<span class="flex items-center justify-between text-xs font-semibold text-foreground/85">
+					<span>Email</span>
+					{#if verified}
+						<Badge variant="outline" class="gap-1 text-success">
+							<BadgeCheck class="size-3" />
+							Verified
+						</Badge>
+					{:else}
+						<Badge variant="outline" class="gap-1 text-amber-600 dark:text-amber-400">
+							<MailWarning class="size-3" />
+							Unverified
+						</Badge>
+					{/if}
+				</span>
 				<input type="email" bind:value={settings.profile.email} class={inputClass} />
 			</label>
 			<div class="sm:col-span-2">
@@ -39,4 +93,29 @@
 			</div>
 		</form>
 	</SettingsSection>
+
+	{#if !verified}
+		<!-- Soft nudge for the edge-case path: a user who somehow reached
+		     settings before verifying (e.g. landing in dev mode). The
+		     dashboard layout gates production paths to /verify-email. -->
+		<SettingsSection
+			icon={MailWarning}
+			title="Email verification pending"
+			description="Confirm {accountEmail} to unlock dashboard actions."
+		>
+			<div class="flex flex-wrap items-center gap-3">
+				<Button onclick={resendVerification} disabled={resending} size="sm" class="gap-2">
+					{#if resending}
+						<LoaderCircle class="size-3.5 animate-spin" />
+					{:else}
+						<RefreshCw class="size-3.5" />
+					{/if}
+					{resending ? "Sending…" : "Send verification email"}
+				</Button>
+				<span class="text-xs text-muted-foreground">
+					Link valid for 24 hours.
+				</span>
+			</div>
+		</SettingsSection>
+	{/if}
 </div>

--- a/apps/web/src/routes/dashboard/team/+page.server.ts
+++ b/apps/web/src/routes/dashboard/team/+page.server.ts
@@ -147,6 +147,39 @@ export const actions: Actions = {
 		if (role !== "member" && role !== "admin") {
 			return fail(400, { error: "Invalid role" });
 		}
+
+		// Public sign-up is closed in production, so a brand-new invitee who
+		// isn't on the waitlist couldn't otherwise create an account to
+		// accept the invitation. Pre-create a `status=active` user row so the
+		// magic-link sign-in (and /accept-invitation) flow has something to
+		// find. If a row already exists — active, pending, or banned — we
+		// leave it untouched. Pending invitees get promoted to active so the
+		// invitation supersedes the waitlist queue.
+		const db = getDb();
+		const [existing] = await db
+			.select({ id: userTable.id, status: userTable.status })
+			.from(userTable)
+			.where(eq(userTable.email, email))
+			.limit(1);
+		if (!existing) {
+			await db.insert(userTable).values({
+				id: crypto.randomUUID(),
+				email,
+				name: email.split("@")[0]!,
+				status: "active",
+				// Owner-vouched: the invite IS the verification. Skipping this
+				// makes Better Auth's accept-invitation reject the session with
+				// "email not verified" when the invitee signs in for the first
+				// time via magic link.
+				emailVerified: true,
+			});
+		} else if (existing.status === "pending") {
+			await db
+				.update(userTable)
+				.set({ status: "active", emailVerified: true })
+				.where(eq(userTable.id, existing.id));
+		}
+
 		try {
 			await getAuth().api.createInvitation({
 				headers: request.headers,

--- a/apps/web/src/routes/dashboard/team/+page.svelte
+++ b/apps/web/src/routes/dashboard/team/+page.svelte
@@ -9,6 +9,7 @@
 	import {
 		Crown,
 		Image,
+		LoaderCircle,
 		LogOut,
 		Mail,
 		Send,
@@ -24,6 +25,15 @@
 
 	let inviteEmail = $state("");
 	let inviteRole = $state<"member" | "admin">("member");
+
+	// Per-action in-flight tracking so each button can show its own spinner
+	// without disabling the entire page.
+	let leaving = $state(false);
+	let savingProfile = $state(false);
+	let inviting = $state(false);
+	let cancellingInviteId = $state<string | null>(null);
+	let removingMemberId = $state<string | null>(null);
+	let updatingRoleMemberId = $state<string | null>(null);
 
 	// Owner-editable profile fields. Seeded once from server data so the
 	// inputs don't snap back during form submission.
@@ -48,7 +58,7 @@
 	);
 </script>
 
-<header class="mb-8 flex flex-wrap items-end justify-between gap-4">
+<header class="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 	<div class="min-w-0">
 		<h1 class="truncate text-2xl font-semibold tracking-tight">{data.org.name}</h1>
 		<p class="mt-1 text-sm text-muted-foreground">
@@ -63,15 +73,23 @@
 			<form
 				method="POST"
 				action="?/leave"
-				use:enhance={() =>
-					async ({ result }) => {
+				use:enhance={() => {
+					leaving = true;
+					return async ({ result }) => {
 						if (result.type === "redirect") {
 							toast.success("You've left the team.");
 						}
-					}}
+						leaving = false;
+					};
+				}}
 			>
-				<Button type="submit" variant="outline" size="sm">
-					<LogOut class="size-3.5" /> Leave team
+				<Button type="submit" variant="outline" size="sm" disabled={leaving}>
+					{#if leaving}
+						<LoaderCircle class="size-3.5 animate-spin" />
+					{:else}
+						<LogOut class="size-3.5" />
+					{/if}
+					{leaving ? "Leaving…" : "Leave team"}
 				</Button>
 			</form>
 		{/if}
@@ -96,13 +114,16 @@
 			method="POST"
 			action="?/updateProfile"
 			class="grid gap-3 sm:grid-cols-[88px_1fr]"
-			use:enhance={() =>
-				async ({ result, update }) => {
+			use:enhance={() => {
+				savingProfile = true;
+				return async ({ result, update }) => {
 					if (result.type === "success") toast.success("Team updated.");
 					else if (result.type === "failure")
 						toast.error(String(result.data?.error));
 					await update();
-				}}
+					savingProfile = false;
+				};
+			}}
 		>
 			<div class="row-span-3 flex justify-center sm:justify-start">
 				<div class="relative grid size-20 place-items-center overflow-hidden rounded-2xl bg-foreground/6 text-foreground/70 ring-1 ring-border/40">
@@ -154,7 +175,12 @@
 			</Label>
 
 			<div class="sm:col-start-2">
-				<Button type="submit" size="sm">Save changes</Button>
+				<Button type="submit" size="sm" disabled={savingProfile} class="gap-2">
+					{#if savingProfile}
+						<LoaderCircle class="size-3.5 animate-spin" />
+					{/if}
+					{savingProfile ? "Saving…" : "Save changes"}
+				</Button>
 			</div>
 		</form>
 	</section>
@@ -180,14 +206,20 @@
 							<Badge variant="outline">member</Badge>
 						{/if}
 						{#if canManage && m.userId !== data.viewer.userId && m.role !== "owner"}
+							{#if updatingRoleMemberId === m.id}
+								<LoaderCircle class="size-3.5 animate-spin text-muted-foreground" />
+							{/if}
 							<form
 								method="POST"
 								action="?/updateRole"
-								use:enhance={() =>
-									async ({ result, update }) => {
+								use:enhance={() => {
+									updatingRoleMemberId = m.id;
+									return async ({ result, update }) => {
 										if (result.type === "success") toast.success("Role updated.");
 										await update();
-									}}
+										updatingRoleMemberId = null;
+									};
+								}}
 							>
 								<input type="hidden" name="memberId" value={m.id} />
 								<Select.Root
@@ -224,15 +256,28 @@
 							<form
 								method="POST"
 								action="?/removeMember"
-								use:enhance={() =>
-									async ({ result, update }) => {
+								use:enhance={() => {
+									removingMemberId = m.id;
+									return async ({ result, update }) => {
 										if (result.type === "success") toast.success("Member removed.");
 										await update();
-									}}
+										removingMemberId = null;
+									};
+								}}
 							>
 								<input type="hidden" name="memberIdOrEmail" value={m.id} />
-								<Button type="submit" variant="ghost" size="sm" class="text-destructive">
-									<Trash2 class="size-3.5" />
+								<Button
+									type="submit"
+									variant="ghost"
+									size="sm"
+									disabled={removingMemberId === m.id}
+									class="text-destructive"
+								>
+									{#if removingMemberId === m.id}
+										<LoaderCircle class="size-3.5 animate-spin" />
+									{:else}
+										<Trash2 class="size-3.5" />
+									{/if}
 								</Button>
 							</form>
 						{/if}
@@ -264,8 +309,9 @@
 						method="POST"
 						action="?/invite"
 						class="space-y-3"
-						use:enhance={() =>
-							async ({ result, update }) => {
+						use:enhance={() => {
+							inviting = true;
+							return async ({ result, update }) => {
 								if (result.type === "success") {
 									toast.success("Invitation sent.");
 									inviteEmail = "";
@@ -273,7 +319,9 @@
 									toast.error(String(result.data?.error));
 								}
 								await update();
-							}}
+								inviting = false;
+							};
+						}}
 					>
 						<Label class="block">
 							<span class="mb-1 block text-xs font-semibold text-foreground/85">Email</span>
@@ -296,8 +344,13 @@
 								</Select.Content>
 							</Select.Root>
 						</Label>
-						<Button type="submit" size="sm" class="w-full gap-2">
-							<Mail class="size-3.5" /> Send invite
+						<Button type="submit" size="sm" disabled={inviting || !inviteEmail.trim()} class="w-full gap-2">
+							{#if inviting}
+								<LoaderCircle class="size-3.5 animate-spin" />
+							{:else}
+								<Mail class="size-3.5" />
+							{/if}
+							{inviting ? "Sending invite…" : "Send invite"}
 						</Button>
 					</form>
 				{/if}
@@ -322,15 +375,27 @@
 								<form
 									method="POST"
 									action="?/cancelInvite"
-									use:enhance={() =>
-										async ({ result, update }) => {
+									use:enhance={() => {
+										cancellingInviteId = inv.id;
+										return async ({ result, update }) => {
 											if (result.type === "success") toast.success("Invite canceled.");
 											await update();
-										}}
+											cancellingInviteId = null;
+										};
+									}}
 								>
 									<input type="hidden" name="id" value={inv.id} />
-									<Button type="submit" variant="ghost" size="sm">
-										<X class="size-3.5" />
+									<Button
+										type="submit"
+										variant="ghost"
+										size="sm"
+										disabled={cancellingInviteId === inv.id}
+									>
+										{#if cancellingInviteId === inv.id}
+											<LoaderCircle class="size-3.5 animate-spin" />
+										{:else}
+											<X class="size-3.5" />
+										{/if}
 									</Button>
 								</form>
 							{/if}

--- a/apps/web/src/routes/dashboard/team/+page.svelte
+++ b/apps/web/src/routes/dashboard/team/+page.svelte
@@ -76,10 +76,13 @@
 				use:enhance={() => {
 					leaving = true;
 					return async ({ result }) => {
-						if (result.type === "redirect") {
-							toast.success("You've left the team.");
+						try {
+							if (result.type === "redirect") {
+								toast.success("You've left the team.");
+							}
+						} finally {
+							leaving = false;
 						}
-						leaving = false;
 					};
 				}}
 			>
@@ -117,11 +120,14 @@
 			use:enhance={() => {
 				savingProfile = true;
 				return async ({ result, update }) => {
-					if (result.type === "success") toast.success("Team updated.");
-					else if (result.type === "failure")
-						toast.error(String(result.data?.error));
-					await update();
-					savingProfile = false;
+					try {
+						if (result.type === "success") toast.success("Team updated.");
+						else if (result.type === "failure")
+							toast.error(String(result.data?.error));
+						await update();
+					} finally {
+						savingProfile = false;
+					}
 				};
 			}}
 		>
@@ -215,9 +221,12 @@
 								use:enhance={() => {
 									updatingRoleMemberId = m.id;
 									return async ({ result, update }) => {
-										if (result.type === "success") toast.success("Role updated.");
-										await update();
-										updatingRoleMemberId = null;
+										try {
+											if (result.type === "success") toast.success("Role updated.");
+											await update();
+										} finally {
+											updatingRoleMemberId = null;
+										}
 									};
 								}}
 							>
@@ -259,9 +268,12 @@
 								use:enhance={() => {
 									removingMemberId = m.id;
 									return async ({ result, update }) => {
-										if (result.type === "success") toast.success("Member removed.");
-										await update();
-										removingMemberId = null;
+										try {
+											if (result.type === "success") toast.success("Member removed.");
+											await update();
+										} finally {
+											removingMemberId = null;
+										}
 									};
 								}}
 							>
@@ -312,14 +324,17 @@
 						use:enhance={() => {
 							inviting = true;
 							return async ({ result, update }) => {
-								if (result.type === "success") {
-									toast.success("Invitation sent.");
-									inviteEmail = "";
-								} else if (result.type === "failure") {
-									toast.error(String(result.data?.error));
+								try {
+									if (result.type === "success") {
+										toast.success("Invitation sent.");
+										inviteEmail = "";
+									} else if (result.type === "failure") {
+										toast.error(String(result.data?.error));
+									}
+									await update();
+								} finally {
+									inviting = false;
 								}
-								await update();
-								inviting = false;
 							};
 						}}
 					>
@@ -378,9 +393,12 @@
 									use:enhance={() => {
 										cancellingInviteId = inv.id;
 										return async ({ result, update }) => {
-											if (result.type === "success") toast.success("Invite canceled.");
-											await update();
-											cancellingInviteId = null;
+											try {
+												if (result.type === "success") toast.success("Invite canceled.");
+												await update();
+											} finally {
+												cancellingInviteId = null;
+											}
 										};
 									}}
 								>

--- a/apps/web/src/routes/onboarding/team/+page.svelte
+++ b/apps/web/src/routes/onboarding/team/+page.svelte
@@ -9,6 +9,7 @@
 	import {
 		ArrowRight,
 		Check,
+		LoaderCircle,
 		MailCheck,
 		Plus,
 		Users,
@@ -33,20 +34,24 @@
 		e.preventDefault();
 		if (!teamName.trim() || busy) return;
 		creating = true;
-		const slug = `${teamName.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "")}-${Math.random().toString(36).slice(2, 8)}`;
+		const target = teamName.trim();
+		const slug = `${target.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "")}-${Math.random().toString(36).slice(2, 8)}`;
 		try {
-			const { error } = await authClient.organization.create({
-				name: teamName.trim(),
-				slug,
-			});
-			if (error) {
-				toast.error(error.message ?? "Couldn't create the team.");
-				return;
-			}
-			toast.success(`Welcome to ${teamName}.`);
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.organization.create({
+						name: target,
+						slug,
+					});
+					if (error) throw new Error(error.message ?? "Couldn't create the team.");
+				})(),
+				{
+					loading: `Creating ${target}…`,
+					success: `Welcome to ${target}.`,
+					error: (err) => (err as Error)?.message ?? "Couldn't create the team.",
+				},
+			);
 			await goto("/dashboard");
-		} catch (err) {
-			toast.error((err as Error)?.message ?? "Couldn't create the team.");
 		} finally {
 			// Always release — a thrown rejection (network drop, abort) must
 			// not leave the button permanently disabled.
@@ -57,19 +62,24 @@
 	async function acceptInvite(id: string) {
 		if (busy) return;
 		acceptingId = id;
+		const target = data.invites.find((i) => i.id === id);
+		const orgName = target?.orgName ?? "the team";
 		try {
-			const { error } = await authClient.organization.acceptInvitation({
-				invitationId: id,
-			});
-			if (error) {
-				toast.error(error.message ?? "Couldn't accept the invitation.");
-				return;
-			}
-			toast.success("Invitation accepted.");
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.organization.acceptInvitation({
+						invitationId: id,
+					});
+					if (error) throw new Error(error.message ?? "Couldn't accept the invitation.");
+				})(),
+				{
+					loading: `Joining ${orgName}…`,
+					success: `Welcome to ${orgName}.`,
+					error: (err) => (err as Error)?.message ?? "Couldn't accept the invitation.",
+				},
+			);
 			await invalidateAll();
 			await goto("/dashboard");
-		} catch (err) {
-			toast.error((err as Error)?.message ?? "Couldn't accept the invitation.");
 		} finally {
 			acceptingId = null;
 		}
@@ -148,7 +158,11 @@
 								class="gap-1.5"
 							>
 								{acceptingId === inv.id ? "Joining…" : "Accept"}
-								<Check class="size-3.5" />
+								{#if acceptingId === inv.id}
+									<LoaderCircle class="size-3.5 animate-spin" />
+								{:else}
+									<Check class="size-3.5" />
+								{/if}
 							</Button>
 						</li>
 					{/each}
@@ -187,7 +201,11 @@
 					class="group/cta w-full gap-2"
 				>
 					{creating ? "Creating…" : "Create team"}
-					<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+					{#if creating}
+						<LoaderCircle class="size-4 animate-spin" />
+					{:else}
+						<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+					{/if}
 				</Button>
 			</form>
 		</section>

--- a/apps/web/src/routes/onboarding/team/+page.svelte
+++ b/apps/web/src/routes/onboarding/team/+page.svelte
@@ -35,7 +35,9 @@
 		if (!teamName.trim() || busy) return;
 		creating = true;
 		const target = teamName.trim();
-		const slug = `${target.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "")}-${Math.random().toString(36).slice(2, 8)}`;
+		let base = target.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+		if (!base) base = "team";
+		const slug = `${base}-${Math.random().toString(36).slice(2, 8)}`;
 		try {
 			await toast.promise(
 				(async () => {

--- a/apps/web/src/routes/pricing/+page.svelte
+++ b/apps/web/src/routes/pricing/+page.svelte
@@ -14,6 +14,7 @@
 		Check,
 		Cloud,
 		Download,
+		LoaderCircle,
 		Minus,
 		Sparkles,
 	} from "lucide-svelte";
@@ -25,25 +26,29 @@
 	let loading = $state(false);
 	async function joinWaitlist(e: SubmitEvent) {
 		e.preventDefault();
-		if (!email.trim()) return;
+		if (!email.trim() || loading) return;
 		loading = true;
 		try {
-			const res = await fetch("/api/waitlist", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ email, source: "pricing" }),
-			});
-			const data = (await res.json().catch(() => ({}))) as {
-				ok?: boolean;
-				error?: string;
-			};
-			if (!data.ok) {
-				toast.error(data.error ?? "Couldn't join the waitlist.");
-				return;
-			}
+			await toast.promise(
+				(async () => {
+					const res = await fetch("/api/waitlist", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ email, source: "pricing" }),
+					});
+					const data = (await res.json().catch(() => ({}))) as {
+						ok?: boolean;
+						error?: string;
+					};
+					if (!data.ok) throw new Error(data.error ?? "Couldn't join the waitlist.");
+				})(),
+				{
+					loading: "Adding you to the waitlist…",
+					success: "You're on the list — we'll email when access opens.",
+					error: (err) => (err as Error)?.message ?? "Couldn't join the waitlist.",
+				},
+			);
 			joined = true;
-		} catch {
-			toast.error("Network error — try again.");
 		} finally {
 			loading = false;
 		}
@@ -179,7 +184,11 @@
 									/>
 									<Button type="submit" size="lg" disabled={loading} class="gap-2">
 										{loading ? "Joining…" : "Join waitlist"}
-										<ArrowRight class="size-4" />
+										{#if loading}
+											<LoaderCircle class="size-4 animate-spin" />
+										{:else}
+											<ArrowRight class="size-4" />
+										{/if}
 									</Button>
 								</form>
 							{/if}

--- a/apps/web/src/routes/verify-email/+page.server.ts
+++ b/apps/web/src/routes/verify-email/+page.server.ts
@@ -1,0 +1,24 @@
+import { redirect } from "@sveltejs/kit";
+import { getAuth } from "$lib/auth/server";
+import type { PageServerLoad } from "./$types";
+
+type SessionShape = {
+	user: { email: string; emailVerified?: boolean | null };
+};
+
+/**
+ * Holding page for users whose `emailVerified` is still false. Reached
+ * either by the dashboard layout gate or directly via the link in the
+ * verification email's "didn't get it?" path. Already-verified users
+ * skip past — no point keeping them on this screen.
+ */
+export const load: PageServerLoad = async ({ request }) => {
+	const session = (await getAuth()
+		.api.getSession({ headers: request.headers })
+		.catch(() => null)) as SessionShape | null;
+
+	if (!session) redirect(303, "/login?next=/verify-email");
+	if (session.user.emailVerified) redirect(303, "/dashboard");
+
+	return { email: session.user.email };
+};

--- a/apps/web/src/routes/verify-email/+page.svelte
+++ b/apps/web/src/routes/verify-email/+page.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+	import { goto, invalidateAll } from "$app/navigation";
+	import { authClient } from "$lib/auth/client";
+	import Logo from "$lib/logo.svelte";
+	import { Button } from "@recast/ui/button";
+	import { toast } from "@recast/ui/sonner";
+	import {
+		ArrowRight,
+		LoaderCircle,
+		LogOut,
+		MailCheck,
+		RefreshCw,
+	} from "@lucide/svelte";
+	import { cubicOut } from "svelte/easing";
+	import { fly } from "svelte/transition";
+
+	let { data } = $props();
+
+	let sending = $state(false);
+	let checking = $state(false);
+	let sentOnce = $state(false);
+
+	async function resend() {
+		if (sending) return;
+		sending = true;
+		try {
+			await toast.promise(
+				(async () => {
+					const { error } = await authClient.sendVerificationEmail({
+						email: data.email,
+						callbackURL: "/dashboard",
+					});
+					if (error) throw new Error(error.message ?? "Couldn't send the verification email.");
+				})(),
+				{
+					loading: "Sending verification email…",
+					success: "Sent — check your inbox.",
+					error: (err) => (err as Error)?.message ?? "Couldn't send the verification email.",
+				},
+			);
+			sentOnce = true;
+		} finally {
+			sending = false;
+		}
+	}
+
+	async function refresh() {
+		// User clicked the link in another tab → re-run loaders so the gate
+		// sees the new `emailVerified` and lets them through.
+		if (checking) return;
+		checking = true;
+		try {
+			await invalidateAll();
+		} finally {
+			checking = false;
+		}
+	}
+
+	async function signOut() {
+		await authClient.signOut();
+		await goto("/login");
+	}
+</script>
+
+<svelte:head>
+	<title>Verify your email — Recast</title>
+	<meta name="robots" content="noindex,nofollow" />
+</svelte:head>
+
+<div class="relative grid min-h-screen place-items-center px-6 py-16 text-foreground">
+	<div
+		aria-hidden="true"
+		class="pointer-events-none absolute inset-0 -z-10"
+		style="background: radial-gradient(ellipse 70% 50% at 50% 0%, color-mix(in srgb, var(--color-primary) 9%, transparent), transparent 72%);"
+	></div>
+	<div
+		aria-hidden="true"
+		class="bg-grid bg-grid-fade pointer-events-none absolute inset-0 -z-10 opacity-30"
+	></div>
+
+	<div class="w-full max-w-md" in:fly={{ y: 16, duration: 520, easing: cubicOut }}>
+		<div class="flex flex-col items-center text-center">
+			<a href="/" class="group/logo flex items-center gap-2.5" aria-label="Recast — home">
+				<span
+					class="grid size-9 place-items-center rounded-xl bg-foreground p-1 text-background shadow-craft-sm transition-transform group-hover/logo:rotate-[-4deg]"
+				>
+					<Logo size="22" color="transparent" fill="currentColor" />
+				</span>
+				<span class="text-lg font-semibold tracking-tight text-foreground">Recast</span>
+			</a>
+
+			<span class="glass-chip mt-7 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-primary">
+				<MailCheck class="size-3" />
+				One step left
+			</span>
+
+			<h1 class="text-balance mt-5 text-3xl font-semibold leading-tight tracking-tight text-foreground sm:text-4xl">
+				Verify your email
+			</h1>
+			<p class="text-pretty mt-3 max-w-sm text-sm leading-relaxed text-muted-foreground">
+				We sent a confirmation link to
+				<span class="font-mono font-medium text-foreground">{data.email}</span>.
+				Click it and you'll land back here — until then your dashboard stays
+				read-only.
+			</p>
+		</div>
+
+		<div class="glass-card mt-8 rounded-2xl p-6 shadow-craft-lg sm:p-7">
+			<div class="space-y-2.5">
+				<Button onclick={refresh} disabled={checking} class="group/cta w-full gap-2">
+					{#if checking}
+						<LoaderCircle class="size-4 animate-spin" />
+					{:else}
+						<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+					{/if}
+					{checking ? "Checking…" : "I clicked the link"}
+				</Button>
+				<Button
+					variant="outline"
+					onclick={resend}
+					disabled={sending}
+					class="w-full gap-2"
+				>
+					{#if sending}
+						<LoaderCircle class="size-4 animate-spin" />
+					{:else}
+						<RefreshCw class="size-4" />
+					{/if}
+					{sending ? "Sending…" : sentOnce ? "Send another link" : "Resend verification email"}
+				</Button>
+			</div>
+			<p class="mt-5 text-center text-[11px] text-muted-foreground">
+				Wrong email?
+				<button
+					type="button"
+					onclick={signOut}
+					class="inline-flex items-center gap-1 font-semibold text-foreground transition-colors hover:text-primary"
+				>
+					<LogOut class="size-3" />
+					Sign out
+				</button>
+			</p>
+		</div>
+	</div>
+</div>

--- a/apps/web/src/routes/verify-email/+page.svelte
+++ b/apps/web/src/routes/verify-email/+page.svelte
@@ -100,8 +100,8 @@
 			<p class="text-pretty mt-3 max-w-sm text-sm leading-relaxed text-muted-foreground">
 				We sent a confirmation link to
 				<span class="font-mono font-medium text-foreground">{data.email}</span>.
-				Click it and you'll land back here — until then your dashboard stays
-				read-only.
+				Click it and you'll be redirected to your dashboard — until then your
+				dashboard stays read-only.
 			</p>
 		</div>
 

--- a/apps/web/src/routes/waitlist/+page.svelte
+++ b/apps/web/src/routes/waitlist/+page.svelte
@@ -5,37 +5,46 @@
 	import { Input } from "@recast/ui/input";
 	import { Label } from "@recast/ui/label";
 	import { toast } from "@recast/ui/sonner";
-	import { ArrowLeft, ArrowRight, MailCheck, Sparkles } from "@lucide/svelte";
+	import { ArrowLeft, ArrowRight, LoaderCircle, MailCheck, Sparkles } from "@lucide/svelte";
+	import { untrack } from "svelte";
 	import { cubicOut } from "svelte/easing";
 	import { fly } from "svelte/transition";
 
 	const source = $derived(page.url.searchParams.get("source") ?? "waitlist");
 
-	let email = $state("");
+	// Prefill from `?email=` when the user lands here via the "Join waitlist"
+	// CTA on /login — saves them from retyping.
+	let email = $state(
+		untrack(() => page.url.searchParams.get("email")?.trim() ?? ""),
+	);
 	let loading = $state(false);
 	let joined = $state(false);
 
 	async function submit(e: SubmitEvent) {
 		e.preventDefault();
-		if (!email.trim()) return;
+		if (!email.trim() || loading) return;
 		loading = true;
 		try {
-			const res = await fetch("/api/waitlist", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ email, source }),
-			});
-			const data = (await res.json().catch(() => ({}))) as {
-				ok?: boolean;
-				error?: string;
-			};
-			if (!data.ok) {
-				toast.error(data.error ?? "Couldn't join the waitlist.");
-				return;
-			}
+			await toast.promise(
+				(async () => {
+					const res = await fetch("/api/waitlist", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ email, source }),
+					});
+					const data = (await res.json().catch(() => ({}))) as {
+						ok?: boolean;
+						error?: string;
+					};
+					if (!data.ok) throw new Error(data.error ?? "Couldn't join the waitlist.");
+				})(),
+				{
+					loading: "Adding you to the waitlist…",
+					success: "You're on the list — we'll email when access opens.",
+					error: (err) => (err as Error)?.message ?? "Couldn't join the waitlist.",
+				},
+			);
 			joined = true;
-		} catch {
-			toast.error("Network error — try again.");
 		} finally {
 			loading = false;
 		}
@@ -141,7 +150,11 @@
 						class="group/cta mt-1 w-full gap-2"
 					>
 						{loading ? "Joining…" : "Join the waitlist"}
-						<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+						{#if loading}
+							<LoaderCircle class="size-4 animate-spin" />
+						{:else}
+							<ArrowRight class="size-4 transition-transform group-hover/cta:translate-x-0.5" />
+						{/if}
 					</Button>
 				</form>
 			{/if}

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@recast/player",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "svelte": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./styles.css": "./src/styles.css"
+  },
+  "peerDependencies": {
+    "svelte": "^5.0.0"
+  },
+  "dependencies": {
+    "@lucide/svelte": "^0.577.0",
+    "@recast/ui": "workspace:*",
+    "hls-video-element": "^1.5.11",
+    "media-chrome": "^4.19.0"
+  },
+  "devDependencies": {
+    "svelte": "^5.0.0"
+  },
+  "scripts": {
+    "build": "exit 0",
+    "check": "exit 0"
+  }
+}

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @recast/player — media-chrome-backed video player for the Recast suite.
+ *
+ *   - HLS adaptive streaming via the companion `hls-video-element` (falls
+ *     back to native MP4 for non-`.m3u8` sources).
+ *   - Slot-based composition so editor surfaces (timestamped comments,
+ *     transcripts, AI cut markers) can wrap or extend the player without
+ *     fighting a pre-built layout.
+ *   - Framework-agnostic web components under the hood — same package
+ *     works in `apps/web` (SvelteKit) and `apps/desktop` (Tauri).
+ *
+ * Consumers MUST also import the stylesheet once at the app entry:
+ *   `import "@recast/player/styles.css";`
+ */
+
+export { default as RecastPlayer } from "./RecastPlayer.svelte";
+export type {
+	RecastPlayerProps,
+	RecastPlayerEngagement,
+	RecastPlayerApi,
+} from "./types";

--- a/packages/player/src/types.ts
+++ b/packages/player/src/types.ts
@@ -1,0 +1,49 @@
+/**
+ * Engagement events fired by RecastPlayer. `progress` is throttled to
+ * ~5% steps so a long video can't spam the parent with hundreds of calls.
+ */
+export type RecastPlayerEngagement =
+	| { type: "view-start"; percent: 0 }
+	| { type: "progress"; percent: number; currentTime: number }
+	| { type: "ended"; percent: 100; currentTime: number };
+
+/**
+ * Imperative handle the player exposes back to the parent. Mounted onto
+ * `bind:api` so editor surfaces can drive playback from any function —
+ * transcript-click → `seek(cue.startTime)`, AI cut marker → `pause()` etc.
+ *
+ * `videoEl` is the underlying `<video>` / `<hls-video>` element so callers
+ * can drop down to native APIs (frame-stepping with `requestVideoFrameCallback`,
+ * `captureStream()` for thumbnail generation, etc.) when needed.
+ */
+export type RecastPlayerApi = {
+	play: () => Promise<void>;
+	pause: () => void;
+	seek: (seconds: number) => void;
+	getCurrentTime: () => number;
+	getDuration: () => number;
+	getVideoElement: () => HTMLVideoElement | null;
+};
+
+export type RecastPlayerProps = {
+	/** Absolute video URL. `.m3u8` triggers HLS via hls-video-element. */
+	src: string;
+	/** Preview frame shown before play. */
+	poster?: string | null;
+	/** Sprite VTT for hover-scrub thumbnails (Cloudinary can generate). */
+	thumbnails?: string | null;
+	/** Display title surfaced to accessibility tooling. */
+	title?: string;
+	/** Autoplay when the player mounts (muted policy still applies). */
+	autoplay?: boolean;
+	/** Default volume 0–1. */
+	volume?: number;
+	/** Show the captions/settings menu. Defaults to true. */
+	showMenu?: boolean;
+	/** Optional aspect ratio class (e.g. "aspect-video"). */
+	className?: string;
+	/** Engagement reporter — fired from view-start → progress → ended. */
+	onengagement?: (event: RecastPlayerEngagement) => void;
+	/** Bindable imperative handle (Svelte 5 `$bindable`). */
+	api?: RecastPlayerApi | null;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       gsap:
         specifier: ^3.15.0
         version: 3.15.0
+      hls.js:
+        specifier: ^1.6.16
+        version: 1.6.16
       lucide-svelte:
         specifier: latest
         version: 1.0.1(svelte@5.55.3)
@@ -166,6 +169,9 @@ importers:
       tailwind-variants:
         specifier: ^3.2.2
         version: 3.2.2(tailwind-merge@3.5.0)(tailwindcss@4.2.2)
+      vidstack:
+        specifier: ^1.12.13
+        version: 1.12.13
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -2082,6 +2088,9 @@ packages:
   gsap@3.15.0:
     resolution: {integrity: sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==}
 
+  hls.js@1.6.16:
+    resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
+
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
@@ -2222,6 +2231,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lit-html@2.8.0:
+    resolution: {integrity: sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==}
+
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
@@ -2248,6 +2260,10 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  media-captions@1.0.4:
+    resolution: {integrity: sha512-cyDNmuZvvO4H27rcBq2Eudxo9IZRDCOX/I7VEyqbxsEiD2Ei7UYUhG/Sc5fvMZjmathgz3fEK7iAKqvpY+Ux1w==}
+    engines: {node: '>=16'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2643,11 +2659,19 @@ packages:
   unpic@4.2.2:
     resolution: {integrity: sha512-z6T2ScMgRV2y2H8MwwhY5xHZWXhUx/YxtOCGJwfURSl7ypVy4HpLIMWoIZKnnxQa/RKzM0kg8hUh0paIrpLfvw==}
 
+  unplugin@1.16.1:
+    resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
+    engines: {node: '>=14.0.0'}
+
   vaul-svelte@1.0.0-next.7:
     resolution: {integrity: sha512-7zN7Bi3dFQixvvbUJY9uGDe7Ws/dGZeBQR2pXdXmzQiakjrxBvWo0QrmsX3HK+VH+SZOltz378cmgmCS9f9rSg==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.0.0
+
+  vidstack@1.12.13:
+    resolution: {integrity: sha512-vuNeyRmWoH/7EoFVDYjp9nkgcqtCMmal518LDeb78dYKgWb+p6+vtY0AzDhrkBv5q1UiCn+xwmjMmwvSlPLuhQ==}
+    engines: {node: '>=18'}
 
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
@@ -2696,6 +2720,9 @@ packages:
     peerDependenciesMeta:
       vite:
         optional: true
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4106,6 +4133,8 @@ snapshots:
 
   gsap@3.15.0: {}
 
+  hls.js@1.6.16: {}
+
   human-id@4.1.3: {}
 
   iconv-lite@0.7.2:
@@ -4208,6 +4237,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lit-html@2.8.0:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
   locate-character@3.0.0: {}
 
   locate-path@5.0.0:
@@ -4229,6 +4262,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  media-captions@1.0.4: {}
 
   merge2@1.4.1: {}
 
@@ -4630,11 +4665,23 @@ snapshots:
 
   unpic@4.2.2: {}
 
+  unplugin@1.16.1:
+    dependencies:
+      acorn: 8.16.0
+      webpack-virtual-modules: 0.6.2
+
   vaul-svelte@1.0.0-next.7(svelte@5.55.3):
     dependencies:
       runed: 0.23.4(svelte@5.55.3)
       svelte: 5.55.3
       svelte-toolbelt: 0.7.1(svelte@5.55.3)
+
+  vidstack@1.12.13:
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      lit-html: 2.8.0
+      media-captions: 1.0.4
+      unplugin: 1.16.1
 
   vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3):
     dependencies:
@@ -4654,6 +4701,8 @@ snapshots:
   vitefu@1.1.3(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)):
     optionalDependencies:
       vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)
+
+  webpack-virtual-modules@0.6.2: {}
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
The `screencapturekit` crate transitively pulls `apple-metal`, whose
Swift bridge unconditionally references macOS 14.4 (`reactiveTextureUsage`)
and macOS 26 (`MTLSamplerReductionMode`) SDK symbols. Neither is on the
GH Actions `macos-latest` runner's Xcode, and pinning `apple-metal` to
any 0.6-0.8.x version doesn't help — the macOS 14.4 reference goes back
to 0.6.x. This is an upstream packaging bug: the Swift code uses
runtime `#available` checks where it needs compile-time `#if canImport`
gates.

Mitigation:
- Make `screencapturekit` an optional dep, hidden behind the new
  `sckit-loopback` Cargo feature (off by default).
- Split `macos_sckit.rs` into `enabled` / `disabled` modules; the
  default build re-exports the stub `ScKitLoopback` whose `try_start`
  returns Err and lets the existing BlackHole fallback chain take over.
- Builds that enable `--features sckit-loopback` against a Mac with
  the required SDK locally exercise the real SCKit path.

Net effect: CI stays green, BlackHole-on-macOS UX is unchanged, and
the SCKit work survives intact for when upstream fixes apple-metal
(or the runner SDK catches up).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Email verification: Users verify email addresses after signup. Verification emails are automatically sent with a 24-hour expiry window.
  * Login eligibility check: Pre-sign-in validation confirms email eligibility status.

* **Improvements**
  * Enhanced form feedback: Improved status messages and visual indicators across authentication flows and form submissions.
  * Streamlined team workflows: Better invitation handling and team management operations with improved feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kanakkholwal/recast/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->