### PR TITLE
feat: add API endpoints for managing tags and integrate with recasts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -82,6 +82,7 @@ windows = { version = "0.58.0", features = [
     "Win32_Media_Audio",
     "Win32_System_Com",
     "Win32_System_Com_StructuredStorage",
+    "Win32_UI_Shell",
     "Win32_UI_Shell_PropertiesSystem",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_WindowsAndMessaging",

--- a/apps/desktop/src-tauri/src/commands/auth.rs
+++ b/apps/desktop/src-tauri/src/commands/auth.rs
@@ -27,6 +27,7 @@
 //! Token storage uses `keyring` — DPAPI on Windows, Keychain on macOS,
 //! SecretService on Linux. Service name is the bundle identifier.
 
+use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
 use keyring::Entry;
@@ -34,20 +35,64 @@ use reqwest::header;
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
 
+use super::system::save_config;
 use super::types::AppState;
 
 const KEYRING_SERVICE: &str = "com.nexonauts.recast";
 const KEYRING_ENTRY: &str = "cloud-session-token";
 const CLIENT_ID: &str = "recast-desktop";
-const DEFAULT_CLOUD_API_URL: &str = "https://recast.nexonauts.com";
+const DEFAULT_CLOUD_API_URL: &str = "https://recast.li";
 
-/// Resolves the cloud API base URL. In debug builds the `CLOUD_API_URL`
-/// env var is honored so dev work can point at a local SvelteKit server
-/// without recompiling. Release builds ignore the env var deliberately:
-/// the desktop has no settings UI for this and we don't want a malicious
-/// or accidentally-injected env to silently redirect auth/sync traffic to
-/// an attacker-controlled host. Trailing slashes are stripped.
+/// Self-hosting override for the cloud API base URL, cached in-process so the
+/// no-arg `cloud_api_url()` resolver (called from many sites that don't carry
+/// `AppState`) can read it without threading state everywhere. Mirrors
+/// `AppConfig.cloud_api_url`: seeded from disk on startup via
+/// `init_cloud_api_override`, updated by the `set_cloud_api_url` command.
+static CLOUD_API_OVERRIDE: RwLock<Option<String>> = RwLock::new(None);
+
+/// Validate + normalize a user-supplied self-host URL. Accepts only an
+/// absolute `http`/`https` URL with a non-empty host; returns the
+/// trailing-slash-stripped form. `None` for anything malformed — the caller
+/// treats that as "no usable override" (setter rejects it; resolver ignores
+/// it and falls back to the default endpoint).
+pub(crate) fn normalize_api_url(raw: &str) -> Option<String> {
+    let trimmed = raw.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+    let parsed = reqwest::Url::parse(trimmed).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return None;
+    }
+    if parsed.host_str().map(str::is_empty).unwrap_or(true) {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+/// Seed the in-process override from persisted config at startup. Called once
+/// during app setup after the config is loaded.
+pub(crate) fn init_cloud_api_override(value: Option<String>) {
+    *CLOUD_API_OVERRIDE.write().unwrap() = value;
+}
+
+/// Resolves the cloud API base URL. Resolution order:
+///   1. The self-host override the user set in Settings → Cloud, if present
+///      and still valid. This is deliberate user action, so unlike an
+///      injected env var it's honored in release builds too — it's how
+///      self-hosters point the desktop at their own server.
+///   2. In debug builds only, the `CLOUD_API_URL` env var (dev convenience —
+///      lets `pnpm tauri dev` target a local SvelteKit server). Release
+///      builds skip this so a stray/injected env can't silently redirect
+///      auth traffic to an attacker host.
+///   3. The bundled default endpoint.
+/// Trailing slashes are stripped at every layer.
 pub(crate) fn cloud_api_url() -> String {
+    if let Some(raw) = CLOUD_API_OVERRIDE.read().unwrap().clone() {
+        if let Some(valid) = normalize_api_url(&raw) {
+            return valid;
+        }
+    }
     #[cfg(debug_assertions)]
     let raw = std::env::var("CLOUD_API_URL").unwrap_or_else(|_| DEFAULT_CLOUD_API_URL.to_string());
     #[cfg(not(debug_assertions))]
@@ -618,6 +663,86 @@ pub async fn auth_sign_out() -> Result<(), String> {
         }
     }
     delete_session_token()
+}
+
+/// Current cloud-endpoint configuration, surfaced to Settings → Cloud so a
+/// self-hoster can see what's in effect and what the built-in default is.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CloudApiConfig {
+    /// The base URL actually used for cloud requests right now.
+    effective: String,
+    /// The user's saved self-host override, or `None` when using the default.
+    override_url: Option<String>,
+    /// The bundled default endpoint — shown as the fallback / placeholder.
+    default_url: String,
+    /// Whether `effective` differs from the bundled default (i.e. a custom
+    /// self-host endpoint is in effect).
+    is_custom: bool,
+}
+
+/// Read the current cloud endpoint configuration for the Settings UI.
+#[tauri::command]
+pub fn get_cloud_api_config(state: State<'_, AppState>) -> CloudApiConfig {
+    let override_url = state.config.lock().cloud_api_url.clone();
+    let effective = cloud_api_url();
+    CloudApiConfig {
+        is_custom: effective != DEFAULT_CLOUD_API_URL,
+        effective,
+        override_url,
+        default_url: DEFAULT_CLOUD_API_URL.to_string(),
+    }
+}
+
+/// Set (or clear) the self-host cloud API override.
+///
+/// Passing an empty/whitespace string or `null` clears the override and
+/// reverts to the bundled default. A non-empty value must be a valid absolute
+/// http(s) URL — otherwise this returns an error and nothing is persisted (the
+/// "fall back to the default" behavior the resolver guarantees only kicks in
+/// for already-stored values; we reject bad input up front so the user gets a
+/// clear message instead of a silent revert).
+///
+/// Because a session token is only valid against the server that issued it,
+/// changing the effective endpoint clears the locally-stored token so the UI
+/// shows signed-out and the user re-authenticates against the new server
+/// rather than firing a stale token at it.
+#[tauri::command]
+pub fn set_cloud_api_url(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    url: Option<String>,
+) -> Result<CloudApiConfig, String> {
+    let normalized = match url {
+        Some(raw) if !raw.trim().is_empty() => Some(normalize_api_url(&raw).ok_or_else(|| {
+            "Enter a valid http(s) URL, e.g. https://recast.example.com".to_string()
+        })?),
+        _ => None,
+    };
+
+    let previous_effective = cloud_api_url();
+
+    {
+        let mut config = state.config.lock();
+        config.cloud_api_url = normalized.clone();
+        save_config(&app, &config);
+    }
+    init_cloud_api_override(normalized.clone());
+
+    // If the endpoint actually moved, drop the old server's token locally so
+    // we don't carry a now-invalid session across servers.
+    if cloud_api_url() != previous_effective {
+        let _ = delete_session_token();
+    }
+
+    let override_url = normalized;
+    let effective = cloud_api_url();
+    Ok(CloudApiConfig {
+        is_custom: effective != DEFAULT_CLOUD_API_URL,
+        effective,
+        override_url,
+        default_url: DEFAULT_CLOUD_API_URL.to_string(),
+    })
 }
 
 /// Returns the stored bearer token for downstream cloud-API calls (sync,

--- a/apps/desktop/src-tauri/src/commands/cloud.rs
+++ b/apps/desktop/src-tauri/src/commands/cloud.rs
@@ -199,6 +199,9 @@ struct UploadEnvelope {
 struct InitResp {
     recast_id: String,
     upload: UploadEnvelope,
+    /// Optional PUT envelope for a poster WebP. Absent if the server couldn't
+    /// sign one; the uploader then skips the poster.
+    poster_upload: Option<UploadEnvelope>,
 }
 
 #[derive(Deserialize)]
@@ -249,6 +252,16 @@ pub async fn recast_cloud_upload(
     let fps = (meta.fps.round() as i64).max(1) as u32;
     let duration_sec = meta.duration.round().max(0.0) as u64;
     let size_bytes = meta.size_bytes;
+
+    // Best-effort poster (a single WebP frame). Generated off the main thread;
+    // a failure here never blocks the upload — the recast just keeps no poster.
+    let poster_src = path.clone();
+    let poster_bytes = tauri::async_runtime::spawn_blocking(move || {
+        super::editor::poster_webp_for_export(&poster_src)
+    })
+    .await
+    .ok()
+    .flatten();
 
     let resolved_workspace = resolve_workspace_id(&client, &base, &token, workspace_id).await;
 
@@ -326,6 +339,31 @@ pub async fn recast_cloud_upload(
         return Err(fail(&app, &path, format!("Upload rejected ({status}).")));
     }
 
+    // ── PUT the poster (best-effort) ────────────────────────────────────
+    // Never fails the upload: if the WebP wasn't generated, the server didn't
+    // sign a poster URL, or the PUT errors, we just report `hasPoster: false`.
+    let mut has_poster = false;
+    if let (Some(poster), Some(penv)) = (poster_bytes.as_ref(), init.poster_upload.as_ref()) {
+        if penv.method.eq_ignore_ascii_case("PUT") {
+            let pheaders = penv.headers.clone().unwrap_or_default();
+            let pheader_has_ct = pheaders
+                .keys()
+                .any(|k| k.eq_ignore_ascii_case("content-type"));
+            let mut preq = client.put(&penv.url).body(poster.clone());
+            for (k, v) in &pheaders {
+                preq = preq.header(k.as_str(), v.as_str());
+            }
+            if !pheader_has_ct {
+                preq = preq.header(header::CONTENT_TYPE, "image/webp");
+            }
+            has_poster = preq
+                .send()
+                .await
+                .map(|r| r.status().is_success())
+                .unwrap_or(false);
+        }
+    }
+
     // ── complete ──────────────────────────────────────────────────────
     emit_progress(&app, &path, "finalizing");
     let complete_resp = client
@@ -337,6 +375,7 @@ pub async fn recast_cloud_upload(
             "height": height,
             "fps": fps,
             "durationSec": duration_sec,
+            "hasPoster": has_poster,
         }))
         .send()
         .await
@@ -585,6 +624,9 @@ fn humanize_init_error(status: u16, body: &str) -> String {
         Some("duration_over_cap") => {
             "This recording is longer than your plan allows for cloud sharing.".into()
         }
+        Some("resolution_over_cap") => {
+            "Your plan caps cloud sharing at 720p. Export at 720p, or upgrade for HD.".into()
+        }
         _ if status == 401 => "Your Recast Cloud session expired. Sign in again.".into(),
         _ if status == 403 => "You don't have access to that workspace.".into(),
         _ => format!("Upload init failed ({status})."),
@@ -596,6 +638,9 @@ fn humanize_complete_error(status: u16, body: &str) -> String {
         Some("upload_missing") => "The upload didn't arrive — please try again.".into(),
         Some("empty_upload") => "The uploaded file was empty — please try again.".into(),
         Some("storage_over_cap") => "You're out of cloud storage. Upgrade or free up space.".into(),
+        Some("resolution_over_cap") => {
+            "Your plan caps cloud sharing at 720p. Export at 720p, or upgrade for HD.".into()
+        }
         _ => format!("Finalize failed ({status})."),
     }
 }

--- a/apps/desktop/src-tauri/src/commands/editor.rs
+++ b/apps/desktop/src-tauri/src/commands/editor.rs
@@ -544,6 +544,64 @@ fn extract_single_thumbnail(
     result
 }
 
+/// Single-frame poster encoded as WebP — lighter than JPEG/PNG at equal
+/// visual quality. Best-effort: returns `None` if the seek fails or the
+/// bundled ffmpeg lacks libwebp. Used by the cloud uploader to give shared
+/// recasts a thumbnail.
+fn extract_poster_webp(media_path: &Path, timestamp: f64, scale_width: u32) -> Option<Vec<u8>> {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let temp_dir = std::env::temp_dir()
+        .join("recast-posters")
+        .join(format!("{}-{stamp}", std::process::id()));
+    let _ = fs::create_dir_all(&temp_dir);
+    let out_path = temp_dir.join("poster.webp");
+
+    let mut command = Command::new(crate::ffmpeg::ffmpeg_path());
+    command.args([
+        "-y",
+        "-ss",
+        &format!("{timestamp:.2}"),
+        "-i",
+        &media_path.to_string_lossy(),
+        "-frames:v",
+        "1",
+        "-vf",
+        &format!("scale={scale_width}:-1"),
+        "-c:v",
+        "libwebp",
+        "-quality",
+        "82",
+        "-compression_level",
+        "6",
+        out_path.to_string_lossy().as_ref(),
+    ]);
+    crate::ffmpeg::configure_silent_command(&mut command);
+
+    let result = command
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|_| fs::read(&out_path).ok());
+    let _ = fs::remove_file(&out_path);
+    let _ = fs::remove_dir(&temp_dir);
+    result
+}
+
+/// Poster WebP bytes for an exported MP4 (the cloud uploader's source file).
+/// Seeks to 25% — the same frame the editor's single-thumbnail path picks.
+/// Returns `None` on any failure; callers treat the poster as optional.
+pub(crate) fn poster_webp_for_export(path: &str) -> Option<Vec<u8>> {
+    let input = PathBuf::from(path);
+    let meta = probe_video_metadata(&input).ok()?;
+    if meta.duration <= 0.0 {
+        return None;
+    }
+    extract_poster_webp(&input, meta.duration * 0.25, 960)
+}
+
 /// Pass 1 of the 2-pass GIF export. Consumes the source at the GIF's target
 /// fps + scale and writes a single palette PNG. The main encode pass then
 /// reads that palette as an external input and runs paletteuse on every

--- a/apps/desktop/src-tauri/src/commands/system.rs
+++ b/apps/desktop/src-tauri/src/commands/system.rs
@@ -456,8 +456,14 @@ pub fn exclude_window_from_capture(app: AppHandle, label: String) -> Result<(), 
 /// the camera bubble cycling 1:1 → 16:9) — the constraint updates in place.
 ///
 /// No-op on other platforms; callers there keep the JS snap-to-aspect
-/// fallback. `min_width_px` is in physical pixels (the OS drag rect is too),
-/// so callers pass `logical * devicePixelRatio`.
+/// fallback. `min_width_px` and `chrome_px` are in physical pixels (the OS
+/// drag rect is too), so callers pass `logical * devicePixelRatio`.
+///
+/// `chrome_px` is fixed, non-scaling vertical space reserved at the bottom of
+/// the window for a control bar that sits *outside* the rounded video — the
+/// aspect ratio applies to `height - chrome_px`, so the visible bubble keeps
+/// its shape while the window is that much taller. Pass 0 for a video-only
+/// window.
 #[tauri::command]
 pub fn set_window_aspect_ratio(
     app: AppHandle,
@@ -466,6 +472,7 @@ pub fn set_window_aspect_ratio(
     aspect_height: f64,
     max_screen_fraction: f64,
     min_width_px: f64,
+    chrome_px: f64,
 ) -> Result<(), String> {
     let window = app
         .get_webview_window(&label)
@@ -486,12 +493,13 @@ pub fn set_window_aspect_ratio(
             ratio,
             max_screen_fraction,
             min_width_px.round() as i32,
+            chrome_px.round() as i32,
         );
         Ok(())
     }
     #[cfg(not(windows))]
     {
-        let _ = (window, ratio, max_screen_fraction, min_width_px);
+        let _ = (window, ratio, max_screen_fraction, min_width_px, chrome_px);
         Ok(())
     }
 }

--- a/apps/desktop/src-tauri/src/commands/system.rs
+++ b/apps/desktop/src-tauri/src/commands/system.rs
@@ -446,6 +446,56 @@ pub fn exclude_window_from_capture(app: AppHandle, label: String) -> Result<(), 
     }
 }
 
+/// Lock a window's resize to a fixed aspect ratio and cap its width at a
+/// fraction of its current monitor.
+///
+/// On Windows this installs a `WM_SIZING` subclass so the box stays
+/// proportional *while dragging* (you can't pull width or height
+/// independently) and never exceeds `max_screen_fraction` of the monitor's
+/// work-area width. Re-invoke with a new ratio when the aspect changes (e.g.
+/// the camera bubble cycling 1:1 → 16:9) — the constraint updates in place.
+///
+/// No-op on other platforms; callers there keep the JS snap-to-aspect
+/// fallback. `min_width_px` is in physical pixels (the OS drag rect is too),
+/// so callers pass `logical * devicePixelRatio`.
+#[tauri::command]
+pub fn set_window_aspect_ratio(
+    app: AppHandle,
+    label: String,
+    aspect_width: f64,
+    aspect_height: f64,
+    max_screen_fraction: f64,
+    min_width_px: f64,
+) -> Result<(), String> {
+    let window = app
+        .get_webview_window(&label)
+        .ok_or_else(|| format!("window '{label}' not found"))?;
+    let ratio = if aspect_height > 0.0 {
+        aspect_width / aspect_height
+    } else {
+        1.0
+    };
+    #[cfg(windows)]
+    {
+        let hwnd = window
+            .hwnd()
+            .map_err(|e| format!("hwnd lookup failed for '{label}': {e}"))?;
+        crate::window_aspect::apply(
+            &app,
+            hwnd.0 as isize,
+            ratio,
+            max_screen_fraction,
+            min_width_px.round() as i32,
+        );
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = (window, ratio, max_screen_fraction, min_width_px);
+        Ok(())
+    }
+}
+
 /// List available camera/video capture devices.
 #[tauri::command]
 pub async fn get_camera_devices() -> Result<Vec<CameraDeviceInfo>, String> {
@@ -993,7 +1043,7 @@ pub fn rename_file(path: String, new_name: String) -> Result<String, String> {
 /// thread on Linux (same rationale as `get_displays`).
 #[tauri::command]
 pub async fn probe_video_encoders() -> Result<Vec<crate::ffmpeg::EncoderAvailability>, String> {
-    tauri::async_runtime::spawn_blocking(crate::ffmpeg::probe_h264_encoders)
+    tauri::async_runtime::spawn_blocking(crate::ffmpeg::probe_recordable_encoders)
         .await
         .map_err(|e| format!("probe_video_encoders join error: {e}"))
 }

--- a/apps/desktop/src-tauri/src/commands/system.rs
+++ b/apps/desktop/src-tauri/src/commands/system.rs
@@ -983,6 +983,21 @@ pub fn rename_file(path: String, new_name: String) -> Result<String, String> {
     Ok(dest.to_string_lossy().to_string())
 }
 
+/// Probe which video encoders actually initialize on this device (a real
+/// 1-frame encode per candidate, not just "compiled in"). Drives the
+/// Settings → About "Hardware acceleration" matrix so users can see which
+/// GPU encoder their machine supports and which one the recorder picks.
+///
+/// async + spawn_blocking because each hardware probe spawns FFmpeg and can
+/// take a few hundred ms cold — running it inline would freeze the GTK main
+/// thread on Linux (same rationale as `get_displays`).
+#[tauri::command]
+pub async fn probe_video_encoders() -> Result<Vec<crate::ffmpeg::EncoderAvailability>, String> {
+    tauri::async_runtime::spawn_blocking(crate::ffmpeg::probe_h264_encoders)
+        .await
+        .map_err(|e| format!("probe_video_encoders join error: {e}"))
+}
+
 #[derive(Debug, Serialize)]
 pub struct FfmpegDiagnostics {
     pub ffmpeg_path: String,

--- a/apps/desktop/src-tauri/src/commands/types.rs
+++ b/apps/desktop/src-tauri/src/commands/types.rs
@@ -135,6 +135,13 @@ pub struct AppConfig {
     pub telemetry_errors: bool,
     #[serde(default)]
     pub install_id: Option<String>,
+    /// Self-hosting override for the Recast Cloud API base URL. `None` (the
+    /// default) means "use the bundled default endpoint". Set by self-hosters
+    /// in Settings → Cloud; validated to an absolute http(s) URL before it's
+    /// stored, and the resolver (`auth::cloud_api_url`) falls back to the
+    /// default if it's ever absent or malformed.
+    #[serde(default)]
+    pub cloud_api_url: Option<String>,
 }
 
 fn default_close_to_tray() -> bool {
@@ -154,6 +161,7 @@ impl Default for AppConfig {
             telemetry_product: false,
             telemetry_errors: true,
             install_id: None,
+            cloud_api_url: None,
         }
     }
 }

--- a/apps/desktop/src-tauri/src/ffmpeg.rs
+++ b/apps/desktop/src-tauri/src/ffmpeg.rs
@@ -275,6 +275,87 @@ pub fn preferred_h264_encoder() -> &'static str {
     })
 }
 
+/// Real availability of one H.264 encoder on THIS machine. Unlike
+/// `ffmpeg -encoders` (which only reports what was *compiled in* — the
+/// bundled binaries always ship NVENC/AMF/QSV), `available` reflects an
+/// actual 1-frame init probe, so it's true only when the GPU + driver
+/// combination can really encode. Surfaced to Settings → About so users
+/// can see exactly which hardware acceleration their device supports.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EncoderAvailability {
+    /// FFmpeg codec name, e.g. `h264_nvenc`.
+    pub name: String,
+    /// Human-readable label, e.g. `NVIDIA NVENC`.
+    pub label: String,
+    /// Vendor family, e.g. `NVIDIA` / `AMD` / `Intel` / `Software`.
+    pub vendor: String,
+    /// Hardware-accelerated (GPU) vs software (CPU) path.
+    pub hardware: bool,
+    /// Whether a 1-frame encode actually succeeded on this machine.
+    pub available: bool,
+    /// The encoder the recorder/export will pick — the highest-priority
+    /// available one (mirrors `preferred_h264_encoder`).
+    pub active: bool,
+}
+
+/// Probe every H.264 encoder candidate for real init success on this
+/// device, in the same NVIDIA → AMD → Intel → CPU priority order the
+/// recorder selects from. The first one that initializes is flagged
+/// `active` (libx264 is the always-present software fallback, so there's
+/// always exactly one active entry). Each hardware probe spawns FFmpeg
+/// (~300–500 ms cold); callers should run this off the UI thread.
+pub fn probe_h264_encoders() -> Vec<EncoderAvailability> {
+    let candidates: [(&str, &str, &str, bool, &[&str]); 4] = [
+        (
+            "h264_nvenc",
+            "NVIDIA NVENC",
+            "NVIDIA",
+            true,
+            &["-preset", "p1"],
+        ),
+        ("h264_amf", "AMD AMF", "AMD", true, &["-quality", "speed"]),
+        (
+            "h264_qsv",
+            "Intel Quick Sync",
+            "Intel",
+            true,
+            &["-preset", "veryfast"],
+        ),
+        ("libx264", "x264 (CPU)", "Software", false, &[]),
+    ];
+
+    let mut list: Vec<EncoderAvailability> = candidates
+        .into_iter()
+        .map(|(name, label, vendor, hardware, extra)| {
+            // libx264 ships in every bundled build and always initializes —
+            // skip the spawn for the software path.
+            let available = if hardware {
+                probe_encoder(name, extra)
+            } else {
+                true
+            };
+            EncoderAvailability {
+                name: name.to_string(),
+                label: label.to_string(),
+                vendor: vendor.to_string(),
+                hardware,
+                available,
+                active: false,
+            }
+        })
+        .collect();
+
+    // First available candidate (priority order preserved above) is what the
+    // recorder picks — identical logic to `preferred_h264_encoder`, computed
+    // here from the probe results so we don't double-probe the whole chain.
+    if let Some(idx) = list.iter().position(|e| e.available) {
+        list[idx].active = true;
+    }
+
+    list
+}
+
 fn probe_encoder(name: &str, extra_args: &[&str]) -> bool {
     let mut command = Command::new(ffmpeg_path());
     command.args([

--- a/apps/desktop/src-tauri/src/ffmpeg.rs
+++ b/apps/desktop/src-tauri/src/ffmpeg.rs
@@ -318,13 +318,55 @@ pub fn probe_recordable_encoders() -> Vec<EncoderAvailability> {
     // (name, label, vendor, family, hardware, extra_args). H.264 first so
     // the `active` lookup below lands on the codec the recorder uses.
     let candidates: [(&str, &str, &str, &str, bool, &[&str]); 8] = [
-        ("h264_nvenc", "NVIDIA NVENC", "NVIDIA", "H.264", true, &["-preset", "p1"]),
-        ("h264_amf", "AMD AMF", "AMD", "H.264", true, &["-quality", "speed"]),
-        ("h264_qsv", "Intel Quick Sync", "Intel", "H.264", true, &["-preset", "veryfast"]),
+        (
+            "h264_nvenc",
+            "NVIDIA NVENC",
+            "NVIDIA",
+            "H.264",
+            true,
+            &["-preset", "p1"],
+        ),
+        (
+            "h264_amf",
+            "AMD AMF",
+            "AMD",
+            "H.264",
+            true,
+            &["-quality", "speed"],
+        ),
+        (
+            "h264_qsv",
+            "Intel Quick Sync",
+            "Intel",
+            "H.264",
+            true,
+            &["-preset", "veryfast"],
+        ),
         ("libx264", "x264 (CPU)", "Software", "H.264", false, &[]),
-        ("hevc_nvenc", "NVIDIA NVENC", "NVIDIA", "HEVC", true, &["-preset", "p1"]),
-        ("hevc_amf", "AMD AMF", "AMD", "HEVC", true, &["-quality", "speed"]),
-        ("hevc_qsv", "Intel Quick Sync", "Intel", "HEVC", true, &["-preset", "veryfast"]),
+        (
+            "hevc_nvenc",
+            "NVIDIA NVENC",
+            "NVIDIA",
+            "HEVC",
+            true,
+            &["-preset", "p1"],
+        ),
+        (
+            "hevc_amf",
+            "AMD AMF",
+            "AMD",
+            "HEVC",
+            true,
+            &["-quality", "speed"],
+        ),
+        (
+            "hevc_qsv",
+            "Intel Quick Sync",
+            "Intel",
+            "HEVC",
+            true,
+            &["-preset", "veryfast"],
+        ),
         ("libx265", "x265 (CPU)", "Software", "HEVC", false, &[]),
     ];
 
@@ -371,8 +413,15 @@ fn probe_encoder(name: &str, extra_args: &[&str]) -> bool {
         "error",
         "-f",
         "lavfi",
+        // 320x240, NOT a tiny 64x64. NVENC enforces a minimum frame size
+        // (H.264 ~145x49, HEVC larger) and rejects anything smaller with
+        // "Frame Dimension less than the minimum supported value" — which
+        // made this probe report every NVENC-capable GPU as unavailable and
+        // silently dropped the recorder to CPU x264 on machines that have a
+        // working NVIDIA encoder. 320x240 clears every hardware encoder's
+        // minimum while staying cheap to init.
         "-i",
-        "nullsrc=s=64x64:d=0.04",
+        "nullsrc=s=320x240:d=0.04",
         "-c:v",
         name,
     ]);

--- a/apps/desktop/src-tauri/src/ffmpeg.rs
+++ b/apps/desktop/src-tauri/src/ffmpeg.rs
@@ -290,55 +290,60 @@ pub struct EncoderAvailability {
     pub label: String,
     /// Vendor family, e.g. `NVIDIA` / `AMD` / `Intel` / `Software`.
     pub vendor: String,
+    /// Codec family the row belongs to — `H.264` or `HEVC`. Lets the
+    /// diagnostics UI group the matrix into sections.
+    pub family: String,
     /// Hardware-accelerated (GPU) vs software (CPU) path.
     pub hardware: bool,
     /// Whether a 1-frame encode actually succeeded on this machine.
     pub available: bool,
     /// The encoder the recorder/export will pick — the highest-priority
-    /// available one (mirrors `preferred_h264_encoder`).
+    /// available one (mirrors `preferred_h264_encoder`). Only ever set on
+    /// an H.264 row, since the recording pipeline is H.264-only today; the
+    /// HEVC rows are informational (which HEVC encoders this GPU exposes).
     pub active: bool,
 }
 
-/// Probe every H.264 encoder candidate for real init success on this
-/// device, in the same NVIDIA → AMD → Intel → CPU priority order the
-/// recorder selects from. The first one that initializes is flagged
-/// `active` (libx264 is the always-present software fallback, so there's
-/// always exactly one active entry). Each hardware probe spawns FFmpeg
-/// (~300–500 ms cold); callers should run this off the UI thread.
-pub fn probe_h264_encoders() -> Vec<EncoderAvailability> {
-    let candidates: [(&str, &str, &str, bool, &[&str]); 4] = [
-        (
-            "h264_nvenc",
-            "NVIDIA NVENC",
-            "NVIDIA",
-            true,
-            &["-preset", "p1"],
-        ),
-        ("h264_amf", "AMD AMF", "AMD", true, &["-quality", "speed"]),
-        (
-            "h264_qsv",
-            "Intel Quick Sync",
-            "Intel",
-            true,
-            &["-preset", "veryfast"],
-        ),
-        ("libx264", "x264 (CPU)", "Software", false, &[]),
+/// Probe every recordable encoder candidate for real init success on this
+/// device. The H.264 family is listed in the same NVIDIA → AMD → Intel →
+/// CPU priority order the recorder selects from, followed by the HEVC
+/// family in the same order. The first *available H.264* candidate is
+/// flagged `active` — that's what the recorder/export actually picks
+/// (libx264 is the always-present software fallback, so there's always
+/// exactly one active entry, and it's always H.264 since the pipeline is
+/// H.264-only today). HEVC rows are informational. Each hardware probe
+/// spawns FFmpeg (~300–500 ms cold); callers should run this off the UI
+/// thread.
+pub fn probe_recordable_encoders() -> Vec<EncoderAvailability> {
+    // (name, label, vendor, family, hardware, extra_args). H.264 first so
+    // the `active` lookup below lands on the codec the recorder uses.
+    let candidates: [(&str, &str, &str, &str, bool, &[&str]); 8] = [
+        ("h264_nvenc", "NVIDIA NVENC", "NVIDIA", "H.264", true, &["-preset", "p1"]),
+        ("h264_amf", "AMD AMF", "AMD", "H.264", true, &["-quality", "speed"]),
+        ("h264_qsv", "Intel Quick Sync", "Intel", "H.264", true, &["-preset", "veryfast"]),
+        ("libx264", "x264 (CPU)", "Software", "H.264", false, &[]),
+        ("hevc_nvenc", "NVIDIA NVENC", "NVIDIA", "HEVC", true, &["-preset", "p1"]),
+        ("hevc_amf", "AMD AMF", "AMD", "HEVC", true, &["-quality", "speed"]),
+        ("hevc_qsv", "Intel Quick Sync", "Intel", "HEVC", true, &["-preset", "veryfast"]),
+        ("libx265", "x265 (CPU)", "Software", "HEVC", false, &[]),
     ];
 
     let mut list: Vec<EncoderAvailability> = candidates
         .into_iter()
-        .map(|(name, label, vendor, hardware, extra)| {
+        .map(|(name, label, vendor, family, hardware, extra)| {
             // libx264 ships in every bundled build and always initializes —
-            // skip the spawn for the software path.
-            let available = if hardware {
-                probe_encoder(name, extra)
-            } else {
+            // skip the spawn for it. Everything else (hardware paths and
+            // libx265, which isn't guaranteed compiled in) gets a real probe.
+            let available = if name == "libx264" {
                 true
+            } else {
+                probe_encoder(name, extra)
             };
             EncoderAvailability {
                 name: name.to_string(),
                 label: label.to_string(),
                 vendor: vendor.to_string(),
+                family: family.to_string(),
                 hardware,
                 available,
                 active: false,
@@ -346,9 +351,11 @@ pub fn probe_h264_encoders() -> Vec<EncoderAvailability> {
         })
         .collect();
 
-    // First available candidate (priority order preserved above) is what the
-    // recorder picks — identical logic to `preferred_h264_encoder`, computed
-    // here from the probe results so we don't double-probe the whole chain.
+    // First available candidate (H.264 priority order preserved above) is
+    // what the recorder picks — identical logic to `preferred_h264_encoder`,
+    // computed here from the probe results so we don't double-probe the
+    // chain. libx264 is always available, so this always resolves to an
+    // H.264 row before reaching the HEVC section.
     if let Some(idx) = list.iter().position(|e| e.available) {
         list[idx].active = true;
     }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod render;
 mod silence;
 mod telemetry;
 mod tray;
+mod window_aspect;
 
 use commands::system::load_config;
 use commands::types::AppState;
@@ -242,6 +243,7 @@ pub fn run() {
             commands::validate_camera_source,
             commands::update_camera_preview_state,
             commands::exclude_window_from_capture,
+            commands::set_window_aspect_ratio,
             commands::autosave_project,
             commands::save_project_edits,
             commands::clear_autosave,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -253,6 +253,7 @@ pub fn run() {
             commands::get_cached_asset_path,
             commands::hydrate_cached_assets,
             commands::diagnose_ffmpeg,
+            commands::probe_video_encoders,
             commands::auth_start,
             commands::auth_status,
             commands::auth_sign_out,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -124,6 +124,11 @@ pub fn run() {
             let handle = app.handle();
             let config = load_config(handle);
 
+            // Seed the self-host cloud-endpoint override from persisted config
+            // so the no-arg `cloud_api_url()` resolver reflects the user's
+            // saved choice from the very first auth/sync request onward.
+            commands::auth::init_cloud_api_override(config.cloud_api_url.clone());
+
             // Cold-start file-association path: stash any `.recast` arg the
             // OS handed us so the main window can drain it on mount via
             // `take_pending_open_file`. None for a normal launch.
@@ -260,6 +265,8 @@ pub fn run() {
             commands::auth_status,
             commands::auth_sign_out,
             commands::auth_cancel,
+            commands::get_cloud_api_config,
+            commands::set_cloud_api_url,
             commands::get_close_to_tray,
             commands::set_close_to_tray,
             commands::set_telemetry_consent,

--- a/apps/desktop/src-tauri/src/window_aspect.rs
+++ b/apps/desktop/src-tauri/src/window_aspect.rs
@@ -36,12 +36,19 @@ mod imp {
 
     #[derive(Clone, Copy)]
     struct Constraint {
-        /// width / height.
+        /// Aspect ratio of the *video* region (width / height) — not the whole
+        /// window, which also carries `chrome` rows of controls below it.
         ratio: f64,
         /// Max width as a fraction of the window's monitor work-area width.
         max_fraction: f64,
         /// Minimum width in physical pixels.
         min_w: i32,
+        /// Fixed, non-scaling vertical extent (physical px) reserved at the
+        /// bottom of the window for the control bar that lives *outside* the
+        /// rounded video so it never gets clipped. `ratio` applies to
+        /// `height - chrome`, so the visible bubble keeps its aspect while the
+        /// window is `chrome` px taller. 0 == video fills the window.
+        chrome: i32,
     }
 
     /// HWND pointer value → its live aspect constraint. The subclass proc runs
@@ -56,14 +63,26 @@ mod imp {
     /// `WM_SIZING` subclass is installed. Updating an existing window's ratio
     /// (e.g. the user cycling 1:1 → 16:9) just rewrites the registry entry —
     /// the already-installed subclass picks it up on the next drag.
-    pub fn apply(app: &AppHandle, hwnd_raw: isize, ratio: f64, max_fraction: f64, min_w: i32) {
+    pub fn apply(
+        app: &AppHandle,
+        hwnd_raw: isize,
+        ratio: f64,
+        max_fraction: f64,
+        min_w: i32,
+        chrome: i32,
+    ) {
         if !(ratio.is_finite() && ratio > 0.0) {
             return;
         }
         let constraint = Constraint {
             ratio,
-            max_fraction: if max_fraction > 0.0 { max_fraction } else { 0.25 },
+            max_fraction: if max_fraction > 0.0 {
+                max_fraction
+            } else {
+                0.25
+            },
             min_w: min_w.max(1),
+            chrome: chrome.max(0),
         };
 
         let first = {
@@ -107,18 +126,22 @@ mod imp {
         let cur_w = (rect.right - rect.left).max(1);
         let cur_h = (rect.bottom - rect.top).max(1);
 
+        // The control strip is fixed height; only the video region scales with
+        // the ratio, so strip it off before the aspect math and add it back to
+        // the final window height.
+        let chrome = c.chrome.max(0);
         let max_w = max_w.max(c.min_w);
-        let max_h = ((max_w as f64) / c.ratio).round() as i32;
-        let min_h = ((c.min_w as f64) / c.ratio).round() as i32;
+        let max_vid_h = ((max_w as f64) / c.ratio).round() as i32;
+        let min_vid_h = (((c.min_w as f64) / c.ratio).round() as i32).max(1);
 
         // Vertical-only edges (top/bottom) are height-led; everything else
         // (left/right + all four corners) is width-led.
         let (new_w, new_h) = if edge == WMSZ_TOP || edge == WMSZ_BOTTOM {
-            let h = cur_h.clamp(min_h.max(1), max_h.max(1));
-            ((h as f64 * c.ratio).round() as i32, h)
+            let vid_h = (cur_h - chrome).clamp(min_vid_h, max_vid_h.max(min_vid_h));
+            ((vid_h as f64 * c.ratio).round() as i32, vid_h + chrome)
         } else {
             let w = cur_w.clamp(c.min_w, max_w);
-            (w, ((w as f64) / c.ratio).round() as i32)
+            (w, (((w as f64) / c.ratio).round() as i32) + chrome)
         };
 
         // Anchor the edge opposite the one under the cursor.
@@ -176,5 +199,12 @@ pub use imp::apply;
 /// No-op on platforms without a native aspect lock — the JS snap-to-aspect
 /// fallback handles resizing there.
 #[cfg(not(windows))]
-pub fn apply(_app: &tauri::AppHandle, _hwnd_raw: isize, _ratio: f64, _max_fraction: f64, _min_w: i32) {
+pub fn apply(
+    _app: &tauri::AppHandle,
+    _hwnd_raw: isize,
+    _ratio: f64,
+    _max_fraction: f64,
+    _min_w: i32,
+    _chrome: i32,
+) {
 }

--- a/apps/desktop/src-tauri/src/window_aspect.rs
+++ b/apps/desktop/src-tauri/src/window_aspect.rs
@@ -1,0 +1,180 @@
+//! Aspect-ratio-locked window resizing.
+//!
+//! Tao (Tauri's windowing layer) only exposes min/max size constraints — it
+//! has no aspect-ratio lock. The JS side can *snap back* to an aspect after a
+//! resize finishes (`onResized` → `setSize`), but that reads as a janky
+//! rubber-band: the OS lets you drag width and height independently, then the
+//! box jumps once you release. To make the camera-preview bubble resize
+//! *proportionally while you drag* — and to cap its width at a fraction of the
+//! monitor — we intercept `WM_SIZING` natively on Windows and rewrite the drag
+//! rectangle in real time.
+//!
+//! Non-Windows builds get a no-op `apply` so callers don't need their own
+//! `cfg`; the JS snap-to-aspect fallback keeps those platforms usable until a
+//! native equivalent (macOS: `NSWindow.aspectRatio`) lands.
+
+#[cfg(windows)]
+mod imp {
+    use std::collections::HashMap;
+    use std::ffi::c_void;
+    use std::sync::{Mutex, OnceLock};
+
+    use tauri::AppHandle;
+    use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, RECT, WPARAM};
+    use windows::Win32::Graphics::Gdi::{
+        GetMonitorInfoW, MonitorFromWindow, MONITORINFO, MONITOR_DEFAULTTONEAREST,
+    };
+    use windows::Win32::UI::Shell::{DefSubclassProc, RemoveWindowSubclass, SetWindowSubclass};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        WMSZ_BOTTOM, WMSZ_BOTTOMLEFT, WMSZ_LEFT, WMSZ_TOP, WMSZ_TOPLEFT, WMSZ_TOPRIGHT,
+        WM_NCDESTROY, WM_SIZING,
+    };
+
+    /// Arbitrary, app-unique subclass id (only needs to be stable within the
+    /// process so `Set`/`RemoveWindowSubclass` agree).
+    const SUBCLASS_ID: usize = 0x5245_4341; // "RECA"
+
+    #[derive(Clone, Copy)]
+    struct Constraint {
+        /// width / height.
+        ratio: f64,
+        /// Max width as a fraction of the window's monitor work-area width.
+        max_fraction: f64,
+        /// Minimum width in physical pixels.
+        min_w: i32,
+    }
+
+    /// HWND pointer value → its live aspect constraint. The subclass proc runs
+    /// on the UI thread and reads this; the command writes it from whichever
+    /// thread Tauri dispatched on, so it's behind a mutex.
+    fn registry() -> &'static Mutex<HashMap<isize, Constraint>> {
+        static REG: OnceLock<Mutex<HashMap<isize, Constraint>>> = OnceLock::new();
+        REG.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    /// Register (or update) the aspect constraint for a window and ensure the
+    /// `WM_SIZING` subclass is installed. Updating an existing window's ratio
+    /// (e.g. the user cycling 1:1 → 16:9) just rewrites the registry entry —
+    /// the already-installed subclass picks it up on the next drag.
+    pub fn apply(app: &AppHandle, hwnd_raw: isize, ratio: f64, max_fraction: f64, min_w: i32) {
+        if !(ratio.is_finite() && ratio > 0.0) {
+            return;
+        }
+        let constraint = Constraint {
+            ratio,
+            max_fraction: if max_fraction > 0.0 { max_fraction } else { 0.25 },
+            min_w: min_w.max(1),
+        };
+
+        let first = {
+            let mut reg = registry().lock().unwrap();
+            let first = !reg.contains_key(&hwnd_raw);
+            reg.insert(hwnd_raw, constraint);
+            first
+        };
+
+        // SetWindowSubclass must run on the window's owning (UI) thread —
+        // cross-thread proc-chain edits are rejected by the OS. Only install
+        // once; subsequent ratio changes flow through the registry above.
+        if first {
+            let _ = app.run_on_main_thread(move || unsafe {
+                let hwnd = HWND(hwnd_raw as *mut c_void);
+                let _ = SetWindowSubclass(hwnd, Some(subclass_proc), SUBCLASS_ID, 0);
+            });
+        }
+    }
+
+    /// Width of the work area (excludes the taskbar — matches JS
+    /// `screen.availWidth`) of the monitor the window currently sits on.
+    unsafe fn monitor_work_width(hwnd: HWND) -> i32 {
+        let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+        let mut info = MONITORINFO {
+            cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+            ..Default::default()
+        };
+        if GetMonitorInfoW(monitor, &mut info).as_bool() {
+            (info.rcWork.right - info.rcWork.left).max(1)
+        } else {
+            1920
+        }
+    }
+
+    /// Rewrite the proposed drag rectangle so it keeps `ratio` and stays within
+    /// [min_w, max_w]. The edge being dragged decides which dimension leads and
+    /// which corner stays anchored, so the side under the cursor tracks the
+    /// pointer while the opposite side holds still.
+    fn constrain_rect(rect: &mut RECT, edge: u32, c: Constraint, max_w: i32) {
+        let cur_w = (rect.right - rect.left).max(1);
+        let cur_h = (rect.bottom - rect.top).max(1);
+
+        let max_w = max_w.max(c.min_w);
+        let max_h = ((max_w as f64) / c.ratio).round() as i32;
+        let min_h = ((c.min_w as f64) / c.ratio).round() as i32;
+
+        // Vertical-only edges (top/bottom) are height-led; everything else
+        // (left/right + all four corners) is width-led.
+        let (new_w, new_h) = if edge == WMSZ_TOP || edge == WMSZ_BOTTOM {
+            let h = cur_h.clamp(min_h.max(1), max_h.max(1));
+            ((h as f64 * c.ratio).round() as i32, h)
+        } else {
+            let w = cur_w.clamp(c.min_w, max_w);
+            (w, ((w as f64) / c.ratio).round() as i32)
+        };
+
+        // Anchor the edge opposite the one under the cursor.
+        if edge == WMSZ_LEFT || edge == WMSZ_TOPLEFT || edge == WMSZ_BOTTOMLEFT {
+            rect.left = rect.right - new_w;
+        } else {
+            rect.right = rect.left + new_w;
+        }
+        if edge == WMSZ_TOP || edge == WMSZ_TOPLEFT || edge == WMSZ_TOPRIGHT {
+            rect.top = rect.bottom - new_h;
+        } else {
+            rect.bottom = rect.top + new_h;
+        }
+    }
+
+    unsafe extern "system" fn subclass_proc(
+        hwnd: HWND,
+        msg: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+        _id: usize,
+        _ref: usize,
+    ) -> LRESULT {
+        match msg {
+            WM_SIZING => {
+                let key = hwnd.0 as isize;
+                let constraint = registry().lock().unwrap().get(&key).copied();
+                if let Some(c) = constraint {
+                    // lParam is an LPRECT the OS uses as the new window bounds.
+                    // We edit it in place, then still chain to tao's proc so its
+                    // internal size bookkeeping stays in sync — we already keep
+                    // the rect inside tao's min/max, so it won't fight us.
+                    let rect = &mut *(lparam.0 as *mut RECT);
+                    let max_w = ((monitor_work_width(hwnd) as f64) * c.max_fraction).round() as i32;
+                    constrain_rect(rect, wparam.0 as u32, c, max_w);
+                }
+                DefSubclassProc(hwnd, msg, wparam, lparam)
+            }
+            WM_NCDESTROY => {
+                // Drop our entry and detach the subclass before the window
+                // goes away (documented best practice — the chain is otherwise
+                // freed for us, but this keeps the registry from leaking).
+                registry().lock().unwrap().remove(&(hwnd.0 as isize));
+                let _ = RemoveWindowSubclass(hwnd, Some(subclass_proc), SUBCLASS_ID);
+                DefSubclassProc(hwnd, msg, wparam, lparam)
+            }
+            _ => DefSubclassProc(hwnd, msg, wparam, lparam),
+        }
+    }
+}
+
+#[cfg(windows)]
+pub use imp::apply;
+
+/// No-op on platforms without a native aspect lock — the JS snap-to-aspect
+/// fallback handles resizing there.
+#[cfg(not(windows))]
+pub fn apply(_app: &tauri::AppHandle, _hwnd_raw: isize, _ratio: f64, _max_fraction: f64, _min_w: i32) {
+}

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,8 @@
         "maximizable": true,
         "decorations": false,
         "transparent": false,
-        "center": true
+        "center": true,
+        "shadow": false
       }
     ],
     "security": {

--- a/apps/desktop/src/components/editor/SilenceReviewPopover.svelte
+++ b/apps/desktop/src/components/editor/SilenceReviewPopover.svelte
@@ -19,6 +19,7 @@
   import { Button } from "@recast/ui/button";
   import * as Tooltip from "@recast/ui/tooltip";
   import { cn } from "@recast/ui/utils";
+  import { safeStorage } from "@recast/ui/persisted-state";
 
   interface Props {
     store: EditorStore;
@@ -58,10 +59,7 @@
   ];
 
   function loadSensitivity(): Sensitivity {
-    const v =
-      typeof localStorage !== "undefined"
-        ? localStorage.getItem(SENSITIVITY_KEY)
-        : null;
+    const v = safeStorage.get<string>(SENSITIVITY_KEY, "");
     return v === "relaxed" || v === "aggressive" ? v : "balanced";
   }
 
@@ -70,11 +68,7 @@
   function setSensitivity(next: Sensitivity) {
     if (next === sensitivity) return;
     sensitivity = next;
-    try {
-      localStorage.setItem(SENSITIVITY_KEY, next);
-    } catch {
-      // localStorage unavailable — sensitivity just won't persist.
-    }
+    safeStorage.set(SENSITIVITY_KEY, next);
     // The load effect re-runs because it reads `sensitivity`.
   }
 

--- a/apps/desktop/src/components/logo.svelte
+++ b/apps/desktop/src/components/logo.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { safeStorage } from "@recast/ui/persisted-state";
   type Theme = "light" | "dark" | "system";
 
   let currentTheme = $state<Theme>("system");
   onMount(() => {
-    const storedTheme = localStorage.getItem(
-      "mode-watcher-mode",
-    ) as Theme | null;
-    if (storedTheme) currentTheme = storedTheme;
+    // Read-only — mode-watcher owns this key.
+    currentTheme = safeStorage.get<Theme>("mode-watcher-mode", currentTheme);
   });
 
   let {

--- a/apps/desktop/src/components/recast/PlayerDialog.svelte
+++ b/apps/desktop/src/components/recast/PlayerDialog.svelte
@@ -71,7 +71,13 @@
       </Button>
     </header>
 
-    <RecastPlayer {src} title={entry.filename} autoplay />
+    <!-- autohide={-1} pins the control bar. This is a framed inspect-the-
+         recording dialog, and WebView2 actually honours `autoplay` (a browser
+         blocks the un-muted play and leaves the video paused with controls
+         showing). media-chrome's controller starts in `user-inactive`, so once
+         the clip is playing and the pointer hasn't moved yet the whole bar is
+         hidden — reads as "the player has no controls". -->
+    <RecastPlayer {src} title={entry.filename} autoplay autohide={-1} />
 
     <footer
       class="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-3 text-xs text-muted-foreground"

--- a/apps/desktop/src/components/settings/CloudEndpoint.svelte
+++ b/apps/desktop/src/components/settings/CloudEndpoint.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+	import { Check, LoaderCircle, RotateCcw, Server } from "@lucide/svelte";
+	import { Button } from "@recast/ui/button";
+	import { toast } from "@recast/ui/sonner";
+	import { cn } from "@recast/ui/utils";
+	import { invoke } from "@tauri-apps/api/core";
+	import { emit } from "@tauri-apps/api/event";
+	import { onMount } from "svelte";
+
+	/**
+	 * Self-hosting server endpoint. Most users never touch this — Recast Cloud
+	 * points at the bundled default. Self-hosters run their own SvelteKit
+	 * server and need the desktop to target it; this is the only place to set
+	 * that without recompiling.
+	 *
+	 * The Rust resolver (`auth::cloud_api_url`) validates the saved value and
+	 * falls back to the default if it's empty or malformed, so a bad value can
+	 * never brick cloud sign-in. We validate on save too (via `set_cloud_api_url`)
+	 * to give an explicit error instead of a silent revert. Changing the
+	 * endpoint clears the local session token server-side, so we emit
+	 * `cloud:endpoint-changed` to nudge the sign-in card back to signed-out.
+	 */
+	type CloudApiConfig = {
+		effective: string;
+		overrideUrl: string | null;
+		defaultUrl: string;
+		isCustom: boolean;
+	};
+
+	let config = $state<CloudApiConfig | null>(null);
+	let input = $state("");
+	let saving = $state(false);
+
+	// Dirty only when the trimmed input differs from what's persisted. An empty
+	// input with no override saved is not dirty (nothing to clear).
+	const dirty = $derived(
+		config !== null && input.trim() !== (config.overrideUrl ?? ""),
+	);
+
+	async function load() {
+		try {
+			const c = await invoke<CloudApiConfig>("get_cloud_api_config");
+			config = c;
+			input = c.overrideUrl ?? "";
+		} catch (e) {
+			toast.error(`Couldn't load server endpoint: ${e}`);
+		}
+	}
+
+	async function save() {
+		if (saving) return;
+		saving = true;
+		const prevEffective = config?.effective;
+		try {
+			// Empty string clears the override → back to the default endpoint.
+			const trimmed = input.trim();
+			const next = await invoke<CloudApiConfig>("set_cloud_api_url", {
+				url: trimmed.length > 0 ? trimmed : null,
+			});
+			config = next;
+			input = next.overrideUrl ?? "";
+			toast.success(
+				next.isCustom
+					? `Server endpoint set to ${next.effective}`
+					: "Using the default Recast Cloud endpoint",
+			);
+			// Only nudge the sign-in card if the endpoint actually moved.
+			if (next.effective !== prevEffective) {
+				await emit("cloud:endpoint-changed");
+			}
+		} catch (e) {
+			// `set_cloud_api_url` rejects invalid URLs with a friendly message.
+			toast.error(String(e));
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function reset() {
+		input = "";
+		await save();
+	}
+
+	onMount(load);
+</script>
+
+<div class="flex flex-col gap-3 px-4 py-3">
+	{#if config === null}
+		<div class="flex items-center gap-2 text-[11.5px] text-muted-foreground">
+			<LoaderCircle class="size-3.5 animate-spin" />
+			<span>Loading endpoint…</span>
+		</div>
+	{:else}
+		<div class="flex flex-col gap-1">
+			<span class="text-[12px] font-semibold text-foreground">
+				Server endpoint
+			</span>
+			<span class="text-[11px] text-muted-foreground">
+				Self-hosting Recast Cloud? Point the app at your server. Leave blank
+				to use the default. Changing this signs you out of the current server.
+			</span>
+		</div>
+
+		<div class="flex items-center gap-2">
+			<div
+				class="flex h-9 min-w-0 flex-1 items-center gap-2 rounded-lg border border-border/40 bg-background/60 px-3 focus-within:border-border"
+			>
+				<Server class="size-3.5 shrink-0 text-muted-foreground/70" />
+				<input
+					type="url"
+					bind:value={input}
+					placeholder={config.defaultUrl}
+					spellcheck="false"
+					autocapitalize="off"
+					autocomplete="off"
+					onkeydown={(e) => {
+						if (e.key === "Enter" && dirty) save();
+					}}
+					class="min-w-0 flex-1 bg-transparent font-mono text-[11px] text-foreground placeholder:text-muted-foreground/50 focus:outline-none"
+				/>
+			</div>
+			<Button
+				variant="secondary"
+				size="sm"
+				class="h-9 shrink-0 gap-1.5"
+				disabled={!dirty || saving}
+				onclick={save}
+			>
+				{#if saving}
+					<LoaderCircle class="size-3.5 animate-spin" />
+				{:else}
+					<Check class="size-3.5" />
+				{/if}
+				Save
+			</Button>
+		</div>
+
+		<div class="flex items-center justify-between gap-2">
+			<span
+				class={cn(
+					"inline-flex items-center gap-1.5 text-[10.5px] font-medium",
+					config.isCustom ? "text-amber-500" : "text-muted-foreground/70",
+				)}
+			>
+				<span
+					class={cn(
+						"size-1.5 rounded-full",
+						config.isCustom ? "bg-amber-500" : "bg-emerald-500",
+					)}
+				></span>
+				{config.isCustom ? "Custom endpoint" : "Default endpoint"} ·
+				<span class="font-mono">{config.effective}</span>
+			</span>
+			{#if config.isCustom}
+				<Button
+					variant="ghost"
+					size="xs"
+					class="h-6 gap-1.5 text-[11px]"
+					disabled={saving}
+					onclick={reset}
+				>
+					<RotateCcw class="size-3" />
+					Reset to default
+				</Button>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/apps/desktop/src/components/settings/CloudSignIn.svelte
+++ b/apps/desktop/src/components/settings/CloudSignIn.svelte
@@ -261,6 +261,15 @@
 					toast.error(`Sign-in error: ${event.payload}`);
 					view = { kind: "signed-out" };
 				}),
+				// Self-host endpoint changed (Settings → Cloud → Server endpoint).
+				// The Rust side dropped the old server's token, so re-check status
+				// against the new endpoint — this flips the card back to
+				// signed-out without a full reload.
+				listen("cloud:endpoint-changed", () => {
+					if (view.kind === "waiting") cancelSignIn();
+					view = { kind: "loading" };
+					loadStatus();
+				}),
 			]);
 			// If onDestroy fired while the listens were resolving, we'd leak
 			// these handles forever — call them immediately instead.

--- a/apps/desktop/src/components/settings/DeviceCapabilities.svelte
+++ b/apps/desktop/src/components/settings/DeviceCapabilities.svelte
@@ -94,10 +94,49 @@
     void loadEngine();
   });
 
+  // `os.version()` returns the raw NT version on Windows — "10.0.26200" —
+  // because Windows 11 still reports kernel 10.0; only the build number
+  // (≥22000) distinguishes 11 from 10. Surface the marketing name + build
+  // instead of the bare NT string so the panel reads "Windows 11 (Build
+  // 26200)" rather than the confusing "10.0.26200".
+  function windowsBuild(v: string): number | null {
+    const m = /^\d+\.\d+\.(\d+)/.exec(v);
+    return m ? Number(m[1]) : null;
+  }
+
+  const osName = $derived.by(() => {
+    if (platform === "windows") {
+      const build = windowsBuild(osVersion);
+      if (build !== null) return build >= 22000 ? "Windows 11" : "Windows 10";
+    }
+    if (platform === "macos" && osVersion) return `macOS ${osVersion}`;
+    return osLabel;
+  });
+
+  // Second fact row: the build (Windows) or raw version (kernel/Darwin
+  // elsewhere). Labeled "Build" on Windows since that's the meaningful number.
+  const osDetail = $derived.by(() => {
+    if (platform === "windows") {
+      const build = windowsBuild(osVersion);
+      return build !== null ? String(build) : osVersion;
+    }
+    return osVersion;
+  });
+
+  // Screen capture is only wired up on Windows today (DXGI Desktop
+  // Duplication); the macOS/Linux capture subsystems aren't shipped yet, so
+  // be honest about that rather than implying every platform records.
+  const capture = $derived.by(() => {
+    if (platform === "") return { ok: false, pending: true, label: "Detecting…" };
+    if (platform === "windows")
+      return { ok: true, pending: false, label: "Supported" };
+    return { ok: false, pending: false, label: `Not yet supported on ${osLabel}` };
+  });
+
   const facts = $derived(
     [
-      { label: "Operating system", value: osLabel },
-      { label: "OS version", value: osVersion },
+      { label: "Operating system", value: osName },
+      { label: platform === "windows" ? "Build" : "Version", value: osDetail },
       { label: "Architecture", value: osArch },
       {
         label: "FFmpeg",
@@ -106,6 +145,22 @@
       },
     ].filter((f) => f.value),
   );
+
+  // Group the probed encoders by codec family ("H.264" / "HEVC") so the
+  // matrix renders a labeled section per codec instead of one flat list.
+  // Order follows first-appearance in the probe result (H.264 then HEVC).
+  const encoderGroups = $derived.by(() => {
+    const groups: { family: string; items: EncoderAvailability[] }[] = [];
+    for (const enc of encoders) {
+      let group = groups.find((g) => g.family === enc.family);
+      if (!group) {
+        group = { family: enc.family, items: [] };
+        groups.push(group);
+      }
+      group.items.push(enc);
+    }
+    return groups;
+  });
 </script>
 
 <div class="flex flex-col gap-3">
@@ -130,6 +185,39 @@
         </div>
       {/each}
     </dl>
+  </div>
+
+  <!-- Capture support — whether this platform's screen-recording path is
+       wired up. Windows-only today (DXGI); honest about the rest. -->
+  <div
+    class="overflow-hidden rounded-xl border border-border/60 bg-card/70 shadow-(--shadow-craft-inset) backdrop-blur"
+  >
+    <div class="flex items-center gap-2 border-b border-border/40 px-4 py-2.5">
+      <MonitorPlay class="size-3.5 text-muted-foreground" />
+      <span class="text-[11px] font-semibold text-foreground">
+        Capture support
+      </span>
+    </div>
+    <div class="flex items-center justify-between gap-3 px-4 py-2.5">
+      <dt class="text-[11.5px] text-muted-foreground">Screen capture</dt>
+      <span
+        class={cn(
+          "inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-[10.5px] font-semibold",
+          capture.pending
+            ? "bg-foreground/5 text-muted-foreground/70 ring-1 ring-inset ring-border/40"
+            : capture.ok
+              ? "bg-emerald-500/12 text-emerald-500 ring-1 ring-inset ring-emerald-500/20"
+              : "bg-amber-500/12 text-amber-500 ring-1 ring-inset ring-amber-500/20",
+        )}
+      >
+        {#if capture.ok}
+          <Check class="size-3" />
+        {:else if !capture.pending}
+          <X class="size-3" />
+        {/if}
+        {capture.label}
+      </span>
+    </div>
   </div>
 
   <!-- Hardware acceleration / encoder matrix -->
@@ -168,65 +256,77 @@
         {/each}
       </div>
     {:else}
-      <ul class="divide-y divide-border/30">
-        {#each encoders as enc (enc.name)}
-          <li class="flex items-center justify-between gap-3 px-4 py-2.5">
-            <div class="flex min-w-0 items-center gap-2.5">
-              <div
-                class={cn(
-                  "flex size-7 shrink-0 items-center justify-center rounded-lg ring-1 ring-inset",
-                  enc.available
-                    ? "bg-primary/10 text-primary ring-primary/20"
-                    : "bg-foreground/5 text-muted-foreground/60 ring-border/40",
-                )}
-              >
-                {#if enc.hardware}
-                  <Zap class="size-3.5" />
-                {:else}
-                  <Cpu class="size-3.5" />
-                {/if}
-              </div>
-              <div class="min-w-0">
-                <div class="flex items-center gap-1.5">
-                  <span class="truncate text-[12px] font-semibold text-foreground">
-                    {enc.label}
-                  </span>
-                  {#if enc.active}
-                    <span
-                      class="inline-flex items-center gap-1 rounded-full bg-primary/15 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-primary"
-                    >
-                      <Sparkles class="size-2.5" />
-                      In use
-                    </span>
+      {#each encoderGroups as group (group.family)}
+        <div
+          class="flex items-center gap-2 border-b border-border/30 bg-muted/20 px-4 py-1.5"
+        >
+          <span
+            class="text-[10px] font-bold uppercase tracking-[0.12em] text-muted-foreground/70"
+          >
+            {group.family}
+          </span>
+        </div>
+        <ul class="divide-y divide-border/30">
+          {#each group.items as enc (enc.name)}
+            <li class="flex items-center justify-between gap-3 px-4 py-2.5">
+              <div class="flex min-w-0 items-center gap-2.5">
+                <div
+                  class={cn(
+                    "flex size-7 shrink-0 items-center justify-center rounded-lg ring-1 ring-inset",
+                    enc.available
+                      ? "bg-primary/10 text-primary ring-primary/20"
+                      : "bg-foreground/5 text-muted-foreground/60 ring-border/40",
+                  )}
+                >
+                  {#if enc.hardware}
+                    <Zap class="size-3.5" />
+                  {:else}
+                    <Cpu class="size-3.5" />
                   {/if}
                 </div>
-                <div class="truncate font-mono text-[10px] text-muted-foreground">
-                  {enc.name} · {enc.vendor}
+                <div class="min-w-0">
+                  <div class="flex items-center gap-1.5">
+                    <span class="truncate text-[12px] font-semibold text-foreground">
+                      {enc.label}
+                    </span>
+                    {#if enc.active}
+                      <span
+                        class="inline-flex items-center gap-1 rounded-full bg-primary/15 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-primary"
+                      >
+                        <Sparkles class="size-2.5" />
+                        In use
+                      </span>
+                    {/if}
+                  </div>
+                  <div class="truncate font-mono text-[10px] text-muted-foreground">
+                    {enc.name} · {enc.vendor}
+                  </div>
                 </div>
               </div>
-            </div>
-            <span
-              class={cn(
-                "inline-flex shrink-0 items-center gap-1 text-[10.5px] font-medium",
-                enc.available ? "text-emerald-500" : "text-muted-foreground/70",
-              )}
-            >
-              {#if enc.available}
-                <Check class="size-3.5" />
-                Available
-              {:else}
-                <X class="size-3.5" />
-                Unsupported
-              {/if}
-            </span>
-          </li>
-        {/each}
-      </ul>
+              <span
+                class={cn(
+                  "inline-flex shrink-0 items-center gap-1 text-[10.5px] font-medium",
+                  enc.available ? "text-emerald-500" : "text-muted-foreground/70",
+                )}
+              >
+                {#if enc.available}
+                  <Check class="size-3.5" />
+                  Available
+                {:else}
+                  <X class="size-3.5" />
+                  Unsupported
+                {/if}
+              </span>
+            </li>
+          {/each}
+        </ul>
+      {/each}
       <p class="border-t border-border/30 px-4 py-2.5 text-[10.5px] leading-relaxed text-muted-foreground/80">
         <Minus class="mr-0.5 inline size-3 -translate-y-px" />
-        Recast records with the highest-priority available encoder. Hardware
-        encoders (GPU) keep capture smooth on weaker CPUs; x264 is the always-on
-        software fallback.
+        Recast records with the highest-priority available H.264 encoder.
+        Hardware encoders (GPU) keep capture smooth on weaker CPUs; x264 is the
+        always-on software fallback. HEVC rows are informational — which HEVC
+        encoders this device exposes.
       </p>
     {/if}
   </div>

--- a/apps/desktop/src/components/settings/DeviceCapabilities.svelte
+++ b/apps/desktop/src/components/settings/DeviceCapabilities.svelte
@@ -1,0 +1,227 @@
+<script lang="ts">
+  import {
+    diagnoseFfmpeg,
+    probeVideoEncoders,
+    type EncoderAvailability,
+    type FfmpegDiagnostics,
+  } from "$lib/ipc";
+  import {
+    Check,
+    Cpu,
+    Minus,
+    MonitorCog,
+    RefreshCw,
+    Sparkles,
+    X,
+    Zap,
+  } from "@lucide/svelte";
+  import { Button } from "@recast/ui/button";
+  import { cn } from "@recast/ui/utils";
+  import { onMount } from "svelte";
+
+  // OS facts (best-effort — each os-plugin getter is wrapped so a blocked
+  // permission or non-Tauri preview degrades to "Unknown" instead of
+  // throwing the whole panel away).
+  let osLabel = $state("Unknown");
+  let osVersion = $state("");
+  let osArch = $state("");
+
+  let diagnostics = $state<FfmpegDiagnostics | null>(null);
+  let encoders = $state<EncoderAvailability[]>([]);
+  let probing = $state(true);
+  let probeError = $state<string | null>(null);
+
+  const PLATFORM_LABEL: Record<string, string> = {
+    windows: "Windows",
+    macos: "macOS",
+    linux: "Linux",
+    ios: "iOS",
+    android: "Android",
+  };
+
+  async function loadOsInfo() {
+    try {
+      const os = await import("@tauri-apps/plugin-os");
+      try {
+        const p = os.platform();
+        osLabel = PLATFORM_LABEL[p] ?? p;
+      } catch {
+        /* leave default */
+      }
+      try {
+        osVersion = os.version();
+      } catch {
+        /* optional */
+      }
+      try {
+        osArch = os.arch();
+      } catch {
+        /* optional */
+      }
+    } catch {
+      // Not running under Tauri (browser preview) — leave the defaults.
+    }
+  }
+
+  async function loadEngine() {
+    probing = true;
+    probeError = null;
+    try {
+      // ffmpeg metadata returns fast; the encoder matrix spawns ffmpeg per
+      // hardware candidate (up to ~2s cold), so kick both off together and
+      // let the matrix fill in when it resolves.
+      const [diag, enc] = await Promise.all([
+        diagnoseFfmpeg().catch(() => null),
+        probeVideoEncoders(),
+      ]);
+      diagnostics = diag;
+      encoders = enc;
+    } catch (e) {
+      probeError = String(e);
+    } finally {
+      probing = false;
+    }
+  }
+
+  onMount(() => {
+    void loadOsInfo();
+    void loadEngine();
+  });
+
+  const facts = $derived(
+    [
+      { label: "Operating system", value: osLabel },
+      { label: "OS version", value: osVersion },
+      { label: "Architecture", value: osArch },
+      {
+        label: "FFmpeg",
+        value:
+          diagnostics?.version?.replace(/^ffmpeg version\s*/i, "") ?? "Detecting…",
+      },
+    ].filter((f) => f.value),
+  );
+</script>
+
+<div class="flex flex-col gap-3">
+  <!-- Platform / engine facts -->
+  <div
+    class="overflow-hidden rounded-xl border border-border/60 bg-card/70 shadow-(--shadow-craft-inset) backdrop-blur"
+  >
+    <div class="flex items-center gap-2 border-b border-border/40 px-4 py-2.5">
+      <MonitorCog class="size-3.5 text-muted-foreground" />
+      <span class="text-[11px] font-semibold text-foreground">Platform</span>
+    </div>
+    <dl class="divide-y divide-border/30">
+      {#each facts as fact (fact.label)}
+        <div class="flex items-center justify-between gap-3 px-4 py-2.5">
+          <dt class="text-[11.5px] text-muted-foreground">{fact.label}</dt>
+          <dd
+            class="min-w-0 truncate font-mono text-[11px] text-foreground"
+            title={fact.value}
+          >
+            {fact.value}
+          </dd>
+        </div>
+      {/each}
+    </dl>
+  </div>
+
+  <!-- Hardware acceleration / encoder matrix -->
+  <div
+    class="overflow-hidden rounded-xl border border-border/60 bg-card/70 shadow-(--shadow-craft-inset) backdrop-blur"
+  >
+    <div
+      class="flex items-center justify-between gap-2 border-b border-border/40 px-4 py-2.5"
+    >
+      <div class="flex items-center gap-2">
+        <Zap class="size-3.5 text-primary" />
+        <span class="text-[11px] font-semibold text-foreground">
+          Hardware acceleration
+        </span>
+      </div>
+      <Button
+        variant="ghost"
+        size="xs"
+        class="h-6 gap-1.5 text-[11px]"
+        disabled={probing}
+        onclick={loadEngine}
+      >
+        <RefreshCw class={cn("size-3", probing && "animate-spin")} />
+        {probing ? "Checking…" : "Re-check"}
+      </Button>
+    </div>
+
+    {#if probeError}
+      <div class="px-4 py-3 text-[11px] text-destructive">
+        Couldn't probe encoders: {probeError}
+      </div>
+    {:else if probing && encoders.length === 0}
+      <div class="flex flex-col gap-2 px-4 py-3">
+        {#each [0, 1, 2, 3] as i (i)}
+          <div class="h-9 animate-pulse rounded-lg bg-foreground/5"></div>
+        {/each}
+      </div>
+    {:else}
+      <ul class="divide-y divide-border/30">
+        {#each encoders as enc (enc.name)}
+          <li class="flex items-center justify-between gap-3 px-4 py-2.5">
+            <div class="flex min-w-0 items-center gap-2.5">
+              <div
+                class={cn(
+                  "flex size-7 shrink-0 items-center justify-center rounded-lg ring-1 ring-inset",
+                  enc.available
+                    ? "bg-primary/10 text-primary ring-primary/20"
+                    : "bg-foreground/5 text-muted-foreground/60 ring-border/40",
+                )}
+              >
+                {#if enc.hardware}
+                  <Zap class="size-3.5" />
+                {:else}
+                  <Cpu class="size-3.5" />
+                {/if}
+              </div>
+              <div class="min-w-0">
+                <div class="flex items-center gap-1.5">
+                  <span class="truncate text-[12px] font-semibold text-foreground">
+                    {enc.label}
+                  </span>
+                  {#if enc.active}
+                    <span
+                      class="inline-flex items-center gap-1 rounded-full bg-primary/15 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-primary"
+                    >
+                      <Sparkles class="size-2.5" />
+                      In use
+                    </span>
+                  {/if}
+                </div>
+                <div class="truncate font-mono text-[10px] text-muted-foreground">
+                  {enc.name} · {enc.vendor}
+                </div>
+              </div>
+            </div>
+            <span
+              class={cn(
+                "inline-flex shrink-0 items-center gap-1 text-[10.5px] font-medium",
+                enc.available ? "text-emerald-500" : "text-muted-foreground/70",
+              )}
+            >
+              {#if enc.available}
+                <Check class="size-3.5" />
+                Available
+              {:else}
+                <X class="size-3.5" />
+                Unsupported
+              {/if}
+            </span>
+          </li>
+        {/each}
+      </ul>
+      <p class="border-t border-border/30 px-4 py-2.5 text-[10.5px] leading-relaxed text-muted-foreground/80">
+        <Minus class="mr-0.5 inline size-3 -translate-y-px" />
+        Recast records with the highest-priority available encoder. Hardware
+        encoders (GPU) keep capture smooth on weaker CPUs; x264 is the always-on
+        software fallback.
+      </p>
+    {/if}
+  </div>
+</div>

--- a/apps/desktop/src/components/settings/DeviceCapabilities.svelte
+++ b/apps/desktop/src/components/settings/DeviceCapabilities.svelte
@@ -10,6 +10,7 @@
     Cpu,
     Minus,
     MonitorCog,
+    MonitorPlay,
     RefreshCw,
     Sparkles,
     X,
@@ -25,6 +26,10 @@
   let osLabel = $state("Unknown");
   let osVersion = $state("");
   let osArch = $state("");
+  // Raw platform key ("windows" / "macos" / …) kept alongside the display
+  // label so the capture-support row can key off it without string-matching
+  // the localized label. Empty until loadOsInfo resolves.
+  let platform = $state("");
 
   let diagnostics = $state<FfmpegDiagnostics | null>(null);
   let encoders = $state<EncoderAvailability[]>([]);
@@ -44,6 +49,7 @@
       const os = await import("@tauri-apps/plugin-os");
       try {
         const p = os.platform();
+        platform = p;
         osLabel = PLATFORM_LABEL[p] ?? p;
       } catch {
         /* leave default */

--- a/apps/desktop/src/components/settings/DeviceCapabilities.svelte
+++ b/apps/desktop/src/components/settings/DeviceCapabilities.svelte
@@ -11,6 +11,7 @@
     Cpu,
     Minus,
     MonitorCog,
+    MonitorOff,
     MonitorPlay,
     RefreshCw,
     Sparkles,
@@ -128,10 +129,8 @@
   // Duplication); the macOS/Linux capture subsystems aren't shipped yet, so
   // be honest about that rather than implying every platform records.
   const capture = $derived.by(() => {
-    if (platform === "") return { ok: false, pending: true, label: "Detecting…" };
-    if (platform === "windows")
-      return { ok: true, pending: false, label: "Supported" };
-    return { ok: false, pending: false, label: `Not yet supported on ${osLabel}` };
+    if (platform === "") return { ok: false, pending: true };
+    return { ok: platform === "windows", pending: false };
   });
 
   const facts = $derived(
@@ -206,26 +205,62 @@
         Capture support
       </span>
     </div>
-    <div class="flex items-center justify-between gap-3 px-4 py-2.5">
-      <dt class="text-[11.5px] text-muted-foreground">Screen capture</dt>
-      <span
-        class={cn(
-          "inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-[10.5px] font-semibold",
-          capture.pending
-            ? "bg-foreground/5 text-muted-foreground/70 ring-1 ring-inset ring-border/40"
-            : capture.ok
-              ? "bg-emerald-500/12 text-emerald-500 ring-1 ring-inset ring-emerald-500/20"
-              : "bg-amber-500/12 text-amber-500 ring-1 ring-inset ring-amber-500/20",
-        )}
-      >
-        {#if capture.ok}
-          <Check class="size-3" />
-        {:else if !capture.pending}
-          <X class="size-3" />
-        {/if}
-        {capture.label}
-      </span>
-    </div>
+
+    {#if capture.pending}
+      <div class="flex items-center gap-3 px-4 py-3.5">
+        <div class="size-9 shrink-0 animate-pulse rounded-full bg-foreground/5"></div>
+        <div class="flex-1 space-y-1.5">
+          <div class="h-3 w-36 animate-pulse rounded bg-foreground/5"></div>
+          <div class="h-2.5 w-full max-w-60 animate-pulse rounded bg-foreground/5"></div>
+        </div>
+      </div>
+    {:else}
+      <!-- Plain-language verdict: can this machine actually record its screen? -->
+      <div class="flex items-start gap-3 px-4 py-3.5">
+        <div
+          class={cn(
+            "flex size-9 shrink-0 items-center justify-center rounded-full ring-1 ring-inset",
+            capture.ok
+              ? "bg-primary/15 text-primary ring-primary/25"
+              : "bg-amber-500/12 text-amber-500 ring-1 ring-amber-500/25",
+          )}
+        >
+          {#if capture.ok}
+            <MonitorPlay class="size-5" />
+          {:else}
+            <MonitorOff class="size-5" />
+          {/if}
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <span class="text-[13px] font-semibold text-foreground">
+              {capture.ok
+                ? "Screen recording is ready"
+                : "Screen recording isn't available here"}
+            </span>
+            <span
+              class={cn(
+                "inline-flex items-center rounded-full px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide ring-1 ring-inset",
+                capture.ok
+                  ? "bg-primary/15 text-primary ring-primary/25"
+                  : "bg-amber-500/12 text-amber-500 ring-amber-500/25",
+              )}
+            >
+              {capture.ok ? "Ready" : "Windows only"}
+            </span>
+          </div>
+          <p class="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+            {#if capture.ok}
+              Recast can record your whole screen, a single window, or a
+              selected area on this PC.
+            {:else}
+              Screen recording is Windows-only for now — the {osLabel} capture
+              path isn't shipped yet. Editing, sharing, and playback still work.
+            {/if}
+          </p>
+        </div>
+      </div>
+    {/if}
   </div>
 
   <!-- Hardware acceleration / encoder matrix -->

--- a/apps/desktop/src/components/settings/DeviceCapabilities.svelte
+++ b/apps/desktop/src/components/settings/DeviceCapabilities.svelte
@@ -226,9 +226,9 @@
           )}
         >
           {#if capture.ok}
-            <MonitorPlay class="size-5" />
+            <MonitorPlay class="size-4" />
           {:else}
-            <MonitorOff class="size-5" />
+            <MonitorOff class="size-4" />
           {/if}
         </div>
         <div class="min-w-0 flex-1">

--- a/apps/desktop/src/components/settings/DeviceCapabilities.svelte
+++ b/apps/desktop/src/components/settings/DeviceCapabilities.svelte
@@ -7,6 +7,7 @@
   } from "$lib/ipc";
   import {
     Check,
+    ChevronDown,
     Cpu,
     Minus,
     MonitorCog,
@@ -161,6 +162,13 @@
     }
     return groups;
   });
+
+  // The plain-language verdict: which encoder the recorder actually picked, and
+  // whether it's a GPU (hardware) path. This is the one thing a non-technical
+  // user needs — the per-codec matrix below is collapsed power-user detail.
+  const activeEncoder = $derived(encoders.find((e) => e.active) ?? null);
+  const isAccelerated = $derived(activeEncoder?.hardware ?? false);
+  let showDetails = $state(false);
 </script>
 
 <div class="flex flex-col gap-3">
@@ -247,87 +255,152 @@
 
     {#if probeError}
       <div class="px-4 py-3 text-[11px] text-destructive">
-        Couldn't probe encoders: {probeError}
+        Couldn't check hardware acceleration: {probeError}
       </div>
     {:else if probing && encoders.length === 0}
-      <div class="flex flex-col gap-2 px-4 py-3">
-        {#each [0, 1, 2, 3] as i (i)}
-          <div class="h-9 animate-pulse rounded-lg bg-foreground/5"></div>
-        {/each}
+      <div class="flex items-center gap-3 px-4 py-3.5">
+        <div class="size-9 shrink-0 animate-pulse rounded-full bg-foreground/5"></div>
+        <div class="flex-1 space-y-1.5">
+          <div class="h-3 w-32 animate-pulse rounded bg-foreground/5"></div>
+          <div class="h-2.5 w-full max-w-60 animate-pulse rounded bg-foreground/5"></div>
+        </div>
       </div>
     {:else}
-      {#each encoderGroups as group (group.family)}
+      <!-- Plain-language verdict — the one thing a non-technical user needs:
+           is recording using the graphics card (GPU) or the processor (CPU)? -->
+      <div class="flex items-start gap-3 px-4 py-3.5">
         <div
-          class="flex items-center gap-2 border-b border-border/30 bg-muted/20 px-4 py-1.5"
+          class={cn(
+            "flex size-9 shrink-0 items-center justify-center rounded-full ring-1 ring-inset",
+            isAccelerated
+              ? "bg-primary/15 text-primary ring-primary/25"
+              : "bg-foreground/5 text-muted-foreground ring-border/50",
+          )}
         >
-          <span
-            class="text-[10px] font-bold uppercase tracking-[0.12em] text-muted-foreground/70"
-          >
-            {group.family}
-          </span>
+          {#if isAccelerated}
+            <Zap class="size-5" />
+          {:else}
+            <Cpu class="size-5" />
+          {/if}
         </div>
-        <ul class="divide-y divide-border/30">
-          {#each group.items as enc (enc.name)}
-            <li class="flex items-center justify-between gap-3 px-4 py-2.5">
-              <div class="flex min-w-0 items-center gap-2.5">
-                <div
-                  class={cn(
-                    "flex size-7 shrink-0 items-center justify-center rounded-lg ring-1 ring-inset",
-                    enc.available
-                      ? "bg-primary/10 text-primary ring-primary/20"
-                      : "bg-foreground/5 text-muted-foreground/60 ring-border/40",
-                  )}
-                >
-                  {#if enc.hardware}
-                    <Zap class="size-3.5" />
-                  {:else}
-                    <Cpu class="size-3.5" />
-                  {/if}
-                </div>
-                <div class="min-w-0">
-                  <div class="flex items-center gap-1.5">
-                    <span class="truncate text-[12px] font-semibold text-foreground">
-                      {enc.label}
-                    </span>
-                    {#if enc.active}
-                      <span
-                        class="inline-flex items-center gap-1 rounded-full bg-primary/15 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-primary"
-                      >
-                        <Sparkles class="size-2.5" />
-                        In use
-                      </span>
+        <div class="min-w-0 flex-1">
+          <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <span class="text-[13px] font-semibold text-foreground">
+              {isAccelerated ? "Hardware accelerated" : "Running on your CPU"}
+            </span>
+            <span
+              class={cn(
+                "inline-flex items-center rounded-full px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide ring-1 ring-inset",
+                isAccelerated
+                  ? "bg-primary/15 text-primary ring-primary/25"
+                  : "bg-foreground/5 text-muted-foreground/80 ring-border/50",
+              )}
+            >
+              {isAccelerated ? `GPU · ${activeEncoder?.vendor ?? ""}` : "CPU only"}
+            </span>
+          </div>
+          <p class="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+            {#if isAccelerated}
+              Recordings are encoded by your {activeEncoder?.vendor} graphics
+              card, so capture stays smooth and your processor stays free for
+              everything else.
+            {:else}
+              No graphics-card encoder was available, so recordings are encoded
+              by your processor (CPU). It still works well — just expect higher
+              CPU use while recording.
+            {/if}
+          </p>
+        </div>
+      </div>
+
+      <!-- Per-codec matrix, collapsed by default — kept for power users and bug
+           reports without making jargon the headline. -->
+      <button
+        type="button"
+        onclick={() => (showDetails = !showDetails)}
+        aria-expanded={showDetails}
+        class="flex w-full items-center justify-between gap-2 border-t border-border/30 px-4 py-2 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <span>Technical details</span>
+        <ChevronDown
+          class={cn("size-3.5 transition-transform", showDetails && "rotate-180")}
+        />
+      </button>
+
+      {#if showDetails}
+        {#each encoderGroups as group (group.family)}
+          <div
+            class="flex items-center gap-2 border-b border-border/30 bg-muted/20 px-4 py-1.5"
+          >
+            <span
+              class="text-[10px] font-bold uppercase tracking-[0.12em] text-muted-foreground/70"
+            >
+              {group.family}
+            </span>
+          </div>
+          <ul class="divide-y divide-border/30">
+            {#each group.items as enc (enc.name)}
+              <li class="flex items-center justify-between gap-3 px-4 py-2.5">
+                <div class="flex min-w-0 items-center gap-2.5">
+                  <div
+                    class={cn(
+                      "flex size-7 shrink-0 items-center justify-center rounded-lg ring-1 ring-inset",
+                      enc.available
+                        ? "bg-primary/10 text-primary ring-primary/20"
+                        : "bg-foreground/5 text-muted-foreground/60 ring-border/40",
+                    )}
+                  >
+                    {#if enc.hardware}
+                      <Zap class="size-3.5" />
+                    {:else}
+                      <Cpu class="size-3.5" />
                     {/if}
                   </div>
-                  <div class="truncate font-mono text-[10px] text-muted-foreground">
-                    {enc.name} · {enc.vendor}
+                  <div class="min-w-0">
+                    <div class="flex items-center gap-1.5">
+                      <span class="truncate text-[12px] font-semibold text-foreground">
+                        {enc.label}
+                      </span>
+                      {#if enc.active}
+                        <span
+                          class="inline-flex items-center gap-1 rounded-full bg-primary/15 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-primary"
+                        >
+                          <Sparkles class="size-2.5" />
+                          In use
+                        </span>
+                      {/if}
+                    </div>
+                    <div class="truncate font-mono text-[10px] text-muted-foreground">
+                      {enc.name} · {enc.vendor}
+                    </div>
                   </div>
                 </div>
-              </div>
-              <span
-                class={cn(
-                  "inline-flex shrink-0 items-center gap-1 text-[10.5px] font-medium",
-                  enc.available ? "text-emerald-500" : "text-muted-foreground/70",
-                )}
-              >
-                {#if enc.available}
-                  <Check class="size-3.5" />
-                  Available
-                {:else}
-                  <X class="size-3.5" />
-                  Unsupported
-                {/if}
-              </span>
-            </li>
-          {/each}
-        </ul>
-      {/each}
-      <p class="border-t border-border/30 px-4 py-2.5 text-[10.5px] leading-relaxed text-muted-foreground/80">
-        <Minus class="mr-0.5 inline size-3 -translate-y-px" />
-        Recast records with the highest-priority available H.264 encoder.
-        Hardware encoders (GPU) keep capture smooth on weaker CPUs; x264 is the
-        always-on software fallback. HEVC rows are informational — which HEVC
-        encoders this device exposes.
-      </p>
+                <span
+                  class={cn(
+                    "inline-flex shrink-0 items-center gap-1 text-[10.5px] font-medium",
+                    enc.available ? "text-emerald-500" : "text-muted-foreground/70",
+                  )}
+                >
+                  {#if enc.available}
+                    <Check class="size-3.5" />
+                    Available
+                  {:else}
+                    <X class="size-3.5" />
+                    Unsupported
+                  {/if}
+                </span>
+              </li>
+            {/each}
+          </ul>
+        {/each}
+        <p class="border-t border-border/30 px-4 py-2.5 text-[10.5px] leading-relaxed text-muted-foreground/80">
+          <Minus class="mr-0.5 inline size-3 -translate-y-px" />
+          Recast records with the highest-priority available H.264 encoder.
+          Hardware encoders (GPU) keep capture smooth on weaker CPUs; x264 is the
+          always-on software fallback. HEVC rows are informational — which HEVC
+          encoders this device exposes.
+        </p>
+      {/if}
     {/if}
   </div>
 </div>

--- a/apps/desktop/src/lib/analytics/client.ts
+++ b/apps/desktop/src/lib/analytics/client.ts
@@ -23,7 +23,9 @@ import { desktopConsent } from "$lib/stores/consent.svelte";
 
 export const analytics: AnalyticsClient = createAnalytics({
 	provider: createPostHogBrowserProvider(),
-	enabled: Boolean(POSTHOG_KEY),
+	// Dev builds never track — only packaged/production output emits analytics,
+	// so `tauri dev` and `vite dev` don't pollute the PostHog project.
+	enabled: !import.meta.env.DEV && Boolean(POSTHOG_KEY),
 	initialConsent: {
 		product: desktopConsent.product,
 		errors: desktopConsent.errors,

--- a/apps/desktop/src/lib/analytics/identity.ts
+++ b/apps/desktop/src/lib/analytics/identity.ts
@@ -7,18 +7,19 @@
  * Standalone module (no analytics/posthog imports) so both the consent store and
  * the analytics client can read it without an import cycle.
  */
+import { safeStorage } from "@recast/ui/persisted-state";
+
 const INSTALL_ID_KEY = "trace_install_id";
 
 export function getInstallId(): string {
-	if (typeof localStorage === "undefined") return "anonymous-desktop";
-	let id = localStorage.getItem(INSTALL_ID_KEY);
+	// Keep the explicit sentinel for the truly storage-less case so the crash
+	// reporter still has a stable id during prerender / no-window contexts.
+	if (typeof window === "undefined") return "anonymous-desktop";
+	let id = safeStorage.get<string>(INSTALL_ID_KEY, "");
 	if (!id) {
 		id = crypto.randomUUID();
-		try {
-			localStorage.setItem(INSTALL_ID_KEY, id);
-		} catch {
-			// private mode / quota — fall back to the ephemeral id for this run.
-		}
+		// Best-effort persist; on quota/private-mode the ephemeral id is used.
+		safeStorage.set(INSTALL_ID_KEY, id);
 	}
 	return id;
 }

--- a/apps/desktop/src/lib/annotations/recent-colors.ts
+++ b/apps/desktop/src/lib/annotations/recent-colors.ts
@@ -3,6 +3,8 @@
 // follows them, not the file. Synced to localStorage on every commit so
 // restarts preserve the list. Capped to 12 entries.
 
+import { safeStorage } from "@recast/ui/persisted-state";
+
 const STORAGE_KEY = "recast.annotations.recentColors";
 const MAX = 12;
 
@@ -10,30 +12,16 @@ let cache: string[] | null = null;
 
 function read(): string[] {
 	if (cache) return cache;
-	if (typeof localStorage === "undefined") {
-		cache = [];
-		return cache;
-	}
-	try {
-		const raw = localStorage.getItem(STORAGE_KEY);
-		const parsed = raw ? JSON.parse(raw) : [];
-		cache = Array.isArray(parsed)
-			? parsed.filter((c) => typeof c === "string").slice(0, MAX)
-			: [];
-	} catch {
-		cache = [];
-	}
+	// `safeStorage` handles missing key, no-window, malformed JSON, and the
+	// array-shape guard; we still string-filter + cap defensively.
+	const parsed = safeStorage.get<string[]>(STORAGE_KEY, []);
+	cache = parsed.filter((c) => typeof c === "string").slice(0, MAX);
 	return cache;
 }
 
 function write(next: string[]) {
 	cache = next;
-	if (typeof localStorage === "undefined") return;
-	try {
-		localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-	} catch {
-		// Ignore quota errors — recents are best-effort.
-	}
+	safeStorage.set(STORAGE_KEY, next);
 }
 
 export function getRecentColors(): string[] {

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -120,6 +120,9 @@ export function diagnoseFfmpeg(): Promise<FfmpegDiagnostics> {
  *
  * @param minWidthPx minimum width in *physical* pixels (the OS drag rect is
  *   physical too) — pass `logicalMin * devicePixelRatio`.
+ * @param chromePx fixed, non-scaling vertical space (physical px) reserved at
+ *   the bottom of the window for a control bar outside the video. The aspect
+ *   applies to `height - chromePx`. Pass 0 for a video-only window.
  */
 export function setWindowAspectRatio(
 	label: string,
@@ -127,6 +130,7 @@ export function setWindowAspectRatio(
 	aspectHeight: number,
 	maxScreenFraction: number,
 	minWidthPx: number,
+	chromePx: number,
 ): Promise<void> {
 	return invoke("set_window_aspect_ratio", {
 		label,
@@ -134,6 +138,7 @@ export function setWindowAspectRatio(
 		aspectHeight,
 		maxScreenFraction,
 		minWidthPx,
+		chromePx,
 	});
 }
 
@@ -638,11 +643,16 @@ export async function openCameraPreviewWindow() {
   }
 
   const previewSize = 320;
+  // The window is the square video bubble plus a control strip below it. Keep
+  // this strip height in sync with `CONTROL_BAR_HEIGHT` in
+  // `routes/camera-preview/+page.svelte` so the window opens at the right size
+  // and doesn't visibly resize itself once the aspect lock kicks in on mount.
+  const CONTROL_BAR_HEIGHT = 40;
   const previewWin = new WebviewWindow("camera-preview", {
     url: "/camera-preview",
     title: "Camera",
     width: previewSize,
-    height: previewSize,
+    height: previewSize + CONTROL_BAR_HEIGHT,
     decorations: false,
     transparent: true,
     shadow: false,
@@ -650,7 +660,7 @@ export async function openCameraPreviewWindow() {
     resizable: true,
     skipTaskbar: true,
     x: Math.round(window.screen.availWidth - previewSize - 40),
-    y: Math.round(window.screen.availHeight - previewSize - 40),
+    y: Math.round(window.screen.availHeight - previewSize - CONTROL_BAR_HEIGHT - 40),
   });
 
   previewWin.once("tauri://error", (e) => console.error(e));

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -76,6 +76,40 @@ export interface AutosaveState {
 
 //  System commands
 
+/** One H.264 encoder candidate and whether it really initializes here.
+ *  Mirrors the Rust `EncoderAvailability` struct (`probe_video_encoders`). */
+export interface EncoderAvailability {
+	name: string;
+	label: string;
+	vendor: string;
+	hardware: boolean;
+	available: boolean;
+	active: boolean;
+}
+
+/** ffmpeg/ffprobe resolution + codec diagnostics. Mirrors the Rust
+ *  `FfmpegDiagnostics` struct (`diagnose_ffmpeg`). */
+export interface FfmpegDiagnostics {
+	ffmpeg_path: string;
+	ffprobe_path: string;
+	version: string | null;
+	h264_encoder: string;
+	encoders_present: string[];
+	encoders_missing: string[];
+}
+
+/** Probe which video encoders actually work on this device (real init
+ *  probe, not just "compiled in"). Each hardware probe spawns ffmpeg, so
+ *  this can take up to ~2s cold — call it off the render path. */
+export function probeVideoEncoders(): Promise<EncoderAvailability[]> {
+	return invoke<EncoderAvailability[]>("probe_video_encoders");
+}
+
+/** Resolved ffmpeg paths, version, and which export codecs are present. */
+export function diagnoseFfmpeg(): Promise<FfmpegDiagnostics> {
+	return invoke<FfmpegDiagnostics>("diagnose_ffmpeg");
+}
+
 export function getOutputDir(): Promise<string> {
 	return invoke<string>("get_output_dir");
 }

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -76,12 +76,14 @@ export interface AutosaveState {
 
 //  System commands
 
-/** One H.264 encoder candidate and whether it really initializes here.
- *  Mirrors the Rust `EncoderAvailability` struct (`probe_video_encoders`). */
+/** One encoder candidate (H.264 or HEVC) and whether it really initializes
+ *  here. Mirrors the Rust `EncoderAvailability` struct (`probe_video_encoders`). */
 export interface EncoderAvailability {
 	name: string;
 	label: string;
 	vendor: string;
+	/** Codec family — "H.264" or "HEVC" — used to group the matrix. */
+	family: string;
 	hardware: boolean;
 	available: boolean;
 	active: boolean;
@@ -108,6 +110,31 @@ export function probeVideoEncoders(): Promise<EncoderAvailability[]> {
 /** Resolved ffmpeg paths, version, and which export codecs are present. */
 export function diagnoseFfmpeg(): Promise<FfmpegDiagnostics> {
 	return invoke<FfmpegDiagnostics>("diagnose_ffmpeg");
+}
+
+/**
+ * Lock a window's resize to a fixed aspect ratio and cap its width at a
+ * fraction of its monitor. On Windows this is a real-time WM_SIZING constraint
+ * (proportional while dragging); other platforms no-op and rely on the JS
+ * snap-to-aspect fallback. Re-call when the ratio changes.
+ *
+ * @param minWidthPx minimum width in *physical* pixels (the OS drag rect is
+ *   physical too) — pass `logicalMin * devicePixelRatio`.
+ */
+export function setWindowAspectRatio(
+	label: string,
+	aspectWidth: number,
+	aspectHeight: number,
+	maxScreenFraction: number,
+	minWidthPx: number,
+): Promise<void> {
+	return invoke("set_window_aspect_ratio", {
+		label,
+		aspectWidth,
+		aspectHeight,
+		maxScreenFraction,
+		minWidthPx,
+	});
 }
 
 export function getOutputDir(): Promise<string> {

--- a/apps/desktop/src/lib/profiles.ts
+++ b/apps/desktop/src/lib/profiles.ts
@@ -6,6 +6,7 @@
  * non-component code (panel page, IPC layer, etc.).
  */
 
+import { safeStorage } from "@recast/ui/persisted-state";
 import type { AudioDeviceInfo } from "$lib/ipc";
 import type { BrowserCamera } from "$lib/camera/browser-devices";
 import { findCamera } from "$lib/camera/browser-devices";
@@ -251,20 +252,9 @@ function isV2(p: unknown): p is RecordingProfile {
  * unparseable, or every entry was unrecognizable. Never throws.
  */
 export function loadProfiles(): RecordingProfile[] {
-	let raw: string | null = null;
-	try {
-		raw = localStorage.getItem(PROFILES_STORAGE_KEY);
-	} catch {
-		return seedProfiles();
-	}
-	if (!raw) return seedProfiles();
-
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(raw);
-	} catch {
-		return seedProfiles();
-	}
+	// `safeStorage` returns [] for missing key / no-window / malformed JSON /
+	// non-array data — every empty-ish case funnels into the seed below.
+	const parsed = safeStorage.get<unknown[]>(PROFILES_STORAGE_KEY, []);
 	if (!Array.isArray(parsed) || parsed.length === 0) return seedProfiles();
 
 	const migrated: RecordingProfile[] = [];
@@ -292,33 +282,18 @@ export function loadProfiles(): RecordingProfile[] {
 
 /** Persist profiles to localStorage. Silently no-ops if storage is unavailable. */
 export function persistProfiles(list: RecordingProfile[]): void {
-	try {
-		localStorage.setItem(PROFILES_STORAGE_KEY, JSON.stringify(list));
-	} catch {
-		/* unavailable — silently degrade */
-	}
+	safeStorage.set(PROFILES_STORAGE_KEY, list);
 }
 
-/** Read the on/off flag for the whole profile system. Defaults to enabled. */
+/** Read the on/off flag for the whole profile system. Defaults to enabled.
+ *  The `true` fallback drives the boolean serializer, which reads the existing
+ *  raw "true"/"false" values and returns true when the key is unset. */
 export function loadProfilesEnabled(): boolean {
-	try {
-		const raw = localStorage.getItem(PROFILES_ENABLED_STORAGE_KEY);
-		if (raw === null) return true;
-		return raw === "true";
-	} catch {
-		return true;
-	}
+	return safeStorage.get<boolean>(PROFILES_ENABLED_STORAGE_KEY, true);
 }
 
 export function persistProfilesEnabled(enabled: boolean): void {
-	try {
-		localStorage.setItem(
-			PROFILES_ENABLED_STORAGE_KEY,
-			enabled ? "true" : "false",
-		);
-	} catch {
-		/* unavailable — silently degrade */
-	}
+	safeStorage.set(PROFILES_ENABLED_STORAGE_KEY, enabled);
 }
 
 /** Pick the user's default profile, or the first one if no default flag is

--- a/apps/desktop/src/lib/profiles.ts
+++ b/apps/desktop/src/lib/profiles.ts
@@ -25,6 +25,15 @@ export interface RecordingProfile {
 	cameraLabel: string | null;
 	/** Browser MediaDevices id — what the camera-preview window consumes. */
 	cameraDeviceId: string | null;
+	/**
+	 * Per-profile countdown override (seconds) before capture starts. `null`
+	 * or absent means "inherit the global Settings → Recording countdown";
+	 * `0` explicitly disables the countdown for this profile. Lets a "quick
+	 * capture" profile start instantly while a "presentation" profile waits.
+	 * Not part of the capability fingerprint (`capSig`) — it's a preference,
+	 * not a capability, so two profiles can't differ by countdown alone.
+	 */
+	countdown?: number | null;
 	isDefault: boolean;
 }
 

--- a/apps/desktop/src/lib/stores/consent.svelte.ts
+++ b/apps/desktop/src/lib/stores/consent.svelte.ts
@@ -7,12 +7,14 @@
  *   - `errors`  (crash / error reporting):          ON  — default opt-in, with
  *     an explicit toggle to turn it off.
  *
- * Clones the `experimental.svelte.ts` pattern: a localStorage-backed `$state`
- * rune with cross-window `storage` sync (Tauri v2 webviews share a localStorage
- * origin, so flipping a toggle in the settings window reaches open editor
- * windows without a reload).
+ * Backed by the shared `PersistedState` primitive (`@recast/ui/persisted-state`)
+ * for localStorage persistence + cross-window `storage` sync (Tauri v2 webviews
+ * share a localStorage origin, so flipping a toggle in the settings window
+ * reaches open editor windows without a reload), with the Rust mirror layered
+ * on top in the setters.
  */
 
+import { PersistedState, safeStorage } from "@recast/ui/persisted-state";
 import { getInstallId } from "$lib/analytics/identity";
 
 export interface DesktopConsent {
@@ -25,28 +27,13 @@ const DEFAULTS: DesktopConsent = { product: false, errors: true };
 const STORAGE_KEY = "recast-telemetry-consent";
 const SEEN_KEY = "recast-consent-seen";
 
-function load(): DesktopConsent {
-	if (typeof localStorage === "undefined") return { ...DEFAULTS };
-	try {
-		const raw = localStorage.getItem(STORAGE_KEY);
-		if (!raw) return { ...DEFAULTS };
-		const parsed = JSON.parse(raw) as Partial<DesktopConsent>;
-		return { ...DEFAULTS, ...parsed };
-	} catch {
-		return { ...DEFAULTS };
-	}
-}
-
-function persist(consent: DesktopConsent) {
-	if (typeof localStorage !== "undefined") {
-		try {
-			localStorage.setItem(STORAGE_KEY, JSON.stringify(consent));
-		} catch {
-			// Quota / private mode — best effort.
-		}
-	}
-	// Mirror into Rust so the panic hook / error reporter can read `errors`
-	// and attribute crashes to the same anonymous install id as JS events.
+/**
+ * Mirror consent into Rust so the panic hook / error reporter can read
+ * `errors` and attribute crashes to the same anonymous install id as JS
+ * events. Called on every explicit toggle (not on cross-window re-reads — the
+ * window that made the change already mirrored it to the shared backend).
+ */
+function mirrorToRust(consent: DesktopConsent) {
 	void import("@tauri-apps/api/core")
 		.then(({ invoke }) =>
 			invoke("set_telemetry_consent", {
@@ -61,42 +48,36 @@ function persist(consent: DesktopConsent) {
 }
 
 function createConsentStore() {
-	let consent = $state<DesktopConsent>(load());
-
-	if (typeof window !== "undefined") {
-		window.addEventListener("storage", (e) => {
-			if (e.key !== STORAGE_KEY) return;
-			consent = load();
-		});
-	}
+	// localStorage-backed reactive consent with cross-window `storage` sync:
+	// flipping a toggle in the settings window reaches open editor windows
+	// without a reload. The JSON value is merged over DEFAULTS, so a consent
+	// key added in a future build keeps its default for existing users.
+	const consent = new PersistedState<DesktopConsent>(STORAGE_KEY, DEFAULTS);
 
 	return {
 		get product() {
-			return consent.product;
+			return consent.current.product;
 		},
 		get errors() {
-			return consent.errors;
+			return consent.current.errors;
 		},
 		/** Has the first-run privacy moment been shown + dismissed yet? */
 		get hasSeenFirstRun() {
-			if (typeof localStorage === "undefined") return true;
-			return localStorage.getItem(SEEN_KEY) === "1";
+			// During SSR / no-window previews, treat as seen so the prompt never
+			// flashes before storage is readable.
+			if (typeof window === "undefined") return true;
+			return safeStorage.get<string>(SEEN_KEY, "") === "1";
 		},
 		markFirstRunSeen() {
-			if (typeof localStorage === "undefined") return;
-			try {
-				localStorage.setItem(SEEN_KEY, "1");
-			} catch {
-				/* best effort */
-			}
+			safeStorage.set(SEEN_KEY, "1");
 		},
 		setProduct(value: boolean) {
-			consent = { ...consent, product: value };
-			persist(consent);
+			consent.current = { ...consent.current, product: value };
+			mirrorToRust(consent.current);
 		},
 		setErrors(value: boolean) {
-			consent = { ...consent, errors: value };
-			persist(consent);
+			consent.current = { ...consent.current, errors: value };
+			mirrorToRust(consent.current);
 		},
 	};
 }

--- a/apps/desktop/src/lib/stores/experimental.svelte.ts
+++ b/apps/desktop/src/lib/stores/experimental.svelte.ts
@@ -10,7 +10,7 @@
  * wiring.
  */
 
-export type ExperimentalFlag = "silenceDetection";
+export type ExperimentalFlag = "silenceDetection" | "selfHosting";
 
 interface FlagMeta {
 	key: ExperimentalFlag;
@@ -25,10 +25,17 @@ export const FLAG_META: FlagMeta[] = [
 		description:
 			"Detect dead air (quiet audio + still cursor) and skip it during playback/export. Hidden when off.",
 	},
+	{
+		key: "selfHosting",
+		label: "Self-hosting server endpoint",
+		description:
+			"Point the app at your own Recast Cloud server. Recast Cloud isn't ready yet, so this is for early self-hosters only — leave off to use the default.",
+	},
 ];
 
 const DEFAULTS: Record<ExperimentalFlag, boolean> = {
 	silenceDetection: false,
+	selfHosting: false,
 };
 
 const STORAGE_KEY = "recast-experimental-flags";

--- a/apps/desktop/src/lib/stores/experimental.svelte.ts
+++ b/apps/desktop/src/lib/stores/experimental.svelte.ts
@@ -10,6 +10,8 @@
  * wiring.
  */
 
+import { PersistedState } from "@recast/ui/persisted-state";
+
 export type ExperimentalFlag = "silenceDetection" | "selfHosting";
 
 interface FlagMeta {
@@ -40,54 +42,23 @@ const DEFAULTS: Record<ExperimentalFlag, boolean> = {
 
 const STORAGE_KEY = "recast-experimental-flags";
 
-function load(): Record<ExperimentalFlag, boolean> {
-	if (typeof localStorage === "undefined") return { ...DEFAULTS };
-	try {
-		const raw = localStorage.getItem(STORAGE_KEY);
-		if (!raw) return { ...DEFAULTS };
-		const parsed = JSON.parse(raw) as Partial<Record<ExperimentalFlag, boolean>>;
-		return { ...DEFAULTS, ...parsed };
-	} catch {
-		return { ...DEFAULTS };
-	}
-}
-
-function persist(flags: Record<ExperimentalFlag, boolean>) {
-	if (typeof localStorage === "undefined") return;
-	try {
-		localStorage.setItem(STORAGE_KEY, JSON.stringify(flags));
-	} catch {
-		// Quota / private mode — best effort.
-	}
-}
-
 function createExperimentalStore() {
-	// Read once at module init. localStorage is available in Tauri webviews;
-	// the load() guard handles the SSR/no-window edge cases.
-	let flags = $state<Record<ExperimentalFlag, boolean>>(load());
-
-	// Cross-window sync. Tauri v2 webviews share localStorage origin, so a
-	// write from the settings window fires a `storage` event in any editor
-	// windows that were already open. Re-read on match so the flag flip is
-	// reflected without a reload. Same-window writes don't fire `storage`,
-	// but `setEnabled` updates the rune directly — both paths covered.
-	if (typeof window !== "undefined") {
-		window.addEventListener("storage", (e) => {
-			if (e.key !== STORAGE_KEY) return;
-			flags = load();
-		});
-	}
+	// Backed by the shared PersistedState primitive: synchronous first read,
+	// JSON storage merged over DEFAULTS (so adding a flag later doesn't wipe a
+	// user's saved choices), and cross-window `storage` sync. Tauri v2 webviews
+	// share a localStorage origin, so flipping a flag in the settings window is
+	// reflected in any open editor windows without a reload.
+	const flags = new PersistedState<Record<ExperimentalFlag, boolean>>(STORAGE_KEY, DEFAULTS);
 
 	return {
 		get silenceDetection() {
-			return flags.silenceDetection;
+			return flags.current.silenceDetection;
 		},
 		isEnabled(key: ExperimentalFlag): boolean {
-			return flags[key];
+			return flags.current[key];
 		},
 		setEnabled(key: ExperimentalFlag, value: boolean) {
-			flags = { ...flags, [key]: value };
-			persist(flags);
+			flags.current = { ...flags.current, [key]: value };
 		},
 	};
 }

--- a/apps/desktop/src/lib/stores/recording-countdown.svelte.ts
+++ b/apps/desktop/src/lib/stores/recording-countdown.svelte.ts
@@ -1,0 +1,41 @@
+/**
+ * The "count down before capture starts" setting, shared between the Settings →
+ * Recording panel (where it's chosen) and the recording panel window (where it's
+ * applied). Backed by the shared `PersistedState` primitive so the two windows
+ * stay in sync: Tauri v2 webviews share a localStorage origin, so changing the
+ * value in Settings reaches an already-open panel live via the `storage` event,
+ * no relaunch — the panel no longer needs its own listener.
+ *
+ * Stored as a raw number string (e.g. `"3"`), matching the historical on-disk
+ * format; `PersistedState`'s number serializer reads it back and falls back to
+ * the default on `NaN`. `value` additionally coerces to a known option so a
+ * stale / out-of-range stored number can never reach the UI.
+ */
+
+import { PersistedState } from "@recast/ui/persisted-state";
+
+export type CountdownSeconds = 0 | 3 | 5 | 10;
+
+const STORAGE_KEY = "recast-recording-countdown";
+const VALID: readonly CountdownSeconds[] = [0, 3, 5, 10];
+const DEFAULT: CountdownSeconds = 3;
+
+function coerce(n: number): CountdownSeconds {
+	return (VALID as readonly number[]).includes(n) ? (n as CountdownSeconds) : DEFAULT;
+}
+
+function createRecordingCountdownStore() {
+	const store = new PersistedState<number>(STORAGE_KEY, DEFAULT);
+
+	return {
+		/** Current countdown in seconds, coerced to a valid option (0/3/5/10). */
+		get value(): CountdownSeconds {
+			return coerce(store.current);
+		},
+		set(value: CountdownSeconds) {
+			store.current = value;
+		},
+	};
+}
+
+export const recordingCountdown = createRecordingCountdownStore();

--- a/apps/desktop/src/lib/stores/user-store.svelte.ts
+++ b/apps/desktop/src/lib/stores/user-store.svelte.ts
@@ -1,3 +1,4 @@
+import { safeStorage } from "@recast/ui/persisted-state";
 
 export type User = {
     // --- Identification & Telemetry ---
@@ -24,12 +25,13 @@ export type User = {
 
 export function createUserStore() {
     // Attempt to load an existing install ID to track returning anonymous users,
-    // or generate a new persistent one.
-    const storedInstallId = typeof localStorage !== 'undefined' ? localStorage.getItem('trace_install_id') : null;
+    // or generate a new persistent one. Shares the `trace_install_id` key with
+    // `analytics/identity` and the Rust crash reporter.
+    const storedInstallId = safeStorage.get<string>('trace_install_id', '');
     const installId = storedInstallId || crypto.randomUUID();
-    
-    if (typeof localStorage !== 'undefined' && !storedInstallId) {
-        localStorage.setItem('trace_install_id', installId);
+
+    if (!storedInstallId) {
+        safeStorage.set('trace_install_id', installId);
     }
 
     let user = $state<User>({

--- a/apps/desktop/src/lib/stores/whats-new.svelte.ts
+++ b/apps/desktop/src/lib/stores/whats-new.svelte.ts
@@ -1,22 +1,18 @@
+import { safeStorage } from "@recast/ui/persisted-state";
 import { config } from "$constants/app";
 import { LATEST_RELEASE } from "$constants/changelog";
 
 const STORAGE_KEY = "recast-last-seen-version";
 
-function readSeen(): string | null {
-	try {
-		return localStorage.getItem(STORAGE_KEY);
-	} catch {
-		return null;
-	}
+// Stored as a raw version string (not JSON) — `safeStorage` infers the
+// string serializer from the "" fallback, preserving the existing on-disk
+// format and returning "" (never equal to a real version) when unset.
+function readSeen(): string {
+	return safeStorage.get<string>(STORAGE_KEY, "");
 }
 
 function writeSeen(v: string) {
-	try {
-		localStorage.setItem(STORAGE_KEY, v);
-	} catch {
-		/* localStorage unavailable — silently degrade */
-	}
+	safeStorage.set(STORAGE_KEY, v);
 }
 
 function createWhatsNewStore() {

--- a/apps/desktop/src/routes/(app)/+page.svelte
+++ b/apps/desktop/src/routes/(app)/+page.svelte
@@ -29,6 +29,7 @@
   import { Kbd } from "@recast/ui/kbd";
   import { toast } from "@recast/ui/sonner";
   import { cn } from "@recast/ui/utils";
+  import { safeStorage } from "@recast/ui/persisted-state";
   import { listen } from "@tauri-apps/api/event";
   import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
   import { onMount } from "svelte";
@@ -45,11 +46,10 @@
 
   onMount(() => {
     fetchAll();
-    const stored = localStorage.getItem("recast-editor-window") as
-      | "navigate"
-      | "new-window"
-      | null;
-    if (stored) editorWindow = stored;
+    editorWindow = safeStorage.get<"navigate" | "new-window">(
+      "recast-editor-window",
+      editorWindow,
+    );
     const unlisten = listen("refresh-recordings", () => fetchAll());
     const tick = window.setInterval(() => (now = Date.now()), 60_000);
     return () => {

--- a/apps/desktop/src/routes/(app)/exports/+page.svelte
+++ b/apps/desktop/src/routes/(app)/exports/+page.svelte
@@ -48,6 +48,7 @@
   import { Skeleton } from "@recast/ui/skeleton";
   import { toast } from "@recast/ui/sonner";
   import { cn } from "@recast/ui/utils";
+  import { safeStorage } from "@recast/ui/persisted-state";
   import { onMount } from "svelte";
   import { cubicOut } from "svelte/easing";
   import { SvelteSet } from "svelte/reactivity";
@@ -82,15 +83,11 @@
     // Same for Recast Cloud — hydrates sign-in state + the share manifest so
     // each row shows "Share to Cloud" vs. "Copy link / Manage".
     void cloudShare.init();
-    const storedView = localStorage.getItem("exports-view") as
-      | "grid"
-      | "list"
-      | null;
-    if (storedView) view = storedView;
+    view = safeStorage.get<"grid" | "list">("exports-view", view);
   });
 
   $effect(() => {
-    localStorage.setItem("exports-view", view);
+    safeStorage.set("exports-view", view);
   });
 
   async function fetchExports() {

--- a/apps/desktop/src/routes/(app)/profiles/+page.svelte
+++ b/apps/desktop/src/routes/(app)/profiles/+page.svelte
@@ -14,6 +14,7 @@
     SlidersHorizontal as SlidersIcon,
     Sparkles,
     Star,
+    Timer,
     Trash2,
     Volume2,
     VolumeOff,
@@ -262,6 +263,21 @@
     draft = { ...draft, cameraDeviceId: dev.deviceId, cameraLabel: dev.label };
   }
 
+  // Per-profile countdown override. `null` = inherit the global Settings →
+  // Recording countdown; `0` = no countdown for this profile.
+  const countdownChoices: { value: number | null; label: string }[] = [
+    { value: null, label: "Default" },
+    { value: 0, label: "Off" },
+    { value: 3, label: "3s" },
+    { value: 5, label: "5s" },
+    { value: 10, label: "10s" },
+  ];
+
+  function setDraftCountdown(value: number | null) {
+    if (!draft) return;
+    draft = { ...draft, countdown: value };
+  }
+
   function handleGlobalShortcut(e: KeyboardEvent) {
     const meta = e.metaKey || e.ctrlKey;
     if (!meta || e.shiftKey || e.altKey) return;
@@ -314,6 +330,12 @@
         (profile.cameraLabel
           ? `Cam: ${profile.cameraLabel}`
           : "Camera"),
+      // Only surface an explicit countdown override (null/undefined inherits
+      // the global setting and isn't worth a chip).
+      profile.countdown != null &&
+        (profile.countdown === 0
+          ? "No countdown"
+          : `${profile.countdown}s countdown`),
     ].filter(Boolean) as string[];
     return parts.length === 0 ? "Silent capture" : parts.join(" · ");
   }
@@ -928,6 +950,49 @@
             "No cameras detected",
           )}
         {/if}
+
+        <!-- Countdown override. "Default" inherits the global Settings →
+             Recording countdown; the rest pin a per-profile value for quick
+             access when switching profiles. -->
+        <div class="flex items-center gap-3 px-5 py-3">
+          <span
+            class="flex size-8 shrink-0 items-center justify-center rounded-lg bg-background/70 text-muted-foreground ring-1 ring-inset ring-border/40"
+            aria-hidden="true"
+          >
+            <Timer size={14} />
+          </span>
+          <span class="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span class="truncate text-[12.5px] font-semibold text-foreground">
+              Countdown
+            </span>
+            <span class="truncate text-[11px] font-medium text-muted-foreground">
+              Seconds before capture starts.
+            </span>
+          </span>
+          <div
+            class="flex items-center gap-0.5 rounded-xl bg-muted/30 p-1 ring-1 ring-inset ring-border/40"
+            role="radiogroup"
+            aria-label="Countdown before recording"
+          >
+            {#each countdownChoices as c (c.label)}
+              {@const active = (draft.countdown ?? null) === c.value}
+              <button
+                type="button"
+                role="radio"
+                aria-checked={active}
+                onclick={() => setDraftCountdown(c.value)}
+                class={cn(
+                  "flex h-6 items-center rounded-lg px-2 text-[10.5px] font-semibold tabular-nums transition-all duration-200",
+                  active
+                    ? "bg-card text-foreground shadow-(--shadow-craft-inset) ring-1 ring-inset ring-border/40"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {c.label}
+              </button>
+            {/each}
+          </div>
+        </div>
       </div>
 
       <footer

--- a/apps/desktop/src/routes/(app)/recasts/+page.svelte
+++ b/apps/desktop/src/routes/(app)/recasts/+page.svelte
@@ -40,6 +40,7 @@
   import { Skeleton } from "@recast/ui/skeleton";
   import { toast } from "@recast/ui/sonner";
   import { cn } from "@recast/ui/utils";
+  import { safeStorage } from "@recast/ui/persisted-state";
   import { listen } from "@tauri-apps/api/event";
   import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
   import { onMount } from "svelte";
@@ -67,16 +68,11 @@
 
   onMount(() => {
     fetchRecasts();
-    const stored = localStorage.getItem("recast-editor-window") as
-      | "navigate"
-      | "new-window"
-      | null;
-    if (stored) editorWindow = stored;
-    const storedView = localStorage.getItem("recasts-view") as
-      | "grid"
-      | "list"
-      | null;
-    if (storedView) view = storedView;
+    editorWindow = safeStorage.get<"navigate" | "new-window">(
+      "recast-editor-window",
+      editorWindow,
+    );
+    view = safeStorage.get<"grid" | "list">("recasts-view", view);
     const unlisten = listen("refresh-recordings", () => fetchRecasts());
     return () => {
       unlisten.then((fn) => fn());
@@ -84,7 +80,7 @@
   });
 
   $effect(() => {
-    localStorage.setItem("recasts-view", view);
+    safeStorage.set("recasts-view", view);
   });
 
   async function fetchRecasts() {

--- a/apps/desktop/src/routes/(app)/settings/+page.svelte
+++ b/apps/desktop/src/routes/(app)/settings/+page.svelte
@@ -26,6 +26,7 @@
     SlidersHorizontal as SlidersIcon,
     Sparkles,
     Sun,
+    Timer,
     Video,
   } from "@lucide/svelte";
   import { Button } from "@recast/ui/button";
@@ -48,6 +49,10 @@
 
   type Theme = "light" | "dark" | "system";
   type EditorBehavior = "navigate" | "new-window";
+  type CountdownSeconds = 0 | 3 | 5 | 10;
+  // localStorage key shared with the recording panel (panel/+page.svelte),
+  // which reads it to decide how long to count down before capture starts.
+  const COUNTDOWN_KEY = "recast-recording-countdown";
   type SettingsTab =
     | "general"
     | "recording"
@@ -58,6 +63,7 @@
   let outputDir = $state("");
   let currentTheme = $state<Theme>("system");
   let editorWindow = $state<EditorBehavior>("navigate");
+  let countdown = $state<CountdownSeconds>(3);
   let closeToTray = $state(true);
   // Land on Recording — the daily-use panel (output directory, profiles,
   // editor behavior) — rather than the leftmost General tab, matching how
@@ -75,6 +81,11 @@
       "recast-editor-window",
     ) as EditorBehavior | null;
     if (storedEditor) editorWindow = storedEditor;
+    const storedCountdown = localStorage.getItem(COUNTDOWN_KEY);
+    if (storedCountdown !== null) {
+      const n = Number.parseInt(storedCountdown, 10);
+      if (n === 0 || n === 3 || n === 5 || n === 10) countdown = n;
+    }
   });
 
   function toggleProfilesEnabled() {
@@ -142,6 +153,18 @@
     editorWindow = value;
     localStorage.setItem("recast-editor-window", value);
   }
+
+  function updateCountdown(value: CountdownSeconds) {
+    countdown = value;
+    localStorage.setItem(COUNTDOWN_KEY, String(value));
+  }
+
+  const countdownOptions: { value: CountdownSeconds; label: string }[] = [
+    { value: 0, label: "Off" },
+    { value: 3, label: "3s" },
+    { value: 5, label: "5s" },
+    { value: 10, label: "10s" },
+  ];
 
   async function pickDirectory() {
     const { open } = await import("@tauri-apps/plugin-dialog");
@@ -295,6 +318,63 @@
                         <FolderOpen class="size-3.5" />
                         Change
                       </Button>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <!-- Countdown before recording. Read by the recording panel
+                   (panel/+page.svelte) via the shared COUNTDOWN_KEY localStorage
+                   entry. Recording profiles can override it per-profile for
+                   quick access. -->
+              <section id="settings-countdown" class="flex flex-col gap-3">
+                <div class="px-1">
+                  <h2
+                    class="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
+                  >
+                    <Timer class="size-3 text-primary" />
+                    Countdown
+                  </h2>
+                  <p class="mt-0.5 text-[11px] text-muted-foreground/80">
+                    Wait a beat before capture starts — time to switch windows.
+                  </p>
+                </div>
+                <div
+                  class="rounded-xl border border-border/60 bg-card/70 shadow-(--shadow-craft-inset) backdrop-blur"
+                >
+                  <div class="flex items-center justify-between gap-3 px-4 py-3">
+                    <div class="min-w-0">
+                      <div class="text-[12px] font-semibold text-foreground">
+                        Countdown before recording
+                      </div>
+                      <div class="text-[11px] text-muted-foreground">
+                        {countdown === 0
+                          ? "Recording starts immediately."
+                          : `A ${countdown}-second countdown shows in the panel first.`}
+                      </div>
+                    </div>
+                    <div
+                      class="flex items-center gap-1 rounded-xl bg-muted/30 p-1 ring-1 ring-inset ring-border/40"
+                      role="radiogroup"
+                      aria-label="Countdown before recording"
+                    >
+                      {#each countdownOptions as o (o.value)}
+                        {@const active = countdown === o.value}
+                        <button
+                          type="button"
+                          role="radio"
+                          aria-checked={active}
+                          onclick={() => updateCountdown(o.value)}
+                          class={cn(
+                            "flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-[11px] font-semibold tabular-nums transition-all duration-200",
+                            active
+                              ? "bg-card text-foreground shadow-(--shadow-craft-inset) ring-1 ring-inset ring-border/40"
+                              : "text-muted-foreground hover:text-foreground",
+                          )}
+                        >
+                          {o.label}
+                        </button>
+                      {/each}
                     </div>
                   </div>
                 </div>

--- a/apps/desktop/src/routes/(app)/settings/+page.svelte
+++ b/apps/desktop/src/routes/(app)/settings/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Logo from "$components/logo.svelte";
+  import CloudEndpoint from "$components/settings/CloudEndpoint.svelte";
   import CloudSignIn from "$components/settings/CloudSignIn.svelte";
   import DeviceCapabilities from "$components/settings/DeviceCapabilities.svelte";
   import GoogleDriveConnection from "$components/settings/GoogleDriveConnection.svelte";
@@ -19,6 +20,7 @@
     Monitor,
     Moon,
     Navigation,
+    Server,
     Settings as SettingsIcon,
     Shield,
     SlidersHorizontal as SlidersIcon,
@@ -46,7 +48,12 @@
 
   type Theme = "light" | "dark" | "system";
   type EditorBehavior = "navigate" | "new-window";
-  type SettingsTab = "general" | "recording" | "cloud" | "privacy" | "about";
+  type SettingsTab =
+    | "general"
+    | "recording"
+    | "cloud"
+    | "experimental"
+    | "about";
 
   let outputDir = $state("");
   let currentTheme = $state<Theme>("system");
@@ -198,11 +205,14 @@
     </header>
 
     <!-- Tabs, grouped by concern:
-           General   — appearance + window behavior
-           Recording — storage, editor, capture profiles (daily-use)
-           Cloud     — Recast Cloud + Google Drive (network integrations)
-           Privacy   — telemetry consent + experimental flags
-           About     — version, links, and device/encoder diagnostics
+           General      — appearance, window behavior + telemetry consent
+           Recording    — storage, editor, capture profiles (daily-use)
+           Cloud        — Recast Cloud + Google Drive (network integrations)
+           Experimental — opt-in unfinished features
+           About        — version, links, and device/encoder diagnostics
+         Telemetry lives under General (it's a small, two-toggle consent
+         block, not its own surface); Experimental gets a dedicated tab so
+         its growing flag list doesn't crowd anything else.
          Each panel slides/fades in via tw-animate-css inside Tabs.Content. -->
     <div
       in:fly={{ y: 12, duration: 320, delay: 80, easing: cubicOut }}
@@ -229,9 +239,9 @@
             <Cloud class="size-3.5" />
             <span class="text-[12px] font-semibold">Cloud</span>
           </Tabs.Trigger>
-          <Tabs.Trigger value="privacy" class="gap-1.5 px-2">
-            <Shield class="size-3.5" />
-            <span class="text-[12px] font-semibold">Privacy</span>
+          <Tabs.Trigger value="experimental" class="gap-1.5 px-2">
+            <FlaskConical class="size-3.5" />
+            <span class="text-[12px] font-semibold">Experimental</span>
           </Tabs.Trigger>
           <Tabs.Trigger value="about" class="gap-1.5 px-2">
             <Info class="size-3.5" />
@@ -449,6 +459,41 @@
                 </div>
               </section>
 
+              <!-- Self-hosting server endpoint. Gated behind the `selfHosting`
+                   experimental flag (Settings → Experimental) because Recast
+                   Cloud's server isn't shipped yet — there's nothing to point
+                   at by default, so this stays hidden for everyone except
+                   early self-hosters who opt in. When enabled, the Rust
+                   resolver validates the URL and falls back to the bundled
+                   default, so a bad value can't break sign-in. -->
+              {#if experimentalStore.isEnabled("selfHosting")}
+                <section id="settings-cloud-endpoint" class="flex flex-col gap-3">
+                  <div class="px-1">
+                    <h2
+                      class="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
+                    >
+                      <Server class="size-3 text-primary" />
+                      Self-hosting
+                      <span
+                        class="inline-flex items-center gap-1 rounded-full bg-amber-500/12 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-amber-500"
+                      >
+                        <FlaskConical class="size-2.5" />
+                        Experimental
+                      </span>
+                    </h2>
+                    <p class="mt-0.5 text-[11px] text-muted-foreground/80">
+                      Run your own Recast Cloud server? Set its address here.
+                      Everyone else can leave this on the default.
+                    </p>
+                  </div>
+                  <div
+                    class="overflow-hidden rounded-xl border border-border/60 bg-card/70 shadow-(--shadow-craft-inset) backdrop-blur"
+                  >
+                    <CloudEndpoint />
+                  </div>
+                </section>
+              {/if}
+
               <!-- Google Drive connection. Independent of the cloud Account
                    section above: signing into Recast Cloud and connecting
                    Google Drive are separate authentications. Both belong on
@@ -580,9 +625,7 @@
                   </div>
                 </div>
               </section>
-        </Tabs.Content>
 
-        <Tabs.Content value="privacy" class="flex min-w-0 flex-col gap-8">
               <!-- Privacy & Telemetry. Two independent, locally-stored opt-ins:
                    usage analytics (strictly opt-in, default off) and crash
                    reports (default on). Both anonymous; crash reports are
@@ -673,7 +716,9 @@
                   </div>
                 </div>
               </section>
+        </Tabs.Content>
 
+        <Tabs.Content value="experimental" class="flex min-w-0 flex-col gap-8">
               <!-- Experimental features -->
               <section id="settings-experimental" class="flex flex-col gap-3">
                 <div class="px-1">

--- a/apps/desktop/src/routes/(app)/settings/+page.svelte
+++ b/apps/desktop/src/routes/(app)/settings/+page.svelte
@@ -1,18 +1,21 @@
 <script lang="ts">
   import Logo from "$components/logo.svelte";
   import CloudSignIn from "$components/settings/CloudSignIn.svelte";
+  import DeviceCapabilities from "$components/settings/DeviceCapabilities.svelte";
   import GoogleDriveConnection from "$components/settings/GoogleDriveConnection.svelte";
   import { config } from "$constants/app";
   import { getOutputDir, setOutputDir } from "$lib/ipc";
   import {
     ArrowUpRight,
     Cloud,
+    Cpu,
     ExternalLink,
     FlaskConical,
     FolderOpen,
     Github,
     Globe,
     HardDrive,
+    Info,
     Monitor,
     Moon,
     Navigation,
@@ -21,6 +24,7 @@
     SlidersHorizontal as SlidersIcon,
     Sparkles,
     Sun,
+    Video,
   } from "@lucide/svelte";
   import { Button } from "@recast/ui/button";
   import { toast } from "@recast/ui/sonner";
@@ -31,27 +35,27 @@
   import { cubicOut } from "svelte/easing";
   import { fly } from "svelte/transition";
 
+  import { syncConsent } from "$lib/analytics/client";
+  import { desktopConsent } from "$lib/stores/consent.svelte";
   import {
     FLAG_META,
     experimentalStore,
     type ExperimentalFlag,
   } from "$lib/stores/experimental.svelte";
   import { profilesStore } from "$lib/stores/profiles.svelte";
-  import { desktopConsent } from "$lib/stores/consent.svelte";
-  import { syncConsent } from "$lib/analytics/client";
 
   type Theme = "light" | "dark" | "system";
   type EditorBehavior = "navigate" | "new-window";
-  type SettingsTab = "general" | "local" | "cloud";
+  type SettingsTab = "general" | "recording" | "cloud" | "privacy" | "about";
 
   let outputDir = $state("");
   let currentTheme = $state<Theme>("system");
   let editorWindow = $state<EditorBehavior>("navigate");
   let closeToTray = $state(true);
-  // Default to the middle tab so the visual ordering reads naturally
-  // (general — local — cloud) while landing the user on the daily-use
-  // panel (output dir, profiles, editor behavior).
-  let activeTab = $state<SettingsTab>("local");
+  // Land on Recording — the daily-use panel (output directory, profiles,
+  // editor behavior) — rather than the leftmost General tab, matching how
+  // people actually reach for these settings.
+  let activeTab = $state<SettingsTab>("recording");
 
   onMount(() => {
     fetchSettings();
@@ -193,10 +197,13 @@
       </p>
     </header>
 
-    <!-- Tabs: Local (offline, daily-use) / Cloud (network-dependent) /
-         General (theme, experimental, about). Side-slide transition tracks
-         tab order in `TAB_ORDER` so backward navigation slides right and
-         forward navigation slides left — same convention as iOS push/pop. -->
+    <!-- Tabs, grouped by concern:
+           General   — appearance + window behavior
+           Recording — storage, editor, capture profiles (daily-use)
+           Cloud     — Recast Cloud + Google Drive (network integrations)
+           Privacy   — telemetry consent + experimental flags
+           About     — version, links, and device/encoder diagnostics
+         Each panel slides/fades in via tw-animate-css inside Tabs.Content. -->
     <div
       in:fly={{ y: 12, duration: 320, delay: 80, easing: cubicOut }}
       class="flex min-w-0 flex-col gap-6"
@@ -206,18 +213,29 @@
         onValueChange={(v) => (activeTab = v as SettingsTab)}
         class="flex flex-col gap-6"
       >
-        <Tabs.List variant="soft" class="grid w-full max-w-md grid-cols-3 gap-1 p-1">
-          <Tabs.Trigger value="general" class="gap-1.5 px-3">
+        <Tabs.List
+          variant="soft"
+          class="grid w-full max-w-2xl grid-cols-5 gap-1 p-1"
+        >
+          <Tabs.Trigger value="general" class="gap-1.5 px-2">
             <SettingsIcon class="size-3.5" />
             <span class="text-[12px] font-semibold">General</span>
           </Tabs.Trigger>
-          <Tabs.Trigger value="local" class="gap-1.5 px-3">
-            <HardDrive class="size-3.5" />
-            <span class="text-[12px] font-semibold">Local</span>
+          <Tabs.Trigger value="recording" class="gap-1.5 px-2">
+            <Video class="size-3.5" />
+            <span class="text-[12px] font-semibold">Recording</span>
           </Tabs.Trigger>
-          <Tabs.Trigger value="cloud" class="gap-1.5 px-3">
+          <Tabs.Trigger value="cloud" class="gap-1.5 px-2">
             <Cloud class="size-3.5" />
             <span class="text-[12px] font-semibold">Cloud</span>
+          </Tabs.Trigger>
+          <Tabs.Trigger value="privacy" class="gap-1.5 px-2">
+            <Shield class="size-3.5" />
+            <span class="text-[12px] font-semibold">Privacy</span>
+          </Tabs.Trigger>
+          <Tabs.Trigger value="about" class="gap-1.5 px-2">
+            <Info class="size-3.5" />
+            <span class="text-[12px] font-semibold">About</span>
           </Tabs.Trigger>
         </Tabs.List>
 
@@ -225,7 +243,7 @@
              tw-animate-css (defined in @recast/ui's tabs-content.svelte) —
              no need for custom Svelte transitions. Panels not matching the
              active value unmount, so we don't pay layout cost. -->
-        <Tabs.Content value="local" class="flex min-w-0 flex-col gap-8">
+        <Tabs.Content value="recording" class="flex min-w-0 flex-col gap-8">
               <!-- Storage / Output directory -->
               <section id="settings-storage" class="flex flex-col gap-3">
                 <div class="px-1">
@@ -562,7 +580,9 @@
                   </div>
                 </div>
               </section>
+        </Tabs.Content>
 
+        <Tabs.Content value="privacy" class="flex min-w-0 flex-col gap-8">
               <!-- Privacy & Telemetry. Two independent, locally-stored opt-ins:
                    usage analytics (strictly opt-in, default off) and crash
                    reports (default on). Both anonymous; crash reports are
@@ -711,7 +731,9 @@
                   {/each}
                 </div>
               </section>
+        </Tabs.Content>
 
+        <Tabs.Content value="about" class="flex min-w-0 flex-col gap-8">
               <!-- About -->
               <section id="settings-about" class="flex flex-col gap-3">
                 <div class="px-1">
@@ -731,7 +753,7 @@
                     <div
                       class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-foreground/5 text-foreground ring-1 ring-inset ring-border/40"
                     >
-                      <Logo class="size-4" />
+                      <Logo class="size-6" />
                     </div>
                     <div class="min-w-0 flex-1">
                       <div class="text-[13px] font-semibold text-foreground">
@@ -777,6 +799,25 @@
                     </Button>
                   </div>
                 </div>
+              </section>
+
+              <!-- Device & diagnostics. Encoder availability is probed live
+                   against this machine's GPU (not just "compiled in"), so the
+                   matrix reflects what Recast can actually use here — handy in
+                   bug reports and for users wondering why capture is on CPU. -->
+              <section id="settings-device" class="flex flex-col gap-3">
+                <div class="px-1">
+                  <h2
+                    class="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
+                  >
+                    <Cpu class="size-3 text-primary" />
+                    Device & diagnostics
+                  </h2>
+                  <p class="mt-0.5 text-[11px] text-muted-foreground/80">
+                    Your platform and which video encoders this device supports.
+                  </p>
+                </div>
+                <DeviceCapabilities />
               </section>
         </Tabs.Content>
       </Tabs.Root>

--- a/apps/desktop/src/routes/(app)/settings/+page.svelte
+++ b/apps/desktop/src/routes/(app)/settings/+page.svelte
@@ -46,13 +46,14 @@
     type ExperimentalFlag,
   } from "$lib/stores/experimental.svelte";
   import { profilesStore } from "$lib/stores/profiles.svelte";
+  import {
+    recordingCountdown,
+    type CountdownSeconds,
+  } from "$lib/stores/recording-countdown.svelte";
+  import { safeStorage } from "@recast/ui/persisted-state";
 
   type Theme = "light" | "dark" | "system";
   type EditorBehavior = "navigate" | "new-window";
-  type CountdownSeconds = 0 | 3 | 5 | 10;
-  // localStorage key shared with the recording panel (panel/+page.svelte),
-  // which reads it to decide how long to count down before capture starts.
-  const COUNTDOWN_KEY = "recast-recording-countdown";
   type SettingsTab =
     | "general"
     | "recording"
@@ -73,19 +74,14 @@
   onMount(() => {
     fetchSettings();
     profilesStore.hydrate();
-    const storedTheme = localStorage.getItem("mode-watcher-mode") as
-      | Theme
-      | null;
-    if (storedTheme) currentTheme = storedTheme;
-    const storedEditor = localStorage.getItem(
+    // `mode-watcher-mode` is owned by the mode-watcher library — we only read
+    // it here to reflect the current choice in the radio group.
+    currentTheme = safeStorage.get<Theme>("mode-watcher-mode", currentTheme);
+    editorWindow = safeStorage.get<EditorBehavior>(
       "recast-editor-window",
-    ) as EditorBehavior | null;
-    if (storedEditor) editorWindow = storedEditor;
-    const storedCountdown = localStorage.getItem(COUNTDOWN_KEY);
-    if (storedCountdown !== null) {
-      const n = Number.parseInt(storedCountdown, 10);
-      if (n === 0 || n === 3 || n === 5 || n === 10) countdown = n;
-    }
+      editorWindow,
+    );
+    countdown = recordingCountdown.value;
   });
 
   function toggleProfilesEnabled() {
@@ -151,12 +147,12 @@
 
   function updateEditorWindow(value: EditorBehavior) {
     editorWindow = value;
-    localStorage.setItem("recast-editor-window", value);
+    safeStorage.set("recast-editor-window", value);
   }
 
   function updateCountdown(value: CountdownSeconds) {
     countdown = value;
-    localStorage.setItem(COUNTDOWN_KEY, String(value));
+    recordingCountdown.set(value);
   }
 
   const countdownOptions: { value: CountdownSeconds; label: string }[] = [

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -92,6 +92,7 @@
   import { getTauriTheme, isTauriApp } from "$lib/runtime/tauri";
   import { Toaster, toast } from "@recast/ui/sonner";
   import { ModeWatcher, setMode } from "@recast/ui/theme";
+  import { safeStorage } from "@recast/ui/persisted-state";
   import { invoke } from "@tauri-apps/api/core";
   import { listen } from "@tauri-apps/api/event";
   import { onMount, tick } from "svelte";
@@ -278,7 +279,9 @@
 
     if (await isTauriApp()) {
       const theme = await getTauriTheme();
-      const stored = localStorage.getItem("mode-watcher-mode");
+      // Read-only — mode-watcher owns this key; we just defer to the OS theme
+      // when the user hasn't explicitly picked light/dark.
+      const stored = safeStorage.get<string>("mode-watcher-mode", "");
       if (theme && (!stored || stored === "system")) {
         setMode(theme);
       }

--- a/apps/desktop/src/routes/camera-preview/+page.svelte
+++ b/apps/desktop/src/routes/camera-preview/+page.svelte
@@ -18,6 +18,7 @@
     openCameraStream,
   } from "$lib/camera/browser-devices";
   import {
+    setWindowAspectRatio,
     updateCameraPreviewState,
     validateCameraSource,
     type CameraPreviewState,
@@ -232,17 +233,20 @@
   }
 
   /**
-   * Compute and apply OS-level min/max size constraints based on the
-   * primary screen's available logical dimensions. Called once on mount.
-   * The OS handles drag-resize clamping for free once these are set; the
-   * aspect-snap helpers do their own arithmetic clamp on top so that
-   * programmatic setSize calls (cycling aspect) can't punch past the cap.
+   * Compute and apply OS-level min/max size constraints. The cap is keyed off
+   * the screen's available *width* (`MAX_SCREEN_FRACTION` of it) — every aspect
+   * we offer is landscape-or-square (ratio ≥ 1), so height is always ≤ width
+   * and a square max box of side `0.25·screenW` bounds the window by width
+   * without ever clipping the proportional height. Called once on mount; the
+   * aspect-snap helpers clamp against `maxLogicalW/H` on top so programmatic
+   * setSize calls (cycling aspect) can't punch past the cap.
    */
   async function applySizeConstraints() {
     const screenW = Math.max(window.screen.availWidth || 1920, 320);
-    const screenH = Math.max(window.screen.availHeight || 1080, 320);
-    maxLogicalW = Math.floor(screenW * MAX_SCREEN_FRACTION);
-    maxLogicalH = Math.floor(screenH * MAX_SCREEN_FRACTION);
+    const maxW = Math.floor(screenW * MAX_SCREEN_FRACTION);
+    // Square bounding box: width is the binding limit, height follows aspect.
+    maxLogicalW = maxW;
+    maxLogicalH = maxW;
 
     const win = getCurrentWindow();
     try {
@@ -250,6 +254,34 @@
       await win.setMaxSize(new LogicalSize(maxLogicalW, maxLogicalH));
     } catch (e) {
       console.warn("camera preview size constraints failed:", e);
+    }
+
+    // Install (or refresh) the native aspect lock for the current aspect.
+    void applyNativeAspectLock();
+  }
+
+  /**
+   * Hand the current aspect ratio to the Windows-native WM_SIZING constraint so
+   * the window resizes *proportionally while dragging* — you can't pull width
+   * or height independently, and it won't exceed MAX_SCREEN_FRACTION of the
+   * monitor width. No-op off Windows, where the `snapToAspect` handler below is
+   * the fallback. Re-invoked whenever the aspect changes so the ratio stays in
+   * sync. The drag rect is in physical pixels, so the min crosses as such.
+   */
+  async function applyNativeAspectLock() {
+    try {
+      const ratio = ASPECT_RATIO[aspect];
+      const dpr = window.devicePixelRatio || 1;
+      await setWindowAspectRatio(
+        "camera-preview",
+        ratio,
+        1,
+        MAX_SCREEN_FRACTION,
+        Math.round(MIN_LOGICAL_SIZE * dpr),
+      );
+    } catch (e) {
+      // Non-Windows / older build — the JS snap-to-aspect path still applies.
+      console.warn("native aspect lock unavailable:", e);
     }
   }
 
@@ -280,6 +312,9 @@
     opts: { snap?: boolean } = {},
   ) {
     aspect = next;
+    // Keep the native WM_SIZING ratio in lockstep with the chosen aspect so the
+    // next drag is constrained to the new shape, not the previous one.
+    void applyNativeAspectLock();
     if (opts.snap) {
       const win = getCurrentWindow();
       const size = await win.outerSize();

--- a/apps/desktop/src/routes/camera-preview/+page.svelte
+++ b/apps/desktop/src/routes/camera-preview/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import {
     Circle,
+    FlipHorizontal2,
     LoaderCircle,
     Maximize2,
-    RotateCcw,
     Square,
     Squircle,
     X,
@@ -59,6 +59,16 @@
   // Floor: small enough to tuck into a corner, large enough that the live
   // feed remains intelligible. ~120 logical px ≈ a thumbnail.
   const MIN_LOGICAL_SIZE = 120;
+
+  // Fixed-height strip reserved at the *bottom* of the window for the control
+  // bar. The bar lives outside the rounded/overflow-hidden video bubble so it
+  // never gets clipped by the circle/rounded mask and never sits over the
+  // camera feed. The window is this much taller than the video; the aspect
+  // lock (native + JS) only governs `windowHeight − CONTROL_BAR_HEIGHT`, and
+  // the preview state reports just the video rect so the recorded composite is
+  // unaffected. Keep in sync with the strip height in the markup below and the
+  // initial window height in `openCameraPreviewWindow` (ipc.ts).
+  const CONTROL_BAR_HEIGHT = 40;
 
   // Cached max logical size for the current screen — recomputed on mount and
   // whenever a resize crosses screens. Used by the aspect-snap helpers to
@@ -244,14 +254,24 @@
   async function applySizeConstraints() {
     const screenW = Math.max(window.screen.availWidth || 1920, 320);
     const maxW = Math.floor(screenW * MAX_SCREEN_FRACTION);
-    // Square bounding box: width is the binding limit, height follows aspect.
+    // Square bounding box for the *video*: width is the binding limit, height
+    // follows aspect. `maxLogicalW/H` are video dimensions; the window adds the
+    // control strip on top.
     maxLogicalW = maxW;
     maxLogicalH = maxW;
 
+    // Loosest min height across aspects (the widest, 16:9, gives the shortest
+    // video for a given min width) so the OS floor never out-clamps the native
+    // per-aspect minimum. Window bounds add the control strip.
+    const widestRatio = Math.max(...Object.values(ASPECT_RATIO));
+    const minWinH = Math.round(MIN_LOGICAL_SIZE / widestRatio) + CONTROL_BAR_HEIGHT;
+
     const win = getCurrentWindow();
     try {
-      await win.setMinSize(new LogicalSize(MIN_LOGICAL_SIZE, MIN_LOGICAL_SIZE));
-      await win.setMaxSize(new LogicalSize(maxLogicalW, maxLogicalH));
+      await win.setMinSize(new LogicalSize(MIN_LOGICAL_SIZE, minWinH));
+      await win.setMaxSize(
+        new LogicalSize(maxLogicalW, maxLogicalH + CONTROL_BAR_HEIGHT),
+      );
     } catch (e) {
       console.warn("camera preview size constraints failed:", e);
     }
@@ -278,6 +298,7 @@
         1,
         MAX_SCREEN_FRACTION,
         Math.round(MIN_LOGICAL_SIZE * dpr),
+        Math.round(CONTROL_BAR_HEIGHT * dpr),
       );
     } catch (e) {
       // Non-Windows / older build — the JS snap-to-aspect path still applies.
@@ -319,15 +340,19 @@
       const win = getCurrentWindow();
       const size = await win.outerSize();
       const factor = window.devicePixelRatio || 1;
+      // Window width == video width (no horizontal chrome).
       const widthLogical = size.width / factor;
       const ratio = ASPECT_RATIO[next];
-      const [clampedW, clampedH] = fitInsideMax(
+      const [clampedW, clampedVideoH] = fitInsideMax(
         widthLogical,
         widthLogical / ratio,
         ratio,
       );
       isSnapping = true;
-      await win.setSize(new LogicalSize(clampedW, clampedH));
+      // Window height = video height + control strip.
+      await win.setSize(
+        new LogicalSize(clampedW, clampedVideoH + CONTROL_BAR_HEIGHT),
+      );
       window.setTimeout(() => {
         isSnapping = false;
       }, 50);
@@ -339,18 +364,20 @@
     if (isSnapping) return;
     const factor = window.devicePixelRatio || 1;
     const w = physWidth / factor;
-    const h = physHeight / factor;
+    // Drag deltas arrive as *window* dimensions — peel off the control strip to
+    // get the video box the aspect ratio actually governs.
+    const videoH = physHeight / factor - CONTROL_BAR_HEIGHT;
     const target = ASPECT_RATIO[aspect];
-    const expectedH = w / target;
-    const [clampedW, clampedH] = fitInsideMax(w, expectedH, target);
+    const expectedVideoH = w / target;
+    const [clampedW, clampedVideoH] = fitInsideMax(w, expectedVideoH, target);
     if (
-      Math.abs(clampedH - h) <= 1 &&
+      Math.abs(clampedVideoH - videoH) <= 1 &&
       Math.abs(clampedW - w) <= 1
     ) return;
     isSnapping = true;
     try {
       await getCurrentWindow().setSize(
-        new LogicalSize(clampedW, clampedH),
+        new LogicalSize(clampedW, clampedVideoH + CONTROL_BAR_HEIGHT),
       );
     } finally {
       window.setTimeout(() => {
@@ -419,11 +446,16 @@
     const screenHeight = Math.max(window.screen.availHeight || 1, 1);
 
     const factor = window.devicePixelRatio || 1;
+    // The control strip sits at the *bottom* of the window; the recorded bubble
+    // is just the video region above it. Subtract the strip so the composite
+    // (which uses windowWidth/Height as the bubble rect) matches what's on
+    // screen and isn't stretched by the controls' height.
+    const videoHeightPhys = Math.max(1, size.height - CONTROL_BAR_HEIGHT * factor);
     const widthLogical = size.width / factor;
     // Relative corner radius proportional to shorter side, capped at 0.5
     // (which paints as a full circle on a 1:1 box). Square → 0, circle →
     // 0.5, rounded → WINDOW_RADIUS scaled to fraction-of-shorter-side.
-    const shortLogical = Math.min(widthLogical, size.height / factor);
+    const shortLogical = Math.min(widthLogical, videoHeightPhys / factor);
     const cornerRadius =
       shape === "square"
         ? 0
@@ -436,10 +468,11 @@
       shape,
       cornerRadius,
       animationPreset: status === "warning" ? "lively" : "soft",
+      // Window top == video top (strip is at the bottom), so X/Y are unchanged.
       windowX: Math.max(0, Math.min(1, position.x / screenWidth)),
       windowY: Math.max(0, Math.min(1, position.y / screenHeight)),
       windowWidth: Math.max(0.05, Math.min(1, size.width / screenWidth)),
-      windowHeight: Math.max(0.05, Math.min(1, size.height / screenHeight)),
+      windowHeight: Math.max(0.05, Math.min(1, videoHeightPhys / screenHeight)),
     };
 
     await updateCameraPreviewState(state);
@@ -456,93 +489,111 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <div
-  class="group/root relative h-screen w-full min-w-dvw select-none overflow-hidden bg-card scroll-m-0 scrollbar-none transition-[border-radius] duration-150 ease-out motion-reduce:transition-none"
+  class="group/root relative flex h-screen w-full select-none flex-col scroll-m-0 scrollbar-none"
   data-tauri-drag-region
-  style="border-radius: {cssRadius}"
 >
-  <!-- svelte-ignore a11y_media_has_caption -->
-  <video
-    bind:this={videoEl}
-    autoplay
-    playsinline
-    muted
-    class="pointer-events-none h-full w-full min-w-dvw object-cover"
-    style="transform: {isMirrored ? 'scaleX(-1)' : 'none'}"
-  ></video>
-
-  {#if status !== "live" || errorMessage}
-    <div
-      class="absolute inset-0 flex items-center justify-center bg-background/85 p-4 text-center backdrop-blur-md"
-    >
-      <div class="space-y-2">
-        {#if status === "loading"}
-          <LoaderCircle size={18} class="mx-auto animate-spin text-muted-foreground" />
-        {/if}
-        <p class="text-[11px] font-semibold text-foreground">
-          {status === "failed" ? "Camera unavailable" : "Camera"}
-        </p>
-        <p class="max-w-[16rem] text-[10px] leading-relaxed text-muted-foreground">
-          {errorMessage ?? statusMessage}
-        </p>
-      </div>
-    </div>
-  {/if}
-
+  <!-- Video bubble — the ONLY clipped/rounded surface. `flex-1` makes it
+       exactly the window height minus the control strip below, i.e. the video
+       region the aspect lock governs. Controls live outside it (next sibling)
+       so the rounded/circle mask never eats them. -->
   <div
-    class="pointer-events-none absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-full border border-border-subtle bg-background/78 px-1 py-1 opacity-0 shadow-craft-floating backdrop-blur-3xl transition-opacity duration-200 group-hover/root:pointer-events-auto group-hover/root:opacity-100"
+    class="relative min-h-0 w-full flex-1 overflow-hidden bg-card transition-[border-radius] duration-150 ease-out motion-reduce:transition-none"
+    data-tauri-drag-region
+    style="border-radius: {cssRadius}"
   >
-    <Button
-      onclick={cycleAspect}
-      onmousedown={(e: MouseEvent) => e.stopPropagation()}
-      variant="ghost"
-      size="sm"
-      class="h-6 gap-1 rounded-full px-1.5 font-mono text-[10px] tabular-nums"
-      title="Cycle aspect ratio"
-    >
-      <Maximize2 size={10} strokeWidth={2} />
-      <span>{aspect}</span>
-    </Button>
+    <!-- svelte-ignore a11y_media_has_caption -->
+    <video
+      bind:this={videoEl}
+      autoplay
+      playsinline
+      muted
+      class="pointer-events-none h-full w-full object-cover"
+      style="transform: {isMirrored ? 'scaleX(-1)' : 'none'}"
+    ></video>
 
-    {#snippet shapeIcon()}
-      {@const SIcon = shapeMeta.icon}
-      <SIcon size={11} strokeWidth={2} />
-    {/snippet}
-    <Button
-      onclick={cycleShape}
-      onmousedown={(e: MouseEvent) => e.stopPropagation()}
-      variant="ghost"
-      size="icon-sm"
-      class="size-6 rounded-full"
-      title={aspect === "1:1"
-        ? `Cycle shape: square → rounded → circle (now ${shapeMeta.label})`
-        : `Cycle shape: square ↔ rounded (now ${shapeMeta.label})`}
-    >
-      {@render shapeIcon()}
-    </Button>
+    {#if status !== "live" || errorMessage}
+      <div
+        class="absolute inset-0 flex items-center justify-center bg-background/85 p-4 text-center backdrop-blur-md"
+      >
+        <div class="space-y-2">
+          {#if status === "loading"}
+            <LoaderCircle size={18} class="mx-auto animate-spin text-muted-foreground" />
+          {/if}
+          <p class="text-[11px] font-semibold text-foreground">
+            {status === "failed" ? "Camera unavailable" : "Camera"}
+          </p>
+          <p class="max-w-[16rem] text-[10px] leading-relaxed text-muted-foreground">
+            {errorMessage ?? statusMessage}
+          </p>
+        </div>
+      </div>
+    {/if}
+  </div>
 
-    <Button
-      onclick={toggleMirror}
-      onmousedown={(e: MouseEvent) => e.stopPropagation()}
-      variant={isMirrored ? "default_soft" : "ghost"}
-      size="icon-sm"
-      class="size-6 rounded-full"
-      title={isMirrored ? "Unmirror camera" : "Mirror camera"}
+  <!-- Control strip — fixed-height row BELOW the bubble (outside its overflow),
+       so the pill is never clipped and never overlaps the camera. The window
+       reserves CONTROL_BAR_HEIGHT for it; the pill fades in on hover. -->
+  <div
+    class="flex w-full shrink-0 items-center justify-center"
+    data-tauri-drag-region
+    style="height: {CONTROL_BAR_HEIGHT}px"
+  >
+    <div
+      class="pointer-events-none flex items-center gap-1 rounded-full border border-border-subtle bg-background/78 px-1 py-1 opacity-0 shadow-craft-floating backdrop-blur-3xl transition-opacity duration-200 group-hover/root:pointer-events-auto group-hover/root:opacity-100"
     >
-      <RotateCcw size={11} strokeWidth={2} />
-    </Button>
+      <Button
+        onclick={cycleAspect}
+        onmousedown={(e: MouseEvent) => e.stopPropagation()}
+        variant="ghost"
+        size="sm"
+        class="h-6 gap-1 rounded-full px-1.5 font-mono text-[10px] tabular-nums"
+        title="Cycle aspect ratio"
+      >
+        <Maximize2 size={10} strokeWidth={2} />
+        <span>{aspect}</span>
+      </Button>
 
-    <div class="mx-0.5 h-3 w-px bg-border"></div>
+      {#snippet shapeIcon()}
+        {@const SIcon = shapeMeta.icon}
+        <SIcon size={11} strokeWidth={2} />
+      {/snippet}
+      <Button
+        onclick={cycleShape}
+        onmousedown={(e: MouseEvent) => e.stopPropagation()}
+        variant="ghost"
+        size="icon-sm"
+        class="size-6 rounded-full"
+        title={aspect === "1:1"
+          ? `Cycle shape: square → rounded → circle (now ${shapeMeta.label})`
+          : `Cycle shape: square ↔ rounded (now ${shapeMeta.label})`}
+      >
+        {@render shapeIcon()}
+      </Button>
 
-    <Button
-      onclick={closeWindow}
-      onmousedown={(e: MouseEvent) => e.stopPropagation()}
-      variant="destructive_soft"
-      size="icon-sm"
-      class="size-6 rounded-full"
-      title="Close camera (Esc)"
-    >
-      <X size={11} strokeWidth={2.5} />
-    </Button>
+      <Button
+        onclick={toggleMirror}
+        onmousedown={(e: MouseEvent) => e.stopPropagation()}
+        variant={isMirrored ? "default_soft" : "ghost"}
+        size="icon-sm"
+        class="size-6 rounded-full"
+        title={isMirrored ? "Mirror: on (flip horizontally)" : "Mirror: off"}
+      >
+        <FlipHorizontal2 size={12} strokeWidth={2} />
+      </Button>
+
+      <div class="mx-0.5 h-3 w-px bg-border"></div>
+
+      <Button
+        onclick={closeWindow}
+        onmousedown={(e: MouseEvent) => e.stopPropagation()}
+        variant="destructive_soft"
+        size="icon-sm"
+        class="size-6 rounded-full"
+        title="Close camera (Esc)"
+      >
+        <X size={11} strokeWidth={2.5} />
+      </Button>
+    </div>
   </div>
 </div>
 

--- a/apps/desktop/src/routes/camera-preview/+page.svelte
+++ b/apps/desktop/src/routes/camera-preview/+page.svelte
@@ -56,9 +56,13 @@
   // that size. 25% of either axis is comfortably visible without dominating
   // the frame.
   const MAX_SCREEN_FRACTION = 0.25;
-  // Floor: small enough to tuck into a corner, large enough that the live
-  // feed remains intelligible. ~120 logical px ≈ a thumbnail.
-  const MIN_LOGICAL_SIZE = 120;
+  // Floor on the video width. Small enough to tuck into a corner, but bounded
+  // below by the control bar: the window width equals the video width, and the
+  // controls pill (aspect chip + shape + mirror + close, widest at the "16:9"
+  // label) is ~150px wide. Going narrower than that clipped the centered pill
+  // on both sides, so we floor at a width that always fits it.
+  const CONTROL_BAR_MIN_WIDTH = 168;
+  const MIN_LOGICAL_SIZE = CONTROL_BAR_MIN_WIDTH;
 
   // Fixed-height strip reserved at the *bottom* of the window for the control
   // bar. The bar lives outside the rounded/overflow-hidden video bubble so it

--- a/apps/desktop/src/routes/panel/+page.svelte
+++ b/apps/desktop/src/routes/panel/+page.svelte
@@ -55,11 +55,7 @@
   import { emit, listen } from "@tauri-apps/api/event";
   import { invoke } from "@tauri-apps/api/core";
   import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
-  import {
-    getCurrentWindow,
-    LogicalPosition,
-    LogicalSize,
-  } from "@tauri-apps/api/window";
+  import { getCurrentWindow } from "@tauri-apps/api/window";
   import { onMount } from "svelte";
   import { Tween } from "svelte/motion";
   import { cubicOut } from "svelte/easing";
@@ -115,25 +111,23 @@
   // the *measured* natural width of its content (the same morph technique as
   // ExportFlowDialog) — buttery, rAF-driven, and consistent with the rest of
   // the app's motion. The content declares its own size via `w-fit`; the bar
-  // just follows. The Tauri window is then snapped once to hug the bar so the
-  // desktop behind isn't left with an invisible click-catcher. Idle width
-  // matches the launch size in ipc.ts.
-  const PANEL_W_IDLE = 520;
-  const PANEL_H = 72;
-  const WRAPPER_PAD = 32; // outer px-4 → 16px each side
-  const BAR_W_IDLE = PANEL_W_IDLE - WRAPPER_PAD; // 488
+  // just follows.
+  //
+  // Crucially, the Tauri window is left at its fixed launch size (520×72, sized
+  // in ipc.ts to hug the full idle bar with room for the drop shadow) and is
+  // NOT resized per phase. A centered, always-on-top window can't be resized
+  // and repositioned in a single atomic frame, so snapping it mid-morph made
+  // the bar visibly drift sideways. Instead the bar just morphs *centered
+  // inside the fixed window* — the transparent margins on either side double as
+  // a drag region. This mirrors ExportFlowDialog, which morphs a DOM element
+  // within a fixed viewport and never touches the window.
+  const BAR_W_IDLE = 488;
 
   let barContentEl = $state<HTMLElement | null>(null);
   let measuredBarW = $state(BAR_W_IDLE);
-  const barWidth = new Tween(BAR_W_IDLE, { duration: 320, easing: cubicOut });
+  const barWidth = new Tween(BAR_W_IDLE, { duration: 340, easing: cubicOut });
   // Snap the very first measurement instead of animating from the seed value.
   let barFirstMeasure = true;
-  // The window always hugs the bar (bar width + shadow padding). We grow the
-  // window immediately when the bar is about to expand (so it has room) and
-  // shrink it only after the bar tween settles (so it never clips). This
-  // tracks the last size we applied, and the timer defers the shrink.
-  let lastSyncedWin = PANEL_W_IDLE;
-  let winSyncTimer: ReturnType<typeof setTimeout> | null = null;
   const prefersReducedMotion =
     typeof window !== "undefined" &&
     window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
@@ -157,37 +151,18 @@
 
   $effect(() => {
     if (measuredBarW <= 0) return;
-    const targetWin = measuredBarW + WRAPPER_PAD;
 
     if (barFirstMeasure) {
-      // First paint: size the bar + window to the content with no animation.
+      // First paint: size the bar to the content with no animation.
       barWidth.set(measuredBarW, { duration: 0 });
       barFirstMeasure = false;
-      lastSyncedWin = targetWin;
-      void setPanelWindowWidth(targetWin);
       return;
     }
 
     // Tween the bar to the new measured width (instant under reduced motion).
+    // The window never moves — the bar morphs centered within it.
     if (prefersReducedMotion) barWidth.set(measuredBarW, { duration: 0 });
     else barWidth.target = measuredBarW;
-
-    // Keep the window hugging the bar. Grow now so the bar can expand into the
-    // new space; defer shrink until the tween has settled so nothing clips.
-    if (winSyncTimer) {
-      clearTimeout(winSyncTimer);
-      winSyncTimer = null;
-    }
-    if (targetWin > lastSyncedWin || prefersReducedMotion) {
-      lastSyncedWin = targetWin;
-      void setPanelWindowWidth(targetWin);
-    } else if (targetWin < lastSyncedWin) {
-      winSyncTimer = setTimeout(() => {
-        winSyncTimer = null;
-        lastSyncedWin = targetWin;
-        void setPanelWindowWidth(targetWin);
-      }, 360);
-    }
   });
 
   // Three visual phases. `idle` = full controls; `countdown` = big number +
@@ -428,7 +403,6 @@
     return () => {
       window.clearInterval(timer);
       if (profileFlashTimer) clearTimeout(profileFlashTimer);
-      if (winSyncTimer) clearTimeout(winSyncTimer);
       clearCountdown();
       unlistenSource.then((fn) => fn());
       unlistenDevice.then((fn) => fn());
@@ -730,41 +704,6 @@
     }, 1000);
   }
 
-  /**
-   * Snap the panel window to `to` (logical px) in a single step, keeping it
-   * centered on its current center. Size and position are issued together
-   * (not awaited sequentially) so the backend applies them in one tick — a
-   * centered window can't be resized + repositioned in two visible frames
-   * without hopping, and firing both at once avoids that. This is cosmetic
-   * cleanup of the window bounds *after* the CSS bar-morph has already moved
-   * the visible pixels, so any residual is at most a single frame.
-   */
-  async function setPanelWindowWidth(to: number) {
-    const win = getCurrentWindow();
-    try {
-      const [size, pos, factor] = await Promise.all([
-        win.innerSize(),
-        win.outerPosition(),
-        win.scaleFactor(),
-      ]);
-      const fromW = size.width / factor;
-      const topY = pos.y / factor;
-      const centerX = pos.x / factor + fromW / 2;
-      await Promise.all([
-        win.setSize(new LogicalSize(to, PANEL_H)),
-        win.setPosition(
-          new LogicalPosition(Math.round(centerX - to / 2), Math.round(topY)),
-        ),
-      ]);
-    } catch {
-      try {
-        await win.setSize(new LogicalSize(to, PANEL_H));
-      } catch {
-        /* best effort */
-      }
-    }
-  }
-
   async function toggleRecording() {
     // While counting down, the Record button isn't shown — but a tray toggle
     // or shortcut could still land here; treat it as "cancel the countdown".
@@ -802,8 +741,8 @@
       pausedSince = null;
       emit("camera-recording-stopped");
       emit("refresh-recordings");
-      // Back to "idle" phase — the effect grows the window and expands the bar
-      // back to the full control set.
+      // Back to "idle" phase — the ResizeObserver → Tween effect expands the
+      // bar back out to the full control set (centered in the fixed window).
       isRecording = false;
     }
   }
@@ -835,8 +774,8 @@
       pausedAccumMs = 0;
       pausedSince = null;
       // Flipping to the "recording" phase swaps in the compact transport; the
-      // ResizeObserver → Tween effect collapses the bar and the window follows
-      // it automatically. Nothing to do here.
+      // ResizeObserver → Tween effect collapses the bar (centered in the fixed
+      // window) automatically. Nothing to do here.
       if (cameraOn) {
         emit("camera-recording-started", { startedAtUnixMs: now });
       }
@@ -953,7 +892,7 @@
     node.style.height = `${h}px`;
     node.style.transform = "translate(-50%, -50%)";
     return {
-      duration: 160,
+      duration: 220,
       easing: cubicOut,
       css: (t: number) => `opacity: ${t}`,
     };
@@ -987,7 +926,7 @@
     <div
       class="flex w-fit items-center gap-2.5"
       data-tauri-drag-region
-      in:fade={{ duration: 180, delay: 140, easing: cubicOut }}
+      in:fade={{ duration: 200, delay: 80, easing: cubicOut }}
       out:phaseOut
     >
       <div
@@ -1023,7 +962,7 @@
          Close — crossfaded in and centered by the bar. -->
     <div
       class="flex w-fit items-center gap-1"
-      in:fade={{ duration: 180, delay: 140, easing: cubicOut }}
+      in:fade={{ duration: 200, delay: 80, easing: cubicOut }}
       out:phaseOut
     >
       <ButtonGroup>
@@ -1077,7 +1016,7 @@
     <!-- Idle phase: full control set. Crossfades with the others. -->
     <div
       class="flex w-fit items-center gap-1"
-      in:fade={{ duration: 180, delay: 140, easing: cubicOut }}
+      in:fade={{ duration: 200, delay: 80, easing: cubicOut }}
       out:phaseOut
     >
       <!-- Drag handle: explicit affordance for moving the panel. The whole

--- a/apps/desktop/src/routes/panel/+page.svelte
+++ b/apps/desktop/src/routes/panel/+page.svelte
@@ -54,8 +54,9 @@
   import { emit, listen } from "@tauri-apps/api/event";
   import { invoke } from "@tauri-apps/api/core";
   import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
-  import { getCurrentWindow } from "@tauri-apps/api/window";
+  import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
   import { onMount } from "svelte";
+  import { fade } from "svelte/transition";
 
   // The panel window is too small to host its own Sonner Toaster; the
   // main window's layout listens for `ui:toast` events and renders
@@ -88,6 +89,33 @@
   let isRecording = $state(false);
   let recordingStartTime: number | null = $state(null);
   let now = $state(Date.now());
+
+  // Countdown-before-recording. `countdownSeconds` is the user's setting
+  // (Settings → Recording, or a profile override), mirrored from localStorage.
+  // `countdownValue` is the live tick — non-null only while counting down, so
+  // it drives the transient "countdown" panel phase between the Record click
+  // and the real capture start.
+  const COUNTDOWN_KEY = "recast-recording-countdown";
+  let countdownSeconds = $state(3);
+  let countdownValue = $state<number | null>(null);
+  let countdownInterval: ReturnType<typeof setInterval> | null = null;
+
+  // Panel window dimensions. Idle shows the full control set (matches the
+  // launch size in ipc.ts); while recording we collapse to just
+  // Stop+timer / Pause / Close and shrink the window to fit so the rest of
+  // the bar isn't an invisible click-catcher over the desktop.
+  const PANEL_W_IDLE = 520;
+  const PANEL_W_RECORDING = 224;
+  const PANEL_H = 72;
+  // Monotonic token so a newer width animation cancels any in-flight one.
+  let widthAnimToken = 0;
+
+  // Three visual phases. `idle` = full controls; `countdown` = big number +
+  // cancel; `recording` = collapsed transport. Derived so the markup can
+  // switch on a single value.
+  const phase = $derived<"idle" | "countdown" | "recording">(
+    isRecording ? "recording" : countdownValue !== null ? "countdown" : "idle",
+  );
 
   // Mirror the recording flag to the system tray so its "Start/Stop
   // Recording" label and any tray-driven UX stays accurate. Best-effort:
@@ -196,6 +224,15 @@
     const timer = window.setInterval(() => {
       if (isRecording) now = Date.now();
     }, 1000);
+
+    // Countdown setting, mirrored from localStorage. Re-read on `storage`
+    // events so changing it in the Settings window updates the panel live
+    // (Tauri webviews share a localStorage origin), without a relaunch.
+    readCountdownSetting();
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === COUNTDOWN_KEY) readCountdownSetting();
+    };
+    window.addEventListener("storage", onStorage);
 
     const unlistenSource = listen<TargetSource>("source-selected", (event) => {
       selectedSource = event.payload;
@@ -320,6 +357,8 @@
     return () => {
       window.clearInterval(timer);
       if (profileFlashTimer) clearTimeout(profileFlashTimer);
+      clearCountdown();
+      window.removeEventListener("storage", onStorage);
       unlistenSource.then((fn) => fn());
       unlistenDevice.then((fn) => fn());
       unlistenProfile.then((fn) => fn());
@@ -440,6 +479,14 @@
   }
 
   function handleGlobalShortcut(e: KeyboardEvent) {
+    // Esc aborts an in-progress countdown.
+    if (countdownValue !== null) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        cancelCountdown();
+      }
+      return;
+    }
     if (isRecording) return;
     const meta = e.metaKey || e.ctrlKey;
     if (!meta || e.shiftKey || e.altKey) return;
@@ -574,71 +621,176 @@
     }
   }
 
-  async function toggleRecording() {
-    if (isRecording) {
-      try {
-        await stopRecording();
-      } catch (e) {
-        // Show the actual error, not a misleading "ffmpeg not installed"
-        // suffix. By the time stop runs, start has already succeeded —
-        // FFmpeg was available, so a stop failure is something else
-        // (encoder thread panic, disk full, codec mismatch in the
-        // bundled binary, etc.). Misattributing to FFmpeg sent users
-        // chasing missing-binary red herrings on bundles where FFmpeg
-        // was actually present.
-        notify("error", `Stop failed: ${e}`, 10000);
-      } finally {
-        // ALWAYS reset client-side state, even on stop failure. The Rust
-        // `RecordingManager::stop()` does `guard.take()` as its first
-        // operation — once that succeeds, the session is gone from the
-        // manager regardless of what later fails. Leaving `isRecording`
-        // stuck at `true` traps the user into clicking Stop again, which
-        // then errors with "recording is not running" because the session
-        // is already gone. Resetting here lets the user start a new
-        // recording immediately.
-        isRecording = false;
-        recordingStartTime = null;
-        isPaused = false;
-        pausedAccumMs = 0;
-        pausedSince = null;
-        emit("camera-recording-stopped");
-        emit("refresh-recordings");
+  function readCountdownSetting() {
+    try {
+      const raw = localStorage.getItem(COUNTDOWN_KEY);
+      const n = raw !== null ? Number.parseInt(raw, 10) : 3;
+      countdownSeconds = n === 0 || n === 3 || n === 5 || n === 10 ? n : 3;
+    } catch {
+      countdownSeconds = 3;
+    }
+  }
+
+  function clearCountdown() {
+    if (countdownInterval) {
+      clearInterval(countdownInterval);
+      countdownInterval = null;
+    }
+    countdownValue = null;
+  }
+
+  function cancelCountdown() {
+    clearCountdown();
+  }
+
+  /**
+   * Start path for the Record button. With a countdown configured, tick it
+   * down in the panel first (cancelable via Esc or the Cancel button), then
+   * fire the real capture. With countdown off, start immediately.
+   */
+  function beginRecording() {
+    if (!selectedSource || isRecording || countdownValue !== null) return;
+    if (countdownSeconds <= 0) {
+      void startActualRecording();
+      return;
+    }
+    countdownValue = countdownSeconds;
+    countdownInterval = setInterval(() => {
+      if (countdownValue === null) return;
+      countdownValue -= 1;
+      if (countdownValue <= 0) {
+        clearCountdown();
+        void startActualRecording();
       }
-    } else {
-      if (!selectedSource) return;
-      const options: RecordingOptions = {
-        systemAudio: systemAudioOn,
-        microphone: micOn,
-        microphoneDeviceId: micOn ? selectedMicId : null,
-        camera: cameraOn,
-        // Rust feeds this directly to FFmpeg dshow as a DirectShow friendly
-        // name — pass the label, not the browser deviceId hash.
-        cameraDeviceId: cameraOn ? selectedCameraName : null,
+    }, 1000);
+  }
+
+  /**
+   * Animate the panel window's width to `to` (logical px) with an eased rAF
+   * tween. Shrinks from the right (top-left origin fixed) so the collapsed
+   * controls — which are left-packed during recording — stay put while the
+   * empty space folds away. Honors prefers-reduced-motion by snapping.
+   */
+  async function animatePanelWidth(to: number) {
+    const win = getCurrentWindow();
+    const token = ++widthAnimToken;
+
+    const reduce =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    if (reduce) {
+      await win.setSize(new LogicalSize(to, PANEL_H)).catch(() => {});
+      return;
+    }
+
+    let from = to;
+    try {
+      const [size, factor] = await Promise.all([
+        win.innerSize(),
+        win.scaleFactor(),
+      ]);
+      from = size.width / factor;
+    } catch {
+      /* fall back to a snap if we can't read the current size */
+    }
+    if (token !== widthAnimToken) return;
+    if (Math.round(from) === Math.round(to)) return;
+
+    const duration = 300;
+    const start = performance.now();
+    await new Promise<void>((resolve) => {
+      const frame = (t: number) => {
+        if (token !== widthAnimToken) return resolve();
+        const p = Math.min(1, (t - start) / duration);
+        const eased = 1 - Math.pow(1 - p, 3); // cubicOut, matches morph.ts
+        const w = Math.round(from + (to - from) * eased);
+        win.setSize(new LogicalSize(w, PANEL_H)).catch(() => {});
+        if (p < 1) requestAnimationFrame(frame);
+        else resolve();
       };
-      try {
-        const result = await startRecording(
-          selectedSource.type,
-          selectedSource.id,
-          options,
-          selectedSource.type === "region" && selectedSource.region
-            ? selectedSource.region
-            : null,
-        );
-        isRecording = true;
-        now = Date.now();
-        recordingStartTime = now;
-        isPaused = false;
-        pausedAccumMs = 0;
-        pausedSince = null;
-        if (cameraOn) {
-          emit("camera-recording-started", { startedAtUnixMs: now });
-        }
-        if (result.warnings.length > 0) {
-          notify("warning", result.warnings.join("\n"), 8000);
-        }
-      } catch (e) {
-        notify("error", `Recording failed: ${e}`, 10000);
+      requestAnimationFrame(frame);
+    });
+  }
+
+  async function toggleRecording() {
+    // While counting down, the Record button isn't shown — but a tray toggle
+    // or shortcut could still land here; treat it as "cancel the countdown".
+    if (countdownValue !== null) {
+      cancelCountdown();
+      return;
+    }
+    if (!isRecording) {
+      beginRecording();
+      return;
+    }
+    try {
+      await stopRecording();
+    } catch (e) {
+      // Show the actual error, not a misleading "ffmpeg not installed"
+      // suffix. By the time stop runs, start has already succeeded —
+      // FFmpeg was available, so a stop failure is something else
+      // (encoder thread panic, disk full, codec mismatch in the
+      // bundled binary, etc.). Misattributing to FFmpeg sent users
+      // chasing missing-binary red herrings on bundles where FFmpeg
+      // was actually present.
+      notify("error", `Stop failed: ${e}`, 10000);
+    } finally {
+      // ALWAYS reset client-side state, even on stop failure. The Rust
+      // `RecordingManager::stop()` does `guard.take()` as its first
+      // operation — once that succeeds, the session is gone from the
+      // manager regardless of what later fails. Leaving `isRecording`
+      // stuck at `true` traps the user into clicking Stop again, which
+      // then errors with "recording is not running" because the session
+      // is already gone. Resetting here lets the user start a new
+      // recording immediately.
+      isRecording = false;
+      recordingStartTime = null;
+      isPaused = false;
+      pausedAccumMs = 0;
+      pausedSince = null;
+      emit("camera-recording-stopped");
+      emit("refresh-recordings");
+      // Expand the panel back to its full control set.
+      void animatePanelWidth(PANEL_W_IDLE);
+    }
+  }
+
+  async function startActualRecording() {
+    if (!selectedSource) return;
+    const options: RecordingOptions = {
+      systemAudio: systemAudioOn,
+      microphone: micOn,
+      microphoneDeviceId: micOn ? selectedMicId : null,
+      camera: cameraOn,
+      // Rust feeds this directly to FFmpeg dshow as a DirectShow friendly
+      // name — pass the label, not the browser deviceId hash.
+      cameraDeviceId: cameraOn ? selectedCameraName : null,
+    };
+    try {
+      const result = await startRecording(
+        selectedSource.type,
+        selectedSource.id,
+        options,
+        selectedSource.type === "region" && selectedSource.region
+          ? selectedSource.region
+          : null,
+      );
+      isRecording = true;
+      now = Date.now();
+      recordingStartTime = now;
+      isPaused = false;
+      pausedAccumMs = 0;
+      pausedSince = null;
+      // Collapse the panel to the compact recording transport.
+      void animatePanelWidth(PANEL_W_RECORDING);
+      if (cameraOn) {
+        emit("camera-recording-started", { startedAtUnixMs: now });
       }
+      if (result.warnings.length > 0) {
+        notify("warning", result.warnings.join("\n"), 8000);
+      }
+    } catch (e) {
+      notify("error", `Recording failed: ${e}`, 10000);
     }
   }
 
@@ -754,6 +906,42 @@
     <GripVertical size={12} strokeWidth={2} class="pointer-events-none" />
   </div>
 
+  {#if phase === "countdown"}
+    <!-- Countdown phase: big ticking number + Cancel, in place of the full
+         control set. The panel stays full-width here; it only collapses once
+         capture actually starts. Esc also cancels (see handleGlobalShortcut). -->
+    <div
+      class="flex w-full items-center gap-2.5 pr-1"
+      data-tauri-drag-region
+      in:fade={{ duration: 120 }}
+    >
+      <div
+        class="relative flex size-7 shrink-0 items-center justify-center"
+        aria-live="assertive"
+      >
+        <span class="absolute inset-0 rounded-full ring-2 ring-primary/25"></span>
+        <span
+          class="font-mono text-[15px] font-bold leading-none tabular-nums text-primary"
+        >
+          {countdownValue}
+        </span>
+      </div>
+      <span class="text-[12px] font-semibold tracking-tight text-foreground/80">
+        Starting in {countdownValue}s…
+      </span>
+      <Button
+        onclick={cancelCountdown}
+        onmousedown={(e: MouseEvent) => e.stopPropagation()}
+        size="sm"
+        variant="ghost"
+        class="ml-auto h-7 gap-1.5"
+        title="Cancel (Esc)"
+      >
+        <X size={12} strokeWidth={2.5} class="text-destructive" />
+        <span class="text-[11px] font-semibold">Cancel</span>
+      </Button>
+    </div>
+  {:else}
   <ButtonGroup>
     <!-- Record / Stop -->
     <Button
@@ -803,7 +991,9 @@
     {/if}
   </ButtonGroup>
 
-  <!-- Source -->
+  <!-- Source. Hidden once recording starts — the source is locked in, so the
+       selector just takes space; dropping it is part of the collapse. -->
+  {#if !isRecording}
   <Button
     size="sm"
     disabled={isRecording}
@@ -811,6 +1001,7 @@
     onmousedown={(e: MouseEvent) => e.stopPropagation()}
     variant="ghost"
     class="group/source hover:scale-none"
+    out:fade={{ duration: 120 }}
   >
     {#if selectedSource?.type === "window"}
       <AppWindow
@@ -844,8 +1035,18 @@
       />
     {/if}
   </Button>
+  {/if}
 
-  <div class="shrink-0 px-1 ml-auto inline-flex items-center gap-1">
+  <!-- Right cluster. While recording, the profile switcher and device toggles
+       are hidden and `ml-auto` is dropped so the remaining Close button packs
+       in tight next to the transport — the panel collapses to just the
+       essentials. -->
+  <div
+    class="shrink-0 px-1 inline-flex items-center gap-1"
+    class:ml-auto={!isRecording}
+  >
+    {#if !isRecording}
+    <div class="inline-flex items-center gap-1" out:fade={{ duration: 120 }}>
     <!-- Profile switcher button. Opens a separate Tauri window (like the
          device-pickers) instead of a popover — the panel window is too
          short to host an in-place dropdown without changing its height,
@@ -940,6 +1141,8 @@
         {/if}
       </Button>
     </ButtonGroup>
+    </div>
+    {/if}
     <!-- Close -->
     <Button
       onclick={closePanel}
@@ -951,5 +1154,6 @@
       <X size={10} strokeWidth={2} class="shrink-0 text-destructive" />
     </Button>
   </div>
+  {/if}
 </div>
 </div>

--- a/apps/desktop/src/routes/panel/+page.svelte
+++ b/apps/desktop/src/routes/panel/+page.svelte
@@ -50,6 +50,7 @@
   } from "@lucide/svelte";
   import { Button } from "@recast/ui/button";
   import { ButtonGroup } from "@recast/ui/button-group";
+  import { recordingCountdown } from "$lib/stores/recording-countdown.svelte";
   import { ask } from "@tauri-apps/plugin-dialog";
   import { emit, listen } from "@tauri-apps/api/event";
   import { invoke } from "@tauri-apps/api/core";
@@ -60,7 +61,9 @@
     LogicalSize,
   } from "@tauri-apps/api/window";
   import { onMount } from "svelte";
-  import { fade } from "svelte/transition";
+  import { Tween } from "svelte/motion";
+  import { cubicOut } from "svelte/easing";
+  import { fade, scale } from "svelte/transition";
 
   // The panel window is too small to host its own Sonner Toaster; the
   // main window's layout listens for `ui:toast` events and renders
@@ -94,28 +97,98 @@
   let recordingStartTime: number | null = $state(null);
   let now = $state(Date.now());
 
-  // Countdown-before-recording. `globalCountdown` mirrors the Settings →
-  // Recording value from localStorage; `profileCountdownOverride` is set when a
-  // profile with its own countdown is applied (null = inherit). The effective
-  // `countdownSeconds` prefers the profile override. `countdownValue` is the
-  // live tick — non-null only while counting down, driving the transient
-  // "countdown" panel phase between the Record click and real capture start.
-  const COUNTDOWN_KEY = "recast-recording-countdown";
-  let globalCountdown = $state(3);
+  // Countdown-before-recording. The global value comes from the shared
+  // `recordingCountdown` store (kept in sync with the Settings window for free);
+  // `profileCountdownOverride` is set when a profile with its own countdown is
+  // applied (null = inherit). The effective `countdownSeconds` prefers the
+  // profile override. `countdownValue` is the live tick — non-null only while
+  // counting down, driving the transient "countdown" panel phase between the
+  // Record click and real capture start.
   let profileCountdownOverride = $state<number | null>(null);
-  const countdownSeconds = $derived(profileCountdownOverride ?? globalCountdown);
+  const countdownSeconds = $derived(
+    profileCountdownOverride ?? recordingCountdown.value,
+  );
   let countdownValue = $state<number | null>(null);
   let countdownInterval: ReturnType<typeof setInterval> | null = null;
 
-  // Panel window dimensions. Idle shows the full control set (matches the
-  // launch size in ipc.ts); while recording we collapse to just
-  // Stop+timer / Pause / Close and shrink the window to fit so the rest of
-  // the bar isn't an invisible click-catcher over the desktop.
+  // Panel sizing. The bar's width is driven by a Svelte `Tween` that follows
+  // the *measured* natural width of its content (the same morph technique as
+  // ExportFlowDialog) — buttery, rAF-driven, and consistent with the rest of
+  // the app's motion. The content declares its own size via `w-fit`; the bar
+  // just follows. The Tauri window is then snapped once to hug the bar so the
+  // desktop behind isn't left with an invisible click-catcher. Idle width
+  // matches the launch size in ipc.ts.
   const PANEL_W_IDLE = 520;
-  const PANEL_W_RECORDING = 224;
   const PANEL_H = 72;
-  // Monotonic token so a newer width animation cancels any in-flight one.
-  let widthAnimToken = 0;
+  const WRAPPER_PAD = 32; // outer px-4 → 16px each side
+  const BAR_W_IDLE = PANEL_W_IDLE - WRAPPER_PAD; // 488
+
+  let barContentEl = $state<HTMLElement | null>(null);
+  let measuredBarW = $state(BAR_W_IDLE);
+  const barWidth = new Tween(BAR_W_IDLE, { duration: 320, easing: cubicOut });
+  // Snap the very first measurement instead of animating from the seed value.
+  let barFirstMeasure = true;
+  // The window always hugs the bar (bar width + shadow padding). We grow the
+  // window immediately when the bar is about to expand (so it has room) and
+  // shrink it only after the bar tween settles (so it never clips). This
+  // tracks the last size we applied, and the timer defers the shrink.
+  let lastSyncedWin = PANEL_W_IDLE;
+  let winSyncTimer: ReturnType<typeof setTimeout> | null = null;
+  const prefersReducedMotion =
+    typeof window !== "undefined" &&
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
+  // Watch the content's natural width and tween the bar to match. Uses the
+  // border box (includes the content's own padding) so the bar wraps it
+  // exactly, and rounds to whole px so sub-pixel jitter can't retrigger.
+  $effect(() => {
+    if (!barContentEl) return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const w = Math.round(
+        entry.borderBoxSize?.[0]?.inlineSize ?? entry.contentRect.width,
+      );
+      if (w > 0) measuredBarW = w;
+    });
+    ro.observe(barContentEl);
+    return () => ro.disconnect();
+  });
+
+  $effect(() => {
+    if (measuredBarW <= 0) return;
+    const targetWin = measuredBarW + WRAPPER_PAD;
+
+    if (barFirstMeasure) {
+      // First paint: size the bar + window to the content with no animation.
+      barWidth.set(measuredBarW, { duration: 0 });
+      barFirstMeasure = false;
+      lastSyncedWin = targetWin;
+      void setPanelWindowWidth(targetWin);
+      return;
+    }
+
+    // Tween the bar to the new measured width (instant under reduced motion).
+    if (prefersReducedMotion) barWidth.set(measuredBarW, { duration: 0 });
+    else barWidth.target = measuredBarW;
+
+    // Keep the window hugging the bar. Grow now so the bar can expand into the
+    // new space; defer shrink until the tween has settled so nothing clips.
+    if (winSyncTimer) {
+      clearTimeout(winSyncTimer);
+      winSyncTimer = null;
+    }
+    if (targetWin > lastSyncedWin || prefersReducedMotion) {
+      lastSyncedWin = targetWin;
+      void setPanelWindowWidth(targetWin);
+    } else if (targetWin < lastSyncedWin) {
+      winSyncTimer = setTimeout(() => {
+        winSyncTimer = null;
+        lastSyncedWin = targetWin;
+        void setPanelWindowWidth(targetWin);
+      }, 360);
+    }
+  });
 
   // Three visual phases. `idle` = full controls; `countdown` = big number +
   // cancel; `recording` = collapsed transport. Derived so the markup can
@@ -231,15 +304,6 @@
     const timer = window.setInterval(() => {
       if (isRecording) now = Date.now();
     }, 1000);
-
-    // Countdown setting, mirrored from localStorage. Re-read on `storage`
-    // events so changing it in the Settings window updates the panel live
-    // (Tauri webviews share a localStorage origin), without a relaunch.
-    readCountdownSetting();
-    const onStorage = (e: StorageEvent) => {
-      if (e.key === COUNTDOWN_KEY) readCountdownSetting();
-    };
-    window.addEventListener("storage", onStorage);
 
     const unlistenSource = listen<TargetSource>("source-selected", (event) => {
       selectedSource = event.payload;
@@ -364,8 +428,8 @@
     return () => {
       window.clearInterval(timer);
       if (profileFlashTimer) clearTimeout(profileFlashTimer);
+      if (winSyncTimer) clearTimeout(winSyncTimer);
       clearCountdown();
-      window.removeEventListener("storage", onStorage);
       unlistenSource.then((fn) => fn());
       unlistenDevice.then((fn) => fn());
       unlistenProfile.then((fn) => fn());
@@ -632,16 +696,6 @@
     }
   }
 
-  function readCountdownSetting() {
-    try {
-      const raw = localStorage.getItem(COUNTDOWN_KEY);
-      const n = raw !== null ? Number.parseInt(raw, 10) : 3;
-      globalCountdown = n === 0 || n === 3 || n === 5 || n === 10 ? n : 3;
-    } catch {
-      globalCountdown = 3;
-    }
-  }
-
   function clearCountdown() {
     if (countdownInterval) {
       clearInterval(countdownInterval);
@@ -677,66 +731,38 @@
   }
 
   /**
-   * Animate the panel window's width to `to` (logical px) with an eased rAF
-   * tween, keeping the panel centered on its current center (so it collapses
-   * symmetrically toward the middle rather than drifting to one edge). Honors
-   * prefers-reduced-motion by snapping. A monotonic token cancels any
-   * in-flight tween if a newer one starts.
+   * Snap the panel window to `to` (logical px) in a single step, keeping it
+   * centered on its current center. Size and position are issued together
+   * (not awaited sequentially) so the backend applies them in one tick — a
+   * centered window can't be resized + repositioned in two visible frames
+   * without hopping, and firing both at once avoids that. This is cosmetic
+   * cleanup of the window bounds *after* the CSS bar-morph has already moved
+   * the visible pixels, so any residual is at most a single frame.
    */
-  async function animatePanelWidth(to: number) {
+  async function setPanelWindowWidth(to: number) {
     const win = getCurrentWindow();
-    const token = ++widthAnimToken;
-
-    // Current logical width + center, so we can hold the center fixed and
-    // resolve the next top-left as the width changes.
-    let from = to;
-    let centerX: number | null = null;
-    let topY: number | null = null;
     try {
       const [size, pos, factor] = await Promise.all([
         win.innerSize(),
         win.outerPosition(),
         win.scaleFactor(),
       ]);
-      from = size.width / factor;
-      const leftX = pos.x / factor;
-      topY = pos.y / factor;
-      centerX = leftX + from / 2;
+      const fromW = size.width / factor;
+      const topY = pos.y / factor;
+      const centerX = pos.x / factor + fromW / 2;
+      await Promise.all([
+        win.setSize(new LogicalSize(to, PANEL_H)),
+        win.setPosition(
+          new LogicalPosition(Math.round(centerX - to / 2), Math.round(topY)),
+        ),
+      ]);
     } catch {
-      /* fall back to a plain snap below if we can't read geometry */
-    }
-    if (token !== widthAnimToken) return;
-
-    const apply = (w: number) => {
-      win.setSize(new LogicalSize(w, PANEL_H)).catch(() => {});
-      if (centerX !== null && topY !== null) {
-        win
-          .setPosition(new LogicalPosition(Math.round(centerX - w / 2), Math.round(topY)))
-          .catch(() => {});
+      try {
+        await win.setSize(new LogicalSize(to, PANEL_H));
+      } catch {
+        /* best effort */
       }
-    };
-
-    const reduce =
-      typeof window !== "undefined" &&
-      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
-    if (reduce || Math.round(from) === Math.round(to)) {
-      apply(to);
-      return;
     }
-
-    const duration = 300;
-    const start = performance.now();
-    await new Promise<void>((resolve) => {
-      const frame = (t: number) => {
-        if (token !== widthAnimToken) return resolve();
-        const p = Math.min(1, (t - start) / duration);
-        const eased = 1 - Math.pow(1 - p, 3); // cubicOut, matches morph.ts
-        apply(Math.round(from + (to - from) * eased));
-        if (p < 1) requestAnimationFrame(frame);
-        else resolve();
-      };
-      requestAnimationFrame(frame);
-    });
   }
 
   async function toggleRecording() {
@@ -770,15 +796,15 @@
       // then errors with "recording is not running" because the session
       // is already gone. Resetting here lets the user start a new
       // recording immediately.
-      isRecording = false;
       recordingStartTime = null;
       isPaused = false;
       pausedAccumMs = 0;
       pausedSince = null;
       emit("camera-recording-stopped");
       emit("refresh-recordings");
-      // Expand the panel back to its full control set.
-      void animatePanelWidth(PANEL_W_IDLE);
+      // Back to "idle" phase — the effect grows the window and expands the bar
+      // back to the full control set.
+      isRecording = false;
     }
   }
 
@@ -808,8 +834,9 @@
       isPaused = false;
       pausedAccumMs = 0;
       pausedSince = null;
-      // Collapse the panel to the compact recording transport.
-      void animatePanelWidth(PANEL_W_RECORDING);
+      // Flipping to the "recording" phase swaps in the compact transport; the
+      // ResizeObserver → Tween effect collapses the bar and the window follows
+      // it automatically. Nothing to do here.
       if (cameraOn) {
         emit("camera-recording-started", { startedAtUnixMs: now });
       }
@@ -907,6 +934,30 @@
       .toString()
       .padStart(2, "0")}:${(elapsed % 60).toString().padStart(2, "0")}`,
   );
+
+  // Out-transition for a leaving phase block: pin it absolute at its current
+  // size so it no longer contributes to the content's measured width while it
+  // fades. The entering block sits in normal flow, so ResizeObserver reports
+  // the *new* width immediately and the bar Tween animates to it concurrent
+  // with the crossfade. Mirrors ExportFlowDialog's `phaseOut`.
+  function phaseOut(node: HTMLElement) {
+    const w = node.offsetWidth;
+    const h = node.offsetHeight;
+    // Pin centered (not top-left) so that as the bar morphs to the smaller
+    // incoming phase, the leaving phase clips/fades symmetrically from the
+    // center instead of appearing to shift to the left.
+    node.style.position = "absolute";
+    node.style.left = "50%";
+    node.style.top = "50%";
+    node.style.width = `${w}px`;
+    node.style.height = `${h}px`;
+    node.style.transform = "translate(-50%, -50%)";
+    return {
+      duration: 160,
+      easing: cubicOut,
+      css: (t: number) => `opacity: ${t}`,
+    };
+  }
 </script>
 
 <!-- Outer wrapper: fills the (oversized) Tauri window. Padding gives the
@@ -918,29 +969,26 @@
   data-tauri-drag-region
 >
 <div
-  class="group/panel relative flex h-11 overflow-hidden no-scrollbar w-full items-center gap-1 bg-card/95 p-2 pl-1 backdrop-blur-3xl border border-border/60 rounded-lg ring-1 ring-foreground/5"
+  class="group/panel relative flex h-11 shrink-0 items-center justify-center overflow-hidden no-scrollbar bg-card/95 backdrop-blur-xl border border-border/60 rounded-lg ring-1 ring-foreground/5"
+  style="width: {barWidth.current}px"
   data-tauri-drag-region
 >
-  <!-- Drag handle: explicit affordance for moving the panel. The whole bar
-       is a Tauri drag region, but users don't know that without a visible
-       grip. Hover lifts opacity so it doesn't compete visually at rest. -->
+  <!-- Content declares its own natural width (`w-fit`); the bar's width is a
+       Tween that follows it via ResizeObserver, so collapse/expand is one
+       smooth motion. The bar centers this content, so it morphs symmetrically. -->
   <div
+    bind:this={barContentEl}
+    class="relative flex w-fit shrink-0 items-center justify-center gap-1 p-2"
     data-tauri-drag-region
-    class="flex h-7 w-4 shrink-0 cursor-grab items-center justify-center rounded text-muted-foreground/40 transition-colors hover:bg-muted/40 hover:text-muted-foreground active:cursor-grabbing"
-    title="Drag to move"
-    aria-label="Drag panel"
   >
-    <GripVertical size={12} strokeWidth={2} class="pointer-events-none" />
-  </div>
-
   {#if phase === "countdown"}
-    <!-- Countdown phase: big ticking number + Cancel, in place of the full
-         control set. The panel stays full-width here; it only collapses once
-         capture actually starts. Esc also cancels (see handleGlobalShortcut). -->
+    <!-- Countdown phase: ring + ticking number + Cancel. Crossfades with the
+         other phases; the bar Tween follows its natural width. -->
     <div
-      class="flex w-full items-center gap-2.5 pr-1"
+      class="flex w-fit items-center gap-2.5"
       data-tauri-drag-region
-      in:fade={{ duration: 120 }}
+      in:fade={{ duration: 180, delay: 140, easing: cubicOut }}
+      out:phaseOut
     >
       <div
         class="relative flex size-7 shrink-0 items-center justify-center"
@@ -953,7 +1001,9 @@
           {countdownValue}
         </span>
       </div>
-      <span class="text-[12px] font-semibold tracking-tight text-foreground/80">
+      <span
+        class="shrink-0 whitespace-nowrap text-[12px] font-semibold tracking-tight text-foreground/80"
+      >
         Starting in {countdownValue}s…
       </span>
       <Button
@@ -961,62 +1011,96 @@
         onmousedown={(e: MouseEvent) => e.stopPropagation()}
         size="sm"
         variant="ghost"
-        class="ml-auto h-7 gap-1.5"
+        class="h-7 gap-1.5"
         title="Cancel (Esc)"
       >
         <X size={12} strokeWidth={2.5} class="text-destructive" />
         <span class="text-[11px] font-semibold">Cancel</span>
       </Button>
     </div>
-  {:else}
-  <ButtonGroup>
-    <!-- Record / Stop -->
-    <Button
-      onclick={toggleRecording}
-      onmousedown={(e: MouseEvent) => e.stopPropagation()}
-      size={isRecording ? "sm" : "icon-sm"}
-      variant={isRecording ? "destructive" : "default"}
-      title={isRecording ? "Stop Recording" : "Start Recording"}
+  {:else if phase === "recording"}
+    <!-- Recording phase: compact transport — soft-red Stop+timer, Pause,
+         Close — crossfaded in and centered by the bar. -->
+    <div
+      class="flex w-fit items-center gap-1"
+      in:fade={{ duration: 180, delay: 140, easing: cubicOut }}
+      out:phaseOut
     >
-      {#if isRecording}
-        <Square
-          size={12}
-          strokeWidth={0}
-          fill="currentColor"
-          class="animate-pulse"
-        />
-      {:else}
-        <Circle size={14} strokeWidth={0} fill="currentColor" />
-      {/if}
-      {#if isRecording}
-        <span
-          class="shrink-0 font-mono text-[13px] font-semibold tabular-nums tracking-tight"
-          class:text-foreground={!isPaused}
-          class:text-muted-foreground={isPaused}
-          data-tauri-drag-region
+      <ButtonGroup>
+        <Button
+          onclick={toggleRecording}
+          onmousedown={(e: MouseEvent) => e.stopPropagation()}
+          size="sm"
+          variant="destructive_soft"
+          title="Stop Recording"
         >
-          {timer}
-        </span>
-      {/if}
-    </Button>
-
-    <!-- Pause / Resume -->
-    {#if isRecording}
+          <Square
+            size={11}
+            strokeWidth={0}
+            fill="currentColor"
+            class="animate-pulse text-destructive"
+          />
+          <span
+            class="shrink-0 font-mono text-[13px] font-semibold tabular-nums tracking-tight"
+            class:text-foreground={!isPaused}
+            class:text-muted-foreground={isPaused}
+            data-tauri-drag-region
+          >
+            {timer}
+          </span>
+        </Button>
+        <Button
+          onclick={togglePause}
+          onmousedown={(e: MouseEvent) => e.stopPropagation()}
+          size="icon-sm"
+          variant={isPaused ? "success_soft" : "secondary"}
+          title={isPaused ? "Resume Recording" : "Pause Recording"}
+        >
+          {#if isPaused}
+            <Play size={13} strokeWidth={0} fill="currentColor" />
+          {:else}
+            <Pause size={13} strokeWidth={0} fill="currentColor" />
+          {/if}
+        </Button>
+      </ButtonGroup>
       <Button
-        onclick={togglePause}
+        onclick={closePanel}
+        onmousedown={(e: MouseEvent) => e.stopPropagation()}
+        title="Close"
+        size="icon-sm"
+        variant="ghost"
+      >
+        <X size={10} strokeWidth={2} class="shrink-0 text-destructive" />
+      </Button>
+    </div>
+  {:else}
+    <!-- Idle phase: full control set. Crossfades with the others. -->
+    <div
+      class="flex w-fit items-center gap-1"
+      in:fade={{ duration: 180, delay: 140, easing: cubicOut }}
+      out:phaseOut
+    >
+      <!-- Drag handle: explicit affordance for moving the panel. The whole
+           bar is a Tauri drag region, but the grip makes that discoverable. -->
+      <div
+        data-tauri-drag-region
+        class="flex h-7 w-4 shrink-0 cursor-grab items-center justify-center rounded text-muted-foreground/40 transition-colors hover:bg-muted/40 hover:text-muted-foreground active:cursor-grabbing"
+        title="Drag to move"
+        aria-label="Drag panel"
+      >
+        <GripVertical size={12} strokeWidth={2} class="pointer-events-none" />
+      </div>
+      <!-- Record. The big primary action; clicking it begins the countdown
+           (or starts capture immediately when countdown is off). -->
+      <Button
+        onclick={toggleRecording}
         onmousedown={(e: MouseEvent) => e.stopPropagation()}
         size="icon-sm"
-        variant={isPaused ? "default" : "secondary"}
-        title={isPaused ? "Resume Recording" : "Pause Recording"}
+        variant="default"
+        title="Start Recording"
       >
-        {#if isPaused}
-          <Play size={13} strokeWidth={0} fill="currentColor" />
-        {:else}
-          <Pause size={13} strokeWidth={0} fill="currentColor" />
-        {/if}
+        <Circle size={14} strokeWidth={0} fill="currentColor" />
       </Button>
-    {/if}
-  </ButtonGroup>
 
   <!-- Source. Hidden once recording starts — the source is locked in, so the
        selector just takes space; dropping it is part of the collapse. The
@@ -1184,6 +1268,8 @@
       <X size={10} strokeWidth={2} class="shrink-0 text-destructive" />
     </Button>
   </div>
+    </div>
   {/if}
+  </div>
 </div>
 </div>

--- a/apps/desktop/src/routes/panel/+page.svelte
+++ b/apps/desktop/src/routes/panel/+page.svelte
@@ -54,7 +54,11 @@
   import { emit, listen } from "@tauri-apps/api/event";
   import { invoke } from "@tauri-apps/api/core";
   import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
-  import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
+  import {
+    getCurrentWindow,
+    LogicalPosition,
+    LogicalSize,
+  } from "@tauri-apps/api/window";
   import { onMount } from "svelte";
   import { fade } from "svelte/transition";
 
@@ -90,13 +94,16 @@
   let recordingStartTime: number | null = $state(null);
   let now = $state(Date.now());
 
-  // Countdown-before-recording. `countdownSeconds` is the user's setting
-  // (Settings → Recording, or a profile override), mirrored from localStorage.
-  // `countdownValue` is the live tick — non-null only while counting down, so
-  // it drives the transient "countdown" panel phase between the Record click
-  // and the real capture start.
+  // Countdown-before-recording. `globalCountdown` mirrors the Settings →
+  // Recording value from localStorage; `profileCountdownOverride` is set when a
+  // profile with its own countdown is applied (null = inherit). The effective
+  // `countdownSeconds` prefers the profile override. `countdownValue` is the
+  // live tick — non-null only while counting down, driving the transient
+  // "countdown" panel phase between the Record click and real capture start.
   const COUNTDOWN_KEY = "recast-recording-countdown";
-  let countdownSeconds = $state(3);
+  let globalCountdown = $state(3);
+  let profileCountdownOverride = $state<number | null>(null);
+  const countdownSeconds = $derived(profileCountdownOverride ?? globalCountdown);
   let countdownValue = $state<number | null>(null);
   let countdownInterval: ReturnType<typeof setInterval> | null = null;
 
@@ -462,6 +469,10 @@
       cameraWarning = null;
     }
 
+    // Profile countdown override — null/absent falls back to the global
+    // setting via the `countdownSeconds` derived.
+    profileCountdownOverride = profile.countdown ?? null;
+
     activeProfileId = profile.id;
   }
 
@@ -625,9 +636,9 @@
     try {
       const raw = localStorage.getItem(COUNTDOWN_KEY);
       const n = raw !== null ? Number.parseInt(raw, 10) : 3;
-      countdownSeconds = n === 0 || n === 3 || n === 5 || n === 10 ? n : 3;
+      globalCountdown = n === 0 || n === 3 || n === 5 || n === 10 ? n : 3;
     } catch {
-      countdownSeconds = 3;
+      globalCountdown = 3;
     }
   }
 
@@ -667,34 +678,51 @@
 
   /**
    * Animate the panel window's width to `to` (logical px) with an eased rAF
-   * tween. Shrinks from the right (top-left origin fixed) so the collapsed
-   * controls — which are left-packed during recording — stay put while the
-   * empty space folds away. Honors prefers-reduced-motion by snapping.
+   * tween, keeping the panel centered on its current center (so it collapses
+   * symmetrically toward the middle rather than drifting to one edge). Honors
+   * prefers-reduced-motion by snapping. A monotonic token cancels any
+   * in-flight tween if a newer one starts.
    */
   async function animatePanelWidth(to: number) {
     const win = getCurrentWindow();
     const token = ++widthAnimToken;
 
-    const reduce =
-      typeof window !== "undefined" &&
-      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
-    if (reduce) {
-      await win.setSize(new LogicalSize(to, PANEL_H)).catch(() => {});
-      return;
-    }
-
+    // Current logical width + center, so we can hold the center fixed and
+    // resolve the next top-left as the width changes.
     let from = to;
+    let centerX: number | null = null;
+    let topY: number | null = null;
     try {
-      const [size, factor] = await Promise.all([
+      const [size, pos, factor] = await Promise.all([
         win.innerSize(),
+        win.outerPosition(),
         win.scaleFactor(),
       ]);
       from = size.width / factor;
+      const leftX = pos.x / factor;
+      topY = pos.y / factor;
+      centerX = leftX + from / 2;
     } catch {
-      /* fall back to a snap if we can't read the current size */
+      /* fall back to a plain snap below if we can't read geometry */
     }
     if (token !== widthAnimToken) return;
-    if (Math.round(from) === Math.round(to)) return;
+
+    const apply = (w: number) => {
+      win.setSize(new LogicalSize(w, PANEL_H)).catch(() => {});
+      if (centerX !== null && topY !== null) {
+        win
+          .setPosition(new LogicalPosition(Math.round(centerX - w / 2), Math.round(topY)))
+          .catch(() => {});
+      }
+    };
+
+    const reduce =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    if (reduce || Math.round(from) === Math.round(to)) {
+      apply(to);
+      return;
+    }
 
     const duration = 300;
     const start = performance.now();
@@ -703,8 +731,7 @@
         if (token !== widthAnimToken) return resolve();
         const p = Math.min(1, (t - start) / duration);
         const eased = 1 - Math.pow(1 - p, 3); // cubicOut, matches morph.ts
-        const w = Math.round(from + (to - from) * eased);
-        win.setSize(new LogicalSize(w, PANEL_H)).catch(() => {});
+        apply(Math.round(from + (to - from) * eased));
         if (p < 1) requestAnimationFrame(frame);
         else resolve();
       };
@@ -992,8 +1019,11 @@
   </ButtonGroup>
 
   <!-- Source. Hidden once recording starts — the source is locked in, so the
-       selector just takes space; dropping it is part of the collapse. -->
+       selector just takes space; dropping it is part of the collapse. The
+       fade lives on a wrapping div because Svelte transitions can't bind to a
+       component directly. -->
   {#if !isRecording}
+  <div class="inline-flex" out:fade={{ duration: 120 }}>
   <Button
     size="sm"
     disabled={isRecording}
@@ -1001,7 +1031,6 @@
     onmousedown={(e: MouseEvent) => e.stopPropagation()}
     variant="ghost"
     class="group/source hover:scale-none"
-    out:fade={{ duration: 120 }}
   >
     {#if selectedSource?.type === "window"}
       <AppWindow
@@ -1035,6 +1064,7 @@
       />
     {/if}
   </Button>
+  </div>
   {/if}
 
   <!-- Right cluster. While recording, the profile switcher and device toggles

--- a/apps/desktop/src/routes/profile-picker/+page.svelte
+++ b/apps/desktop/src/routes/profile-picker/+page.svelte
@@ -98,7 +98,7 @@
     class="flex items-center justify-between border-b border-border-subtle px-4 h-10 shrink-0"
     data-tauri-drag-region
   >
-    <div class="flex items-center gap-2">
+    <div class="flex items-center gap-2" data-tauri-drag-region>
       <SlidersIcon size={11} class="text-muted-foreground" />
       <span
         class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
@@ -199,16 +199,14 @@
               <kbd
                 class={cn(
                   "rounded border border-border/40 px-1 text-[9.5px] font-mono",
-                  active ? "bg-card text-foreground" : "bg-muted/40 text-muted-foreground",
-                )}
-              >⌘{i + 1}</kbd>
+                  active
+                    ? "bg-card text-foreground"
+                    : "bg-muted/40 text-muted-foreground",
+                )}>⌘{i + 1}</kbd
+              >
             {/if}
             {#if profile.id === initialSelected}
-              <Check
-                size={12}
-                strokeWidth={3}
-                class="shrink-0 text-primary"
-              />
+              <Check size={12} strokeWidth={3} class="shrink-0 text-primary" />
             {/if}
           </button>
         {/each}
@@ -218,6 +216,7 @@
 
   <!-- Footer hint -->
   <footer
+    data-tauri-drag-region
     class="flex items-center justify-between border-t border-border-subtle bg-card/50 px-3 h-9 shrink-0"
   >
     <span class="text-[10px] font-medium text-muted-foreground/80">

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -30,8 +30,8 @@ export default defineConfig({
 		// @recast/analytics; pre-bundle it so the first capture in the webview
 		// doesn't trigger a dep-optimize reload. Keep the workspace package itself
 		// out so edits hot-reload.
-		include: ['posthog-js'],
-		exclude: ['@recast/analytics'],
+		include: ['@recast/analytics'],
+		// exclude: ['@recast/analytics'],
 	},
 	// Env variables starting with the item of `envPrefix` will be exposed in tauri's source code through `import.meta.env`.
 	envPrefix: ['VITE_', 'TAURI_ENV_*']

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -84,6 +84,17 @@ CLOUDINARY_API_KEY=
 CLOUDINARY_API_SECRET=
 
 #  Azure Blob Storage (STORAGE_PROVIDER=azure) ──────────────────────────
+# Two ways to authenticate (pick one):
+#   A) Bare account name + key:
+#        AZURE_STORAGE_ACCOUNT=myaccount          (name only, NOT the URL)
+#        AZURE_STORAGE_KEY=<base64 account key>    (Access keys → key1, ends "==")
+#   B) Full connection string in AZURE_STORAGE_ACCOUNT (carries its own key,
+#      so AZURE_STORAGE_KEY can stay blank):
+#        AZURE_STORAGE_ACCOUNT="DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=<key>==;EndpointSuffix=core.windows.net"
+# The key must be an ACCOUNT KEY, not a SAS token — deletes use Shared Key auth.
+# AZURE_PUBLIC_URL is optional: set only for a public container / CDN
+# (e.g. https://myaccount.blob.core.windows.net/mycontainer); leave blank for
+# private containers (the app serves signed URLs instead).
 AZURE_STORAGE_ACCOUNT=
 AZURE_STORAGE_KEY=
 AZURE_BLOB_CONTAINER=

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "@aws-sdk/client-s3": "^3.1057.0",
     "@aws-sdk/s3-presigned-post": "^3.1057.0",
     "@aws-sdk/s3-request-presigner": "^3.1057.0",
+    "@azure/storage-blob": "^12.26.0",
     "@fontsource-variable/instrument-sans": "^5.2.8",
     "@lucide/svelte": "^0.577.0",
     "@polar-sh/better-auth": "^1.8.4",

--- a/apps/web/src/lib/analytics/client.ts
+++ b/apps/web/src/lib/analytics/client.ts
@@ -35,7 +35,9 @@ const env = getPublicEnv();
 
 export const analytics: AnalyticsClient = createAnalytics({
 	provider: createPostHogBrowserProvider(),
-	enabled: browser && Boolean(env.PUBLIC_POSTHOG_KEY),
+	// Dev builds never track — only real production (`vite build`) output emits
+	// analytics, so local development doesn't pollute the PostHog project.
+	enabled: browser && !import.meta.env.DEV && Boolean(env.PUBLIC_POSTHOG_KEY),
 	initialConsent: { product: true, errors: true },
 	// Web: init on load so PostHog's automatic pageview fires immediately.
 	eagerInit: true,

--- a/apps/web/src/lib/dashboard/api.ts
+++ b/apps/web/src/lib/dashboard/api.ts
@@ -1,0 +1,99 @@
+/**
+ * Thin fetch wrappers for the dashboard's recast / folder / tag mutations.
+ * Each throws an Error with the server message on non-2xx so callers can
+ * `toast.error(e.message)`. Components call these, then update the local
+ * stores optimistically.
+ */
+
+async function jsonOrThrow<T>(res: Response): Promise<T> {
+	if (!res.ok) {
+		const message = await res.text().catch(() => "");
+		throw new Error(message || `Request failed (${res.status})`);
+	}
+	return (await res.json()) as T;
+}
+
+function post(url: string, body: unknown) {
+	return fetch(url, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+function patch(url: string, body: unknown) {
+	return fetch(url, {
+		method: "PATCH",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+function put(url: string, body: unknown) {
+	return fetch(url, {
+		method: "PUT",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+// ── Recasts ──────────────────────────────────────────────────────────
+export async function renameRecast(id: string, title: string): Promise<void> {
+	await jsonOrThrow(await patch(`/api/recasts/${id}`, { title }));
+}
+export async function moveRecast(id: string, folderId: string | null): Promise<void> {
+	await jsonOrThrow(await patch(`/api/recasts/${id}`, { folderId }));
+}
+export async function deleteRecast(id: string): Promise<void> {
+	await jsonOrThrow(await fetch(`/api/recasts/${id}`, { method: "DELETE" }));
+}
+export async function setRecastTags(id: string, tagIds: string[]): Promise<void> {
+	await jsonOrThrow(await put(`/api/recasts/${id}/tags`, { tagIds }));
+}
+
+// ── Folders ──────────────────────────────────────────────────────────
+export type FolderDTO = {
+	id: string;
+	parentId: string | null;
+	name: string;
+	color: string | null;
+	path: string;
+};
+export async function createFolder(input: {
+	workspaceId: string;
+	name: string;
+	parentId?: string | null;
+	color?: string | null;
+}): Promise<FolderDTO> {
+	const { folder } = await jsonOrThrow<{ folder: FolderDTO }>(
+		await post(`/api/folders`, input),
+	);
+	return folder;
+}
+export async function updateFolder(
+	id: string,
+	patchBody: { name?: string; color?: string | null; parentId?: string | null },
+): Promise<void> {
+	await jsonOrThrow(await patch(`/api/folders/${id}`, patchBody));
+}
+export async function deleteFolder(id: string): Promise<void> {
+	await jsonOrThrow(await fetch(`/api/folders/${id}`, { method: "DELETE" }));
+}
+
+// ── Tags ─────────────────────────────────────────────────────────────
+export type TagDTO = { id: string; name: string; color: string | null };
+export async function createTag(input: {
+	workspaceId: string;
+	name: string;
+	color?: string | null;
+}): Promise<TagDTO> {
+	const { tag } = await jsonOrThrow<{ tag: TagDTO }>(await post(`/api/tags`, input));
+	return tag;
+}
+export async function updateTag(
+	id: string,
+	patchBody: { name?: string; color?: string | null },
+): Promise<void> {
+	await jsonOrThrow(await patch(`/api/tags/${id}`, patchBody));
+}
+export async function deleteTag(id: string): Promise<void> {
+	await jsonOrThrow(await fetch(`/api/tags/${id}`, { method: "DELETE" }));
+}

--- a/apps/web/src/lib/dashboard/api.ts
+++ b/apps/web/src/lib/dashboard/api.ts
@@ -48,6 +48,14 @@ export async function deleteRecast(id: string): Promise<void> {
 export async function setRecastTags(id: string, tagIds: string[]): Promise<void> {
 	await jsonOrThrow(await put(`/api/recasts/${id}/tags`, { tagIds }));
 }
+/** Mint a share link for a recast. Default visibility matches the upload flow
+ *  ("public"). Returns the slug + the absolute shareUrl the server built. */
+export async function shareRecast(
+	id: string,
+	visibility: "private" | "workspace" | "selected" | "public" = "public",
+): Promise<{ slug: string; shareUrl: string }> {
+	return jsonOrThrow(await post(`/api/recasts/${id}/share`, { visibility }));
+}
 
 // ── Folders ──────────────────────────────────────────────────────────
 export type FolderDTO = {

--- a/apps/web/src/lib/dashboard/components/ArchivedCard.svelte
+++ b/apps/web/src/lib/dashboard/components/ArchivedCard.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+	import { formatBytes, formatDate, formatDuration } from "$lib/dashboard/format";
+	import * as DropdownMenu from "@recast/ui/dropdown-menu";
+	import { Archive, Clock, Film, MoreHorizontal, Trash2, TriangleAlert } from "@lucide/svelte";
+
+	export type ArchivedRecast = {
+		id: string;
+		title: string;
+		durationSec: number;
+		sizeBytes: number;
+		posterUrl: string | null;
+		archivedAt: number;
+		deletesAt: number;
+	};
+
+	let {
+		recast,
+		ondelete,
+	}: {
+		recast: ArchivedRecast;
+		ondelete: () => void;
+	} = $props();
+
+	let posterFailed = $state(false);
+	const showPoster = $derived(!!recast.posterUrl && !posterFailed);
+
+	// Whole days until the hard-delete sweep purges this row. Clamped at 0 —
+	// a row past its window is just awaiting the next sweep.
+	const daysLeft = $derived(
+		Math.max(0, Math.ceil((recast.deletesAt - Date.now()) / 86_400_000)),
+	);
+	const urgent = $derived(daysLeft <= 3);
+</script>
+
+<article
+	class="glass-card group/card relative flex h-full flex-col overflow-hidden rounded-xl"
+>
+	<!-- Thumbnail — desaturated; the blob is gone so there's nothing to play. -->
+	<div class="relative h-44 w-full shrink-0 overflow-hidden bg-foreground/5">
+		{#if showPoster}
+			<img
+				src={recast.posterUrl}
+				alt=""
+				loading="lazy"
+				onerror={() => (posterFailed = true)}
+				class="absolute inset-0 h-full w-full object-cover opacity-40 grayscale"
+			/>
+		{:else}
+			<div
+				aria-hidden="true"
+				class="absolute inset-0 opacity-50"
+				style="background-image: radial-gradient(circle, color-mix(in srgb, var(--color-foreground) 8%, transparent) 1px, transparent 1px); background-size: 16px 16px;"
+			></div>
+		{/if}
+
+		<!-- Archived overlay -->
+		<div class="absolute inset-0 grid place-items-center bg-background/45 backdrop-blur-[1px]">
+			<span class="grid size-12 place-items-center rounded-xl border border-border-low/60 bg-background/70 text-muted-foreground shadow-craft-sm">
+				{#if showPoster}
+					<Archive class="size-5" />
+				{:else}
+					<Film class="size-5" />
+				{/if}
+			</span>
+		</div>
+
+		<span class="absolute bottom-2.5 right-2.5 z-20 flex items-center gap-1 rounded-md bg-background/85 px-1.5 py-0.5 font-mono text-[10px] font-semibold tabular-nums text-foreground ring-1 ring-inset ring-border-low/50 backdrop-blur-sm">
+			<Clock class="size-3" />
+			{formatDuration(recast.durationSec)}
+		</span>
+
+		<span class="absolute left-2.5 top-2.5 z-20 flex items-center gap-1 rounded-md bg-background/85 px-1.5 py-0.5 font-mono text-[10px] font-bold uppercase tracking-wider text-muted-foreground ring-1 ring-inset ring-border-low/50 backdrop-blur-sm">
+			<Archive class="size-3" />Archived
+		</span>
+	</div>
+
+	<!-- Meta -->
+	<div class="flex flex-1 flex-col p-4">
+		<div class="flex items-start gap-2">
+			<div class="min-w-0 flex-1">
+				<h3 class="truncate text-sm font-semibold text-foreground" title={recast.title}>
+					{recast.title}
+				</h3>
+				<p class="mt-1 text-xs text-muted-foreground">
+					Archived {formatDate(recast.archivedAt)}
+				</p>
+			</div>
+
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger
+					class="grid size-7 shrink-0 place-items-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-foreground/8 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+					aria-label="Archived recast options"
+				>
+					<MoreHorizontal class="size-4" />
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Content align="end" sideOffset={6} class="w-52">
+					<DropdownMenu.Item
+						onclick={ondelete}
+						class="text-destructive/90 data-highlighted:text-destructive"
+					>
+						<Trash2 class="size-4" />
+						Delete permanently
+					</DropdownMenu.Item>
+				</DropdownMenu.Content>
+			</DropdownMenu.Root>
+		</div>
+
+		<!-- Countdown -->
+		<div
+			class="mt-3 flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[11px] font-medium
+				{urgent
+				? 'bg-destructive/10 text-destructive'
+				: 'bg-foreground/5 text-muted-foreground'}"
+		>
+			<TriangleAlert class="size-3.5 shrink-0" />
+			{#if daysLeft === 0}
+				Deletes within a day
+			{:else}
+				Deletes in {daysLeft}{daysLeft === 1 ? " day" : " days"}
+			{/if}
+			<span class="ml-auto tabular-nums opacity-70">{formatBytes(recast.sizeBytes)}</span>
+		</div>
+
+		<p class="mt-2.5 text-[11px] leading-relaxed text-muted-foreground/80">
+			The file was removed after 14 days without views. Re-share it from the Recast
+			desktop app to restore it.
+		</p>
+	</div>
+</article>

--- a/apps/web/src/lib/dashboard/components/FolderRail.svelte
+++ b/apps/web/src/lib/dashboard/components/FolderRail.svelte
@@ -1,0 +1,319 @@
+<script lang="ts">
+	import { createFolder, deleteFolder, updateFolder } from "$lib/dashboard/api";
+	import { focusOnMount } from "$lib/dashboard/focus";
+	import { foldersStore, type Folder } from "$lib/dashboard/library.svelte";
+	import { recastsStore } from "$lib/dashboard/store.svelte";
+	import * as DropdownMenu from "@recast/ui/dropdown-menu";
+	import { toast } from "@recast/ui/sonner";
+	import { cn } from "@recast/ui/utils";
+	import {
+		ChevronRight,
+		FolderClosed,
+		FolderOpen,
+		FolderPlus,
+		Inbox,
+		Layers,
+		MoreHorizontal,
+		Pencil,
+		Plus,
+		Trash2,
+	} from "@lucide/svelte";
+
+	export type FolderSelection = "all" | "root" | string;
+
+	let {
+		workspaceId,
+		selected,
+		onselect,
+		onDropRecast,
+	}: {
+		workspaceId: string;
+		selected: FolderSelection;
+		onselect: (sel: FolderSelection) => void;
+		onDropRecast: (recastId: string, folderId: string | null) => void;
+	} = $props();
+
+	let expanded = $state<Set<string>>(new Set());
+	let creatingParent = $state<string | null | undefined>(undefined); // undefined = not creating
+	let draftName = $state("");
+	let renamingId = $state<string | null>(null);
+	let dropTarget = $state<FolderSelection | null>(null);
+
+	function toggle(id: string) {
+		const next = new Set(expanded);
+		if (next.has(id)) next.delete(id);
+		else next.add(id);
+		expanded = next;
+	}
+
+	function countFor(sel: FolderSelection): number {
+		if (sel === "all") return recastsStore.items.length;
+		if (sel === "root") return recastsStore.items.filter((r) => !r.folderId).length;
+		return recastsStore.items.filter((r) => r.folderId === sel).length;
+	}
+
+	function startCreate(parentId: string | null) {
+		creatingParent = parentId;
+		draftName = "";
+		if (parentId) expanded = new Set(expanded).add(parentId);
+	}
+
+	async function commitCreate() {
+		const name = draftName.trim();
+		const parentId = creatingParent ?? null;
+		creatingParent = undefined;
+		draftName = "";
+		if (!name) return;
+		try {
+			const folder = await createFolder({ workspaceId, name, parentId });
+			foldersStore.add(folder);
+			toast.success(`Folder “${name}” created.`);
+		} catch (e) {
+			toast.error((e as Error)?.message ?? "Couldn't create folder.");
+		}
+	}
+
+	async function commitRename(folder: Folder) {
+		const name = draftName.trim();
+		renamingId = null;
+		if (!name || name === folder.name) return;
+		const prev = folder.name;
+		foldersStore.update(folder.id, { name });
+		try {
+			await updateFolder(folder.id, { name });
+		} catch (e) {
+			foldersStore.update(folder.id, { name: prev });
+			toast.error((e as Error)?.message ?? "Couldn't rename folder.");
+		}
+	}
+
+	async function removeFolder(folder: Folder) {
+		const ids = foldersStore.subtreeIds(folder.id);
+		foldersStore.remove(folder.id);
+		recastsStore.clearFolder(ids);
+		if (selected !== "all" && ids.has(selected as string)) onselect("all");
+		try {
+			await deleteFolder(folder.id);
+			toast.success(`Folder “${folder.name}” deleted.`);
+		} catch (e) {
+			toast.error((e as Error)?.message ?? "Couldn't delete folder.");
+		}
+	}
+
+	function onDrop(e: DragEvent, folderId: string | null) {
+		e.preventDefault();
+		dropTarget = null;
+		const id = e.dataTransfer?.getData("text/recast-id");
+		if (id) onDropRecast(id, folderId);
+	}
+
+	function onCreateKey(e: KeyboardEvent) {
+		if (e.key === "Enter") (e.currentTarget as HTMLInputElement).blur();
+		if (e.key === "Escape") {
+			creatingParent = undefined;
+			draftName = "";
+		}
+	}
+</script>
+
+<aside class="w-full shrink-0 lg:w-56">
+	<div class="flex items-center justify-between px-2 pb-2">
+		<span class="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">Library</span>
+		<button
+			type="button"
+			onclick={() => startCreate(null)}
+			aria-label="New folder"
+			class="grid size-6 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/8 hover:text-foreground"
+		>
+			<FolderPlus class="size-3.5" />
+		</button>
+	</div>
+
+	<nav class="flex flex-col gap-0.5 text-sm">
+		<!-- All recasts -->
+		<button
+			type="button"
+			onclick={() => onselect("all")}
+			ondragover={(e) => {
+				e.preventDefault();
+				dropTarget = "all";
+			}}
+			ondragleave={() => (dropTarget = dropTarget === "all" ? null : dropTarget)}
+			ondrop={(e) => onDrop(e, null)}
+			class={cn(
+				"flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-left transition-colors",
+				selected === "all" ? "bg-primary/12 text-foreground" : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground",
+				dropTarget === "all" && "ring-1 ring-primary/50",
+			)}
+		>
+			<Layers class="size-4 shrink-0" />
+			<span class="flex-1 truncate">All recasts</span>
+			<span class="font-mono text-[10px] tabular-nums text-muted-foreground">{countFor("all")}</span>
+		</button>
+
+		<!-- No folder (root) -->
+		<button
+			type="button"
+			onclick={() => onselect("root")}
+			ondragover={(e) => {
+				e.preventDefault();
+				dropTarget = "root";
+			}}
+			ondragleave={() => (dropTarget = dropTarget === "root" ? null : dropTarget)}
+			ondrop={(e) => onDrop(e, null)}
+			class={cn(
+				"flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-left transition-colors",
+				selected === "root" ? "bg-primary/12 text-foreground" : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground",
+				dropTarget === "root" && "ring-1 ring-primary/50",
+			)}
+		>
+			<Inbox class="size-4 shrink-0" />
+			<span class="flex-1 truncate">No folder</span>
+			<span class="font-mono text-[10px] tabular-nums text-muted-foreground">{countFor("root")}</span>
+		</button>
+
+		<div class="my-1 h-px bg-border-low/40"></div>
+
+		{#snippet folderNode(folder: Folder, depth: number)}
+			{@const kids = foldersStore.childrenOf(folder.id)}
+			{@const isOpen = expanded.has(folder.id)}
+			{@const active = selected === folder.id}
+			{#if renamingId === folder.id}
+				<input
+					value={folder.name}
+					oninput={(e) => (draftName = e.currentTarget.value)}
+					onblur={() => commitRename(folder)}
+					onkeydown={(e) => {
+						if (e.key === "Enter") e.currentTarget.blur();
+						if (e.key === "Escape") renamingId = null;
+					}}
+					class="w-full rounded-lg border border-primary/50 bg-background px-2.5 py-1.5 text-sm outline-none"
+					style="margin-left: {depth * 12}px"
+					use:focusOnMount
+				/>
+			{:else}
+				<!-- Flex container (NOT a button) so chevron / label / menu can
+				     each be their own button without illegal nesting. The whole
+				     row is the drop target. -->
+				<div
+					role="presentation"
+					ondragover={(e) => {
+						e.preventDefault();
+						dropTarget = folder.id;
+					}}
+					ondragleave={() => (dropTarget = dropTarget === folder.id ? null : dropTarget)}
+					ondrop={(e) => onDrop(e, folder.id)}
+					class={cn(
+						"group/row flex items-center gap-1 rounded-lg pr-1 transition-colors",
+						active ? "bg-primary/12 text-foreground" : "text-muted-foreground hover:bg-foreground/5",
+						dropTarget === folder.id && "ring-1 ring-primary/50",
+					)}
+					style="padding-left: {depth * 12 + 6}px"
+				>
+					{#if kids.length > 0}
+						<button
+							type="button"
+							onclick={() => toggle(folder.id)}
+							aria-label={isOpen ? "Collapse" : "Expand"}
+							class="grid size-4 shrink-0 place-items-center rounded text-muted-foreground/70 hover:text-foreground"
+						>
+							<ChevronRight class={cn("size-3.5 transition-transform", isOpen && "rotate-90")} />
+						</button>
+					{:else}
+						<span class="size-4 shrink-0"></span>
+					{/if}
+					<button
+						type="button"
+						onclick={() => onselect(folder.id)}
+						class="flex min-w-0 flex-1 items-center gap-1.5 py-1.5 text-left hover:text-foreground"
+					>
+						{#if folder.color}
+							<span class="size-2.5 shrink-0 rounded-[3px]" style="background:{folder.color}"></span>
+						{:else if isOpen}
+							<FolderOpen class="size-4 shrink-0 text-muted-foreground" />
+						{:else}
+							<FolderClosed class="size-4 shrink-0 text-muted-foreground" />
+						{/if}
+						<span class="truncate">{folder.name}</span>
+					</button>
+					<span class="font-mono text-[10px] tabular-nums text-muted-foreground group-hover/row:hidden">{countFor(folder.id)}</span>
+					<DropdownMenu.Root>
+						<DropdownMenu.Trigger
+							class="hidden size-6 shrink-0 place-items-center rounded-md text-muted-foreground hover:bg-foreground/10 hover:text-foreground group-hover/row:grid"
+							aria-label="Folder options"
+						>
+							<MoreHorizontal class="size-3.5" />
+						</DropdownMenu.Trigger>
+						<DropdownMenu.Content align="end" sideOffset={4} class="w-44">
+							<DropdownMenu.Item
+								onclick={() => {
+									renamingId = folder.id;
+									draftName = folder.name;
+								}}
+							>
+								<Pencil class="size-3.5 text-muted-foreground" /> Rename
+							</DropdownMenu.Item>
+							<DropdownMenu.Item onclick={() => startCreate(folder.id)}>
+								<Plus class="size-3.5 text-muted-foreground" /> New subfolder
+							</DropdownMenu.Item>
+							<DropdownMenu.Separator />
+							<DropdownMenu.Item
+								onclick={() => removeFolder(folder)}
+								class="text-destructive/90 data-highlighted:text-destructive"
+							>
+								<Trash2 class="size-3.5" /> Delete
+							</DropdownMenu.Item>
+						</DropdownMenu.Content>
+					</DropdownMenu.Root>
+				</div>
+			{/if}
+
+			{#if isOpen}
+				{#each kids as child (child.id)}
+					{@render folderNode(child, depth + 1)}
+				{/each}
+			{/if}
+
+			{#if creatingParent === folder.id}
+				<input
+					bind:value={draftName}
+					onblur={commitCreate}
+					onkeydown={onCreateKey}
+					placeholder="Folder name"
+					class="mt-0.5 w-full rounded-lg border border-primary/50 bg-background px-2.5 py-1.5 text-sm outline-none placeholder:text-muted-foreground/60"
+					style="margin-left: {(depth + 1) * 12}px"
+					use:focusOnMount
+				/>
+			{/if}
+		{/snippet}
+
+		{#each foldersStore.childrenOf(null) as root (root.id)}
+			{@render folderNode(root, 0)}
+		{/each}
+
+		{#if creatingParent === null}
+			<input
+				bind:value={draftName}
+				onblur={commitCreate}
+				onkeydown={onCreateKey}
+				placeholder="Folder name"
+				class="mt-0.5 w-full rounded-lg border border-primary/50 bg-background px-2.5 py-1.5 text-sm outline-none placeholder:text-muted-foreground/60"
+				use:focusOnMount
+			/>
+		{/if}
+
+		{#if foldersStore.items.length === 0 && creatingParent === undefined}
+			<button
+				type="button"
+				onclick={() => startCreate(null)}
+				class="mt-1 flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"
+			>
+				<FolderPlus class="size-3.5" /> New folder
+			</button>
+		{/if}
+	</nav>
+
+	<p class="mt-3 px-2.5 text-[10px] leading-relaxed text-muted-foreground/70">
+		Drag a recast onto a folder to file it.
+	</p>
+</aside>

--- a/apps/web/src/lib/dashboard/components/PlayerDialog.svelte
+++ b/apps/web/src/lib/dashboard/components/PlayerDialog.svelte
@@ -57,11 +57,15 @@
 			</button>
 		</header>
 
+		<!-- autohide={-1}: framed preview dialog — keep the controls pinned so an
+		     autoplaying clip doesn't hide its control bar before the viewer
+		     interacts. The immersive share page keeps the 2s default. -->
 		<RecastPlayer
 			src={recast.videoUrl}
 			poster={recast.posterUrl || null}
 			title={recast.title}
 			autoplay
+			autohide={-1}
 			{onengagement}
 		/>
 

--- a/apps/web/src/lib/dashboard/components/RecastCard.svelte
+++ b/apps/web/src/lib/dashboard/components/RecastCard.svelte
@@ -5,44 +5,79 @@
 		formatDuration,
 		formatRelative,
 	} from "$lib/dashboard/format";
+	import type { Folder, Tag } from "$lib/dashboard/library.svelte";
 	import type { Recast } from "$lib/dashboard/store.svelte";
+	import { Chip } from "@recast/ui/chip";
 	import * as DropdownMenu from "@recast/ui/dropdown-menu";
 	import {
+		Check,
 		Clock,
 		Cloud,
 		CloudUpload,
 		Film,
+		FolderInput,
 		HardDrive,
+		Inbox,
 		Link2,
 		MonitorPlay,
 		MoreHorizontal,
 		Pencil,
 		Play,
+		Tag as TagIcon,
 		Trash2,
 	} from "@lucide/svelte";
 
 	let {
 		recast,
+		folders,
+		tags,
 		onplay,
 		onrename,
 		oncopylink,
 		ontogglesource,
+		onmove,
+		ontoggletag,
 		ondelete,
 	}: {
 		recast: Recast;
+		folders: Folder[];
+		tags: Tag[];
 		onplay: () => void;
 		onrename: () => void;
 		oncopylink: () => void;
 		ontogglesource: () => void;
+		onmove: (folderId: string | null) => void;
+		ontoggletag: (tagId: string) => void;
 		ondelete: () => void;
 	} = $props();
 
 	let posterFailed = $state(false);
 	const showPoster = $derived(!!recast.posterUrl && !posterFailed);
+
+	const assignedTags = $derived(
+		recast.tags
+			.map((id) => tags.find((t) => t.id === id))
+			.filter((t): t is Tag => Boolean(t)),
+	);
+	const assignedSet = $derived(new Set(recast.tags));
+
+	// Folders sorted by their materialized path so nesting reads top-down in
+	// the "Move to" submenu; depth drives indentation.
+	const sortedFolders = $derived([...folders].sort((a, b) => a.path.localeCompare(b.path)));
+	function depthOf(path: string): number {
+		return Math.max(0, (path.match(/\//g)?.length ?? 1) - 2);
+	}
+
+	function onDragStart(e: DragEvent) {
+		e.dataTransfer?.setData("text/recast-id", recast.id);
+		if (e.dataTransfer) e.dataTransfer.effectAllowed = "move";
+	}
 </script>
 
 <article
-	class="glass-card group/card relative flex h-full flex-col overflow-hidden rounded-xl transition-shadow duration-300 hover:shadow-craft-lg"
+	draggable="true"
+	ondragstart={onDragStart}
+	class="glass-card group/card relative flex h-full cursor-grab flex-col overflow-hidden rounded-xl transition-shadow duration-300 hover:shadow-craft-lg active:cursor-grabbing"
 >
 	<!-- Thumbnail (fixed height — robust across grid breakpoints) -->
 	<button
@@ -60,10 +95,6 @@
 				class="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover/card:scale-[1.04]"
 			/>
 		{:else}
-			<!-- Empty-poster state. Inherits the techy framing from the home
-			     editor-tour rail: dot grid + primary glow blob + corner
-			     brackets + a glass-tile icon. Reads as "ready for a frame"
-			     instead of "missing image". -->
 			<div
 				aria-hidden="true"
 				class="absolute inset-0 opacity-60"
@@ -81,28 +112,22 @@
 			</div>
 		{/if}
 
-		<!-- CRT-style corner brackets. Always-on accent that ties the card to
-		     the marketing rail's visual language without obscuring posters. -->
 		<span aria-hidden="true" class="pointer-events-none absolute left-2 top-2 z-10 size-2.5 border-l border-t border-foreground/35"></span>
 		<span aria-hidden="true" class="pointer-events-none absolute right-2 top-2 z-10 size-2.5 border-r border-t border-foreground/35"></span>
 		<span aria-hidden="true" class="pointer-events-none absolute bottom-2 left-2 z-10 size-2.5 border-b border-l border-foreground/35"></span>
 		<span aria-hidden="true" class="pointer-events-none absolute bottom-2 right-2 z-10 size-2.5 border-b border-r border-foreground/35"></span>
 
-		<!-- Play overlay -->
 		<span class="absolute inset-0 grid place-items-center bg-background/35 opacity-0 backdrop-blur-[1px] transition-opacity duration-300 group-hover/card:opacity-100">
 			<span class="grid size-12 place-items-center rounded-full bg-primary text-background shadow-craft-floating transition-transform duration-200 group-active/card:scale-95">
 				<Play class="size-5 translate-x-0.5 fill-current" />
 			</span>
 		</span>
 
-		<!-- Duration. Mono-tag style matches the editor-tour chips. -->
 		<span class="absolute bottom-2.5 right-2.5 z-20 flex items-center gap-1 rounded-md bg-background/85 px-1.5 py-0.5 font-mono text-[10px] font-semibold tabular-nums text-foreground ring-1 ring-inset ring-border-low/50 backdrop-blur-sm">
 			<Clock class="size-3" />
 			{formatDuration(recast.durationSec)}
 		</span>
 
-		<!-- Source. Same mono-tag rhythm as the duration chip; primary tint
-		     for cloud, neutral for local. -->
 		<span
 			class="absolute left-2.5 top-2.5 z-20 flex items-center gap-1 rounded-md px-1.5 py-0.5 font-mono text-[10px] font-bold uppercase tracking-wider ring-1 ring-inset backdrop-blur-sm
 				{recast.source === 'cloud'
@@ -118,54 +143,122 @@
 	</button>
 
 	<!-- Meta -->
-	<div class="flex flex-1 items-start gap-2 p-4">
-		<div class="min-w-0 flex-1">
-			<h3 class="truncate text-sm font-semibold text-foreground" title={recast.title}>
-				{recast.title}
-			</h3>
-			<p class="mt-1 text-xs text-muted-foreground">
-				{formatRelative(recast.createdAt)} · {formatBytes(recast.sizeBytes)}{#if recast.source === "cloud"} · {formatCount(recast.views)} views{/if}
-			</p>
+	<div class="flex flex-1 flex-col p-4">
+		<div class="flex items-start gap-2">
+			<div class="min-w-0 flex-1">
+				<h3 class="truncate text-sm font-semibold text-foreground" title={recast.title}>
+					{recast.title}
+				</h3>
+				<p class="mt-1 text-xs text-muted-foreground">
+					{formatRelative(recast.createdAt)} · {formatBytes(recast.sizeBytes)}{#if recast.source === "cloud"} · {formatCount(recast.views)} views{/if}
+				</p>
+			</div>
+
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger
+					class="grid size-7 shrink-0 place-items-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-foreground/8 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+					aria-label="Recast options"
+				>
+					<MoreHorizontal class="size-4" />
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Content align="end" sideOffset={6} class="w-52">
+					<DropdownMenu.Item onclick={onplay}>
+						<Play class="size-4 text-muted-foreground" />
+						Play
+					</DropdownMenu.Item>
+					<DropdownMenu.Item onclick={onrename}>
+						<Pencil class="size-4 text-muted-foreground" />
+						Rename
+					</DropdownMenu.Item>
+					<DropdownMenu.Item onclick={oncopylink}>
+						<Link2 class="size-4 text-muted-foreground" />
+						Copy link
+					</DropdownMenu.Item>
+
+					<!-- Move to folder -->
+					<DropdownMenu.Sub>
+						<DropdownMenu.SubTrigger>
+							<FolderInput class="size-4 text-muted-foreground" />
+							Move to
+						</DropdownMenu.SubTrigger>
+						<DropdownMenu.SubContent class="max-h-72 w-56 overflow-y-auto">
+							<DropdownMenu.Item onclick={() => onmove(null)}>
+								<Inbox class="size-4 text-muted-foreground" />
+								<span class="flex-1">No folder</span>
+								{#if !recast.folderId}<Check class="size-3.5 text-primary" />{/if}
+							</DropdownMenu.Item>
+							{#if sortedFolders.length > 0}
+								<DropdownMenu.Separator />
+								{#each sortedFolders as f (f.id)}
+									<DropdownMenu.Item onclick={() => onmove(f.id)}>
+										<span style="width: {depthOf(f.path) * 10}px" class="shrink-0"></span>
+										{#if f.color}
+											<span class="size-2.5 shrink-0 rounded-[3px]" style="background:{f.color}"></span>
+										{/if}
+										<span class="flex-1 truncate">{f.name}</span>
+										{#if recast.folderId === f.id}<Check class="size-3.5 text-primary" />{/if}
+									</DropdownMenu.Item>
+								{/each}
+							{/if}
+						</DropdownMenu.SubContent>
+					</DropdownMenu.Sub>
+
+					<!-- Tags -->
+					<DropdownMenu.Sub>
+						<DropdownMenu.SubTrigger>
+							<TagIcon class="size-4 text-muted-foreground" />
+							Tags
+						</DropdownMenu.SubTrigger>
+						<DropdownMenu.SubContent class="max-h-72 w-56 overflow-y-auto">
+							{#if tags.length === 0}
+								<div class="px-2 py-2 text-xs text-muted-foreground">
+									No tags yet — create one from the filter bar.
+								</div>
+							{:else}
+								{#each tags as t (t.id)}
+									<DropdownMenu.CheckboxItem
+										checked={assignedSet.has(t.id)}
+										onclick={() => ontoggletag(t.id)}
+										closeOnSelect={false}
+									>
+										{#if t.color}
+											<span class="size-2.5 shrink-0 rounded-full" style="background:{t.color}"></span>
+										{/if}
+										{t.name}
+									</DropdownMenu.CheckboxItem>
+								{/each}
+							{/if}
+						</DropdownMenu.SubContent>
+					</DropdownMenu.Sub>
+
+					<DropdownMenu.Item onclick={ontogglesource}>
+						{#if recast.source === "cloud"}
+							<HardDrive class="size-4 text-muted-foreground" />
+							Move to local
+						{:else}
+							<CloudUpload class="size-4 text-muted-foreground" />
+							Upload to cloud
+						{/if}
+					</DropdownMenu.Item>
+					<DropdownMenu.Separator />
+					<DropdownMenu.Item
+						onclick={ondelete}
+						class="text-destructive/90 data-highlighted:text-destructive"
+					>
+						<Trash2 class="size-4" />
+						Delete
+					</DropdownMenu.Item>
+				</DropdownMenu.Content>
+			</DropdownMenu.Root>
 		</div>
 
-		<DropdownMenu.Root>
-			<DropdownMenu.Trigger
-				class="grid size-7 shrink-0 place-items-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-foreground/8 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
-				aria-label="Recast options"
-			>
-				<MoreHorizontal class="size-4" />
-			</DropdownMenu.Trigger>
-			<DropdownMenu.Content align="end" sideOffset={6} class="w-48">
-				<DropdownMenu.Item onclick={onplay}>
-					<Play class="size-4 text-muted-foreground" />
-					Play
-				</DropdownMenu.Item>
-				<DropdownMenu.Item onclick={onrename}>
-					<Pencil class="size-4 text-muted-foreground" />
-					Rename
-				</DropdownMenu.Item>
-				<DropdownMenu.Item onclick={oncopylink}>
-					<Link2 class="size-4 text-muted-foreground" />
-					Copy link
-				</DropdownMenu.Item>
-				<DropdownMenu.Item onclick={ontogglesource}>
-					{#if recast.source === "cloud"}
-						<HardDrive class="size-4 text-muted-foreground" />
-						Move to local
-					{:else}
-						<CloudUpload class="size-4 text-muted-foreground" />
-						Upload to cloud
-					{/if}
-				</DropdownMenu.Item>
-				<DropdownMenu.Separator />
-				<DropdownMenu.Item
-					onclick={ondelete}
-					class="text-destructive/90 data-highlighted:text-destructive"
-				>
-					<Trash2 class="size-4" />
-					Delete
-				</DropdownMenu.Item>
-			</DropdownMenu.Content>
-		</DropdownMenu.Root>
+		<!-- Assigned tags -->
+		{#if assignedTags.length > 0}
+			<div class="mt-2.5 flex flex-wrap gap-1.5">
+				{#each assignedTags as t (t.id)}
+					<Chip label={t.name} color={t.color} class="py-0.5 text-[10px]" />
+				{/each}
+			</div>
+		{/if}
 	</div>
 </article>

--- a/apps/web/src/lib/dashboard/components/TagManagerDialog.svelte
+++ b/apps/web/src/lib/dashboard/components/TagManagerDialog.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+	import * as api from "$lib/dashboard/api";
+	import { tagsStore, type Tag } from "$lib/dashboard/library.svelte";
+	import { recastsStore } from "$lib/dashboard/store.svelte";
+	import { Button } from "@recast/ui/button";
+	import { toast } from "@recast/ui/sonner";
+	import { Check, Tag as TagIcon, Trash2, X } from "@lucide/svelte";
+	import { cubicOut } from "svelte/easing";
+	import { fade, scale, slide } from "svelte/transition";
+
+	let { onclose }: { onclose: () => void } = $props();
+
+	// Preset swatches — a clicked dot opens this strip inline. `null` clears.
+	const PALETTE = [
+		"#ef4444", "#f97316", "#eab308", "#22c55e",
+		"#14b8a6", "#3b82f6", "#8b5cf6", "#ec4899",
+	];
+
+	// Which row currently has its palette strip open, and which is pending delete.
+	let editingColorId = $state<string | null>(null);
+	let confirmingId = $state<string | null>(null);
+
+	async function rename(t: Tag, raw: string) {
+		const name = raw.trim();
+		if (!name || name === t.name) return;
+		const prev = t.name;
+		tagsStore.update(t.id, { name });
+		try {
+			await api.updateTag(t.id, { name });
+		} catch (e) {
+			tagsStore.update(t.id, { name: prev });
+			toast.error((e as Error)?.message ?? "Couldn't rename tag.");
+		}
+	}
+
+	async function recolor(t: Tag, color: string | null) {
+		editingColorId = null;
+		if (t.color === color) return;
+		const prev = t.color;
+		tagsStore.update(t.id, { color });
+		try {
+			await api.updateTag(t.id, { color });
+		} catch (e) {
+			tagsStore.update(t.id, { color: prev });
+			toast.error((e as Error)?.message ?? "Couldn't recolor tag.");
+		}
+	}
+
+	async function remove(t: Tag) {
+		confirmingId = null;
+		// Optimistic: drop the chip everywhere and from the tag list.
+		const snapshot = { tag: t, taggedRecastIds: recastsStore.items.filter((r) => r.tags.includes(t.id)).map((r) => r.id) };
+		tagsStore.remove(t.id);
+		recastsStore.removeTagEverywhere(t.id);
+		try {
+			await api.deleteTag(t.id);
+			toast.success(`Tag “${t.name}” deleted.`);
+		} catch (e) {
+			// Restore the tag and its assignments.
+			tagsStore.add(snapshot.tag);
+			for (const id of snapshot.taggedRecastIds) {
+				const rec = recastsStore.items.find((r) => r.id === id);
+				if (rec && !rec.tags.includes(t.id)) recastsStore.setTags(id, [...rec.tags, t.id]);
+			}
+			toast.error((e as Error)?.message ?? "Couldn't delete tag.");
+		}
+	}
+
+	function onNameKey(e: KeyboardEvent) {
+		if (e.key === "Enter") (e.currentTarget as HTMLInputElement).blur();
+		if (e.key === "Escape") onclose();
+	}
+</script>
+
+<svelte:window onkeydown={(e) => e.key === "Escape" && onclose()} />
+
+<div class="fixed inset-0 z-100 grid place-items-center p-4">
+	<button
+		type="button"
+		aria-label="Close"
+		onclick={onclose}
+		class="absolute inset-0 cursor-default bg-background/80 backdrop-blur-sm"
+		transition:fade={{ duration: 150 }}
+	></button>
+
+	<div
+		class="glass-card relative z-10 flex max-h-[80vh] w-full max-w-md flex-col rounded-2xl p-6 shadow-craft-xl"
+		transition:scale={{ start: 0.96, duration: 240, easing: cubicOut }}
+	>
+		<div class="flex items-center justify-between">
+			<h2 class="flex items-center gap-2 text-sm font-semibold text-foreground">
+				<TagIcon class="size-4 text-muted-foreground" />
+				Manage tags
+			</h2>
+			<button
+				type="button"
+				onclick={onclose}
+				aria-label="Close"
+				class="grid size-7 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/8 hover:text-foreground"
+			>
+				<X class="size-4" />
+			</button>
+		</div>
+
+		{#if tagsStore.sorted.length === 0}
+			<p class="mt-6 rounded-lg border border-dashed border-border-low/70 py-10 text-center text-xs text-muted-foreground">
+				No tags yet. Create one from the “New tag” button in the filter bar.
+			</p>
+		{:else}
+			<p class="mt-1 text-xs text-muted-foreground">
+				Rename inline, recolor with the dot, or delete. Deleting a tag removes it from every recast.
+			</p>
+			<div class="mt-4 -mr-2 flex flex-col gap-1 overflow-y-auto pr-2">
+				{#each tagsStore.sorted as t (t.id)}
+					<div class="rounded-lg border border-border-low/50 bg-card/40 px-2 py-1.5">
+						<div class="flex items-center gap-2">
+							<button
+								type="button"
+								onclick={() => (editingColorId = editingColorId === t.id ? null : t.id)}
+								aria-label="Change color"
+								class="grid size-6 shrink-0 place-items-center rounded-md transition-colors hover:bg-foreground/8"
+							>
+								<span
+									class="size-3 rounded-full ring-1 ring-inset ring-border-low/60"
+									style={t.color ? `background:${t.color}` : "background:var(--color-muted-foreground); opacity:0.4"}
+								></span>
+							</button>
+
+							<input
+								value={t.name}
+								onblur={(e) => rename(t, e.currentTarget.value)}
+								onkeydown={onNameKey}
+								class="min-w-0 flex-1 rounded-md bg-transparent px-1.5 py-1 text-sm text-foreground outline-none transition-colors focus:bg-background focus:ring-1 focus:ring-primary/40"
+							/>
+
+							{#if confirmingId === t.id}
+								<div class="flex shrink-0 items-center gap-1" in:slide={{ axis: "x", duration: 160 }}>
+									<button
+										type="button"
+										onclick={() => remove(t)}
+										class="rounded-md bg-destructive/15 px-2 py-1 text-[11px] font-semibold text-destructive transition-colors hover:bg-destructive/25"
+									>
+										Delete
+									</button>
+									<button
+										type="button"
+										onclick={() => (confirmingId = null)}
+										class="rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+									>
+										Cancel
+									</button>
+								</div>
+							{:else}
+								<button
+									type="button"
+									onclick={() => (confirmingId = t.id)}
+									aria-label={`Delete ${t.name}`}
+									class="grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground/70 transition-colors hover:bg-destructive/10 hover:text-destructive"
+								>
+									<Trash2 class="size-3.5" />
+								</button>
+							{/if}
+						</div>
+
+						{#if editingColorId === t.id}
+							<div class="mt-1.5 flex flex-wrap items-center gap-1.5 pl-8" in:slide={{ duration: 160 }}>
+								{#each PALETTE as c (c)}
+									<button
+										type="button"
+										onclick={() => recolor(t, c)}
+										aria-label={`Set color ${c}`}
+										class="grid size-5 place-items-center rounded-full ring-1 ring-inset ring-border-low/40 transition-transform hover:scale-110"
+										style="background:{c}"
+									>
+										{#if t.color === c}<Check class="size-3 text-white drop-shadow" />{/if}
+									</button>
+								{/each}
+								<button
+									type="button"
+									onclick={() => recolor(t, null)}
+									aria-label="No color"
+									class="grid size-5 place-items-center rounded-full bg-foreground/5 text-muted-foreground ring-1 ring-inset ring-border-low/60 transition-colors hover:text-foreground"
+								>
+									<X class="size-3" />
+								</button>
+							</div>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
+
+		<div class="mt-5 flex justify-end">
+			<Button type="button" size="sm" onclick={onclose}>Done</Button>
+		</div>
+	</div>
+</div>

--- a/apps/web/src/lib/dashboard/focus.ts
+++ b/apps/web/src/lib/dashboard/focus.ts
@@ -1,0 +1,10 @@
+/**
+ * `use:focusOnMount` — focus an element when it mounts. Used for inline
+ * create/rename inputs so the cursor lands there immediately, without the
+ * `autofocus` attribute (which Svelte flags for a11y and which doesn't
+ * re-fire when the same node is reused).
+ */
+export function focusOnMount(node: HTMLElement) {
+	node.focus();
+	if (node instanceof HTMLInputElement) node.select();
+}

--- a/apps/web/src/lib/dashboard/library.svelte.ts
+++ b/apps/web/src/lib/dashboard/library.svelte.ts
@@ -1,0 +1,103 @@
+import type { FolderDTO, TagDTO } from "./api";
+
+/**
+ * Library organization stores — the workspace's folder tree and tag set.
+ * Siblings of `recastsStore`. Hydrated from the page loader; mutated
+ * optimistically by components after the matching `api.ts` call resolves.
+ *
+ * Folders use the same ID-based materialized `path` as the server
+ * ("/<id>/<id>/"), so subtree math (descendants, delete) is a prefix test.
+ */
+
+export type Folder = FolderDTO;
+export type Tag = TagDTO;
+
+class FoldersStore {
+	items = $state<Folder[]>([]);
+	hydrated = $state(false);
+
+	hydrate(server: Folder[]) {
+		this.items = server;
+		this.hydrated = true;
+	}
+
+	get(id: string): Folder | undefined {
+		return this.items.find((f) => f.id === id);
+	}
+
+	childrenOf(parentId: string | null): Folder[] {
+		return this.items
+			.filter((f) => f.parentId === parentId)
+			.sort((a, b) => a.name.localeCompare(b.name));
+	}
+
+	/** A folder + every descendant (by path prefix). */
+	subtreeIds(id: string): Set<string> {
+		const root = this.get(id);
+		if (!root) return new Set([id]);
+		return new Set(
+			this.items.filter((f) => f.path.startsWith(root.path)).map((f) => f.id),
+		);
+	}
+
+	/** Breadcrumb names from root → folder, for the header trail. */
+	breadcrumb(id: string | null): Folder[] {
+		const trail: Folder[] = [];
+		let cur = id ? this.get(id) : undefined;
+		while (cur) {
+			trail.unshift(cur);
+			cur = cur.parentId ? this.get(cur.parentId) : undefined;
+		}
+		return trail;
+	}
+
+	add(f: Folder) {
+		this.items = [...this.items, f];
+	}
+
+	update(id: string, patch: Partial<Folder>) {
+		this.items = this.items.map((f) => (f.id === id ? { ...f, ...patch } : f));
+	}
+
+	/** Remove a folder and its whole subtree (mirrors the server cascade). */
+	remove(id: string): Set<string> {
+		const ids = this.subtreeIds(id);
+		this.items = this.items.filter((f) => !ids.has(f.id));
+		return ids;
+	}
+}
+
+class TagsStore {
+	items = $state<Tag[]>([]);
+	hydrated = $state(false);
+
+	hydrate(server: Tag[]) {
+		this.items = server;
+		this.hydrated = true;
+	}
+
+	get(id: string): Tag | undefined {
+		return this.items.find((t) => t.id === id);
+	}
+
+	get sorted(): Tag[] {
+		return [...this.items].sort((a, b) => a.name.localeCompare(b.name));
+	}
+
+	add(t: Tag) {
+		// Idempotent on id — the create endpoint returns existing on conflict.
+		if (this.items.some((x) => x.id === t.id)) return;
+		this.items = [...this.items, t];
+	}
+
+	update(id: string, patch: Partial<Tag>) {
+		this.items = this.items.map((t) => (t.id === id ? { ...t, ...patch } : t));
+	}
+
+	remove(id: string) {
+		this.items = this.items.filter((t) => t.id !== id);
+	}
+}
+
+export const foldersStore = new FoldersStore();
+export const tagsStore = new TagsStore();

--- a/apps/web/src/lib/dashboard/store.svelte.ts
+++ b/apps/web/src/lib/dashboard/store.svelte.ts
@@ -152,6 +152,15 @@ class RecordingsStore {
 		this.persist();
 	}
 
+	/** Strip a tag id from every recast that carried it (after the tag is
+	 *  deleted server-side; the recast_tag rows cascade, this mirrors it locally). */
+	removeTagEverywhere(tagId: string) {
+		this.items = this.items.map((r) =>
+			r.tags.includes(tagId) ? { ...r, tags: r.tags.filter((t) => t !== tagId) } : r,
+		);
+		this.persist();
+	}
+
 	/** Drop a folder reference from any recast that pointed at it (after the
 	 *  folder — or its subtree — is deleted server-side; recasts fall to root). */
 	clearFolder(folderIds: Set<string>) {

--- a/apps/web/src/lib/dashboard/store.svelte.ts
+++ b/apps/web/src/lib/dashboard/store.svelte.ts
@@ -21,6 +21,10 @@ export type Recast = {
 	source: RecordingSource;
 	provider: string | null;
 	views: number;
+	/** Owning folder, or null for the library root. */
+	folderId: string | null;
+	/** Tag ids — resolved against the workspace tag list in the UI. */
+	tags: string[];
 	/** Playable URL. May be a `blob:` URL for session uploads. */
 	videoUrl: string;
 	/** Poster image; empty string renders a gradient placeholder. */
@@ -52,7 +56,7 @@ function seedRecordings(): Recast[] {
 		{ id: "rec_bug", title: "Bug repro — export hang", durationSec: 52, createdAt: now - 6 * DAY, sizeBytes: 33_000_000, source: "local", provider: null, views: 0, ...sample("ForBiggerEscapes") },
 		{ id: "rec_teaser", title: "Launch teaser cut", durationSec: 31, createdAt: now - 9 * DAY, sizeBytes: 22_000_000, source: "cloud", provider: "Cloudinary", views: 1024, ...sample("ForBiggerFun") },
 		{ id: "rec_support", title: "Support reply — billing", durationSec: 107, createdAt: now - 13 * DAY, sizeBytes: 68_000_000, source: "local", provider: null, views: 0, ...sample("ForBiggerJoyrides") },
-	];
+	].map((r) => ({ folderId: null, tags: [] as string[], ...r })) as Recast[];
 }
 
 function readJSON<T>(key: string, fallback: T): T {
@@ -131,6 +135,28 @@ class RecordingsStore {
 			r.id === id
 				? { ...r, source, provider: source === "cloud" ? "Cloudinary" : null }
 				: r,
+		);
+		this.persist();
+	}
+
+	/** Move a recast to a folder (or null for root). Local mirror of the
+	 *  PATCH /api/recasts/[id] call the caller makes. */
+	move(id: string, folderId: string | null) {
+		this.items = this.items.map((r) => (r.id === id ? { ...r, folderId } : r));
+		this.persist();
+	}
+
+	/** Replace a recast's tag id set. Mirrors PUT /api/recasts/[id]/tags. */
+	setTags(id: string, tags: string[]) {
+		this.items = this.items.map((r) => (r.id === id ? { ...r, tags } : r));
+		this.persist();
+	}
+
+	/** Drop a folder reference from any recast that pointed at it (after the
+	 *  folder — or its subtree — is deleted server-side; recasts fall to root). */
+	clearFolder(folderIds: Set<string>) {
+		this.items = this.items.map((r) =>
+			r.folderId && folderIds.has(r.folderId) ? { ...r, folderId: null } : r,
 		);
 		this.persist();
 	}

--- a/apps/web/src/lib/dashboard/store.svelte.ts
+++ b/apps/web/src/lib/dashboard/store.svelte.ts
@@ -1,4 +1,4 @@
-import { browser } from "$app/environment";
+import { safeStorage } from "@recast/ui/persisted-state";
 
 /**
  * Dashboard data layer.
@@ -59,16 +59,6 @@ function seedRecordings(): Recast[] {
 	].map((r) => ({ folderId: null, tags: [] as string[], ...r })) as Recast[];
 }
 
-function readJSON<T>(key: string, fallback: T): T {
-	if (!browser) return fallback;
-	try {
-		const raw = localStorage.getItem(key);
-		return raw ? (JSON.parse(raw) as T) : fallback;
-	} catch {
-		return fallback;
-	}
-}
-
 /** Blob URLs don't survive a reload — fall back to sample media so the
  *  recording stays playable rather than becoming a dead entry. */
 function reconcile(r: Recast): Recast {
@@ -83,7 +73,7 @@ class RecordingsStore {
 	hydrated = $state(false);
 
 	constructor() {
-		const stored = readJSON<Recast[] | null>(REC_KEY, null);
+		const stored = safeStorage.get<Recast[] | null>(REC_KEY, null);
 		// Until `hydrate()` is called we show the last cached server list,
 		// or — if we've never seen one — the dummy seed so the design
 		// surface stays explorable on logged-out previews.
@@ -102,7 +92,7 @@ class RecordingsStore {
 	}
 
 	private persist() {
-		if (browser) localStorage.setItem(REC_KEY, JSON.stringify(this.items));
+		safeStorage.set(REC_KEY, this.items);
 	}
 
 	get usedBytes(): number {
@@ -220,7 +210,7 @@ class SettingsStore {
 	value = $state<DashboardSettings>(defaultSettings);
 
 	constructor() {
-		const s = readJSON<Partial<DashboardSettings>>(SET_KEY, {});
+		const s = safeStorage.get<Partial<DashboardSettings>>(SET_KEY, {});
 		this.value = {
 			profile: { ...defaultSettings.profile, ...s.profile },
 			cloudinary: { ...defaultSettings.cloudinary, ...s.cloudinary },
@@ -229,7 +219,7 @@ class SettingsStore {
 	}
 
 	save() {
-		if (browser) localStorage.setItem(SET_KEY, JSON.stringify(this.value));
+		safeStorage.set(SET_KEY, this.value);
 	}
 
 	get initials(): string {

--- a/apps/web/src/lib/dashboard/store.svelte.ts
+++ b/apps/web/src/lib/dashboard/store.svelte.ts
@@ -29,6 +29,9 @@ export type Recast = {
 	videoUrl: string;
 	/** Poster image; empty string renders a gradient placeholder. */
 	posterUrl: string;
+	/** Slug of the recast's most recent share, or null if never shared. The
+	 *  public link is `/share/{latestShareSlug}` — NOT `/share/{id}`. */
+	latestShareSlug?: string | null;
 };
 
 /** Workspace storage quota used by the sidebar meter. */
@@ -139,6 +142,15 @@ class RecordingsStore {
 	/** Replace a recast's tag id set. Mirrors PUT /api/recasts/[id]/tags. */
 	setTags(id: string, tags: string[]) {
 		this.items = this.items.map((r) => (r.id === id ? { ...r, tags } : r));
+		this.persist();
+	}
+
+	/** Cache a freshly-minted share slug so "Copy link" reuses it instead of
+	 *  creating a duplicate share on the next click. */
+	setShareSlug(id: string, slug: string) {
+		this.items = this.items.map((r) =>
+			r.id === id ? { ...r, latestShareSlug: slug } : r,
+		);
 		this.persist();
 	}
 

--- a/apps/web/src/lib/dashboard/upload.ts
+++ b/apps/web/src/lib/dashboard/upload.ts
@@ -1,0 +1,290 @@
+/**
+ * Browser-side cloud upload — the web counterpart to the desktop's
+ * "Share to Cloud" flow. Drives the same three server endpoints:
+ *
+ *   1. POST /api/uploads/init      → reserves a draft recast + signed PUT URLs
+ *   2. PUT  <signed video url>     → uploads the MP4 (with byte progress)
+ *   2b PUT  <signed poster url>    → uploads a WebP frame (best-effort)
+ *   3. POST /api/uploads/complete  → HEAD-verifies + publishes
+ *   4. POST /api/recasts/{id}/share → mints a public link
+ *
+ * Only `.mp4` is accepted. A `.recast` project can't be turned into a
+ * shareable video in the browser — that needs the native render pipeline —
+ * and its inner recording is the raw, unedited source, not a web-ready MP4.
+ */
+
+import { browser } from "$app/environment";
+
+export type UploadPhase = "preparing" | "uploading" | "finalizing" | "sharing";
+
+export interface UploadHandlers {
+	workspaceId?: string;
+	onPhase?: (phase: UploadPhase) => void;
+	/** Byte progress 0–100 during the video PUT. */
+	onProgress?: (pct: number) => void;
+}
+
+export interface UploadResult {
+	recastId: string;
+	slug: string;
+	shareUrl: string;
+}
+
+interface SignedEnvelope {
+	method: string;
+	url: string;
+	headers?: Record<string, string>;
+}
+
+/** Accept attribute + the guard below — keep them in sync. */
+export const UPLOAD_ACCEPT = "video/mp4,.mp4";
+
+export function isUploadableVideo(file: File): boolean {
+	return file.type === "video/mp4" || /\.mp4$/i.test(file.name);
+}
+
+// ── error mapping ─────────────────────────────────────────────────────
+
+type Denial = { reason?: string };
+
+function denialMessage(denial: Denial | undefined, fallback: string): string {
+	switch (denial?.reason) {
+		case "storage_over_cap":
+			return "You're out of cloud storage. Upgrade or free up space.";
+		case "active_recasts_over_cap":
+			return "You've hit your active recast limit. Delete one or upgrade.";
+		case "duration_over_cap":
+			return "This recording is longer than your plan allows for cloud sharing.";
+		case "resolution_over_cap":
+			return "Your plan caps cloud sharing at 720p. Upload a 720p export, or upgrade for HD.";
+		case "upload_missing":
+			return "The upload didn't arrive — please try again.";
+		case "empty_upload":
+			return "That file came through empty — please try again.";
+		default:
+			return fallback;
+	}
+}
+
+async function readJson(res: Response): Promise<Record<string, unknown> | null> {
+	try {
+		return (await res.json()) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+// ── media probing + poster capture ────────────────────────────────────
+
+function loadVideoElement(url: string): Promise<HTMLVideoElement> {
+	return new Promise((resolve, reject) => {
+		const v = document.createElement("video");
+		v.preload = "auto";
+		v.muted = true;
+		v.onloadedmetadata = () => resolve(v);
+		v.onerror = () => reject(new Error("Couldn't read this video file."));
+		v.src = url;
+	});
+}
+
+function seekTo(video: HTMLVideoElement, time: number): Promise<void> {
+	return new Promise((resolve) => {
+		const done = () => {
+			video.removeEventListener("seeked", done);
+			resolve();
+		};
+		video.addEventListener("seeked", done);
+		try {
+			video.currentTime = time;
+		} catch {
+			video.removeEventListener("seeked", done);
+			resolve();
+		}
+	});
+}
+
+/**
+ * Grab a frame ~25% in and encode it as WebP (lighter than PNG/JPEG at
+ * equal quality). Best-effort — returns null on any failure; the recast
+ * just keeps no poster.
+ */
+async function capturePosterWebp(video: HTMLVideoElement): Promise<Blob | null> {
+	try {
+		const w = video.videoWidth;
+		const h = video.videoHeight;
+		if (!w || !h) return null;
+
+		const duration = video.duration || 0;
+		const target = duration > 0 ? Math.min(duration * 0.25, Math.max(0, duration - 0.1)) : 0;
+		await seekTo(video, target);
+
+		const scaleW = Math.min(960, w);
+		const scaleH = Math.max(1, Math.round(h * (scaleW / w)));
+		const canvas = document.createElement("canvas");
+		canvas.width = scaleW;
+		canvas.height = scaleH;
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return null;
+		ctx.drawImage(video, 0, 0, scaleW, scaleH);
+
+		return await new Promise<Blob | null>((resolve) =>
+			canvas.toBlob((b) => resolve(b), "image/webp", 0.82),
+		);
+	} catch {
+		return null;
+	}
+}
+
+// ── signed PUT with progress (fetch has no upload progress) ────────────
+
+function putWithProgress(
+	envelope: SignedEnvelope,
+	body: Blob,
+	contentTypeFallback: string,
+	onProgress?: (pct: number) => void,
+): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const xhr = new XMLHttpRequest();
+		xhr.open("PUT", envelope.url);
+
+		const headers = envelope.headers ?? {};
+		const hasContentType = Object.keys(headers).some(
+			(k) => k.toLowerCase() === "content-type",
+		);
+		for (const [k, v] of Object.entries(headers)) xhr.setRequestHeader(k, v);
+		// Presigned PUTs sign the content-type; match what /init signed when the
+		// envelope didn't carry it explicitly.
+		if (!hasContentType) xhr.setRequestHeader("Content-Type", contentTypeFallback);
+
+		if (onProgress) {
+			xhr.upload.onprogress = (e) => {
+				if (e.lengthComputable) onProgress(Math.round((e.loaded / e.total) * 100));
+			};
+		}
+		xhr.onload = () => resolve(xhr.status);
+		xhr.onerror = () => reject(new Error("Upload failed — check your connection."));
+		xhr.onabort = () => reject(new Error("Upload was cancelled."));
+		xhr.send(body);
+	});
+}
+
+// ── main flow ──────────────────────────────────────────────────────────
+
+export async function uploadRecastFile(
+	file: File,
+	handlers: UploadHandlers = {},
+): Promise<UploadResult> {
+	if (!browser) throw new Error("Upload can only run in the browser.");
+	if (!isUploadableVideo(file)) {
+		throw new Error("Only .mp4 video files can be uploaded here.");
+	}
+
+	handlers.onPhase?.("preparing");
+	const objectUrl = URL.createObjectURL(file);
+	let video: HTMLVideoElement | null = null;
+
+	try {
+		video = await loadVideoElement(objectUrl);
+		const durationSec = Math.max(0, Math.round(video.duration || 0));
+		const width = video.videoWidth || undefined;
+		const height = video.videoHeight || undefined;
+		const title = file.name.replace(/\.[^.]+$/, "") || "Untitled recast";
+
+		// 1. init
+		const initRes = await fetch("/api/uploads/init", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				workspaceId: handlers.workspaceId,
+				title,
+				durationSec,
+				sizeBytes: file.size,
+				width,
+				height,
+			}),
+		});
+		const init = await readJson(initRes);
+		if (!initRes.ok || init?.ok === false) {
+			throw new Error(
+				denialMessage(
+					init?.denial as Denial | undefined,
+					(init?.message as string) ?? "Couldn't start the upload.",
+				),
+			);
+		}
+		const videoUpload = init?.upload as SignedEnvelope | undefined;
+		const posterUpload = init?.posterUpload as SignedEnvelope | undefined;
+		const recastId = init?.recastId as string;
+		if (!videoUpload || videoUpload.method?.toUpperCase() !== "PUT") {
+			throw new Error("This storage provider isn't supported by the web uploader yet.");
+		}
+
+		// Capture the poster while the object URL is still alive (before the
+		// big PUT, so a slow encode doesn't delay finalize).
+		const posterBlob = await capturePosterWebp(video);
+
+		// 2. PUT the video
+		handlers.onPhase?.("uploading");
+		const status = await putWithProgress(videoUpload, file, "video/mp4", handlers.onProgress);
+		if (status < 200 || status >= 300) {
+			throw new Error(`Upload rejected (${status}).`);
+		}
+
+		// 2b. PUT the poster (best-effort)
+		let hasPoster = false;
+		if (posterBlob && posterUpload?.method?.toUpperCase() === "PUT") {
+			try {
+				const ps = await putWithProgress(posterUpload, posterBlob, "image/webp");
+				hasPoster = ps >= 200 && ps < 300;
+			} catch {
+				hasPoster = false;
+			}
+		}
+
+		// 3. complete
+		handlers.onPhase?.("finalizing");
+		const compRes = await fetch("/api/uploads/complete", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ recastId, width, height, durationSec, hasPoster }),
+		});
+		const comp = await readJson(compRes);
+		if (!compRes.ok || comp?.ok === false) {
+			throw new Error(
+				denialMessage(
+					comp?.denial as Denial | undefined,
+					denialMessage(
+						{ reason: comp?.reason as string | undefined },
+						(comp?.message as string) ?? "Couldn't finalize the upload.",
+					),
+				),
+			);
+		}
+
+		// 4. share (public link, matching the desktop "Share to Cloud" default)
+		handlers.onPhase?.("sharing");
+		const shareRes = await fetch(`/api/recasts/${recastId}/share`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ visibility: "public" }),
+		});
+		const shareData = await readJson(shareRes);
+		if (!shareRes.ok || !shareData?.slug) {
+			throw new Error(
+				(shareData?.message as string) ?? "Uploaded, but couldn't create a share link.",
+			);
+		}
+
+		return {
+			recastId,
+			slug: shareData.slug as string,
+			shareUrl: shareData.shareUrl as string,
+		};
+	} finally {
+		URL.revokeObjectURL(objectUrl);
+		if (video) {
+			video.removeAttribute("src");
+			video.load();
+		}
+	}
+}

--- a/apps/web/src/lib/env/schema.ts
+++ b/apps/web/src/lib/env/schema.ts
@@ -188,6 +188,22 @@ export const serverEnvSchema = z
 		// half-filled R2 block (typical when copying from .env.example)
 		// still produces a useful error, while having stray vars from a
 		// provider you switched away from doesn't.
+		// Azure accepts either a bare account name + standalone key, OR a full
+		// connection string pasted into AZURE_STORAGE_ACCOUNT (which carries its
+		// own AccountKey=). Detect the connection-string form with the same regex
+		// `resolveAzureCredentials()` / `isStorageConfigured()` use, and only
+		// require the standalone AZURE_STORAGE_KEY in the bare-name case.
+		const azureIsConnString = /(^|;)\s*AccountName=/i.test(
+			env.AZURE_STORAGE_ACCOUNT ?? "",
+		);
+		const azureVars: (readonly [string, unknown])[] = [
+			["AZURE_STORAGE_ACCOUNT", env.AZURE_STORAGE_ACCOUNT],
+			...(azureIsConnString
+				? []
+				: ([["AZURE_STORAGE_KEY", env.AZURE_STORAGE_KEY]] as const)),
+			["AZURE_BLOB_CONTAINER", env.AZURE_BLOB_CONTAINER],
+		];
+
 		const providerVarSpecs = {
 			r2: {
 				vars: [
@@ -213,11 +229,7 @@ export const serverEnvSchema = z
 				] as const,
 			},
 			azure: {
-				vars: [
-					["AZURE_STORAGE_ACCOUNT", env.AZURE_STORAGE_ACCOUNT],
-					["AZURE_STORAGE_KEY", env.AZURE_STORAGE_KEY],
-					["AZURE_BLOB_CONTAINER", env.AZURE_BLOB_CONTAINER],
-				] as const,
+				vars: azureVars,
 			},
 			gcs: {
 				vars: [

--- a/apps/web/src/lib/share/access.ts
+++ b/apps/web/src/lib/share/access.ts
@@ -1,6 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import { getDb } from "$lib/db";
-import { member, recast, share, user } from "$lib/db/schema";
+import { member, recast, share, shareMember, user } from "$lib/db/schema";
+import { normalizeEmail } from "$lib/share/grant";
 
 /**
  * Share access resolution.
@@ -62,6 +63,7 @@ export type ResolvedShare =
 
 type Viewer = {
 	id: string;
+	email: string;
 	role: string;
 	memberOrgIds: Set<string>;
 } | null;
@@ -70,7 +72,7 @@ export async function loadViewer(userId: string | null | undefined): Promise<Vie
 	if (!userId) return null;
 	const db = getDb();
 	const [u] = await db
-		.select({ id: user.id, role: user.role })
+		.select({ id: user.id, email: user.email, role: user.role })
 		.from(user)
 		.where(eq(user.id, userId))
 		.limit(1);
@@ -81,6 +83,7 @@ export async function loadViewer(userId: string | null | undefined): Promise<Vie
 		.where(eq(member.userId, userId));
 	return {
 		id: u.id,
+		email: u.email,
 		role: u.role,
 		memberOrgIds: new Set(memberships.map((m) => m.organizationId)),
 	};
@@ -89,6 +92,13 @@ export async function loadViewer(userId: string | null | undefined): Promise<Vie
 export async function resolveShareAccess(
 	slug: string,
 	viewer: Viewer,
+	/**
+	 * Email certified by a valid grant cookie (see `$lib/share/grant`), for
+	 * account-less `selected`-share invitees. Null for everyone else. The
+	 * caller derives + verifies the cookie; this function still re-checks the
+	 * email against the allowlist, so a stale grant can't outlive a removal.
+	 */
+	grantedEmail: string | null = null,
 ): Promise<ResolvedShare> {
 	const db = getDb();
 	const rows = await db
@@ -125,16 +135,33 @@ export async function resolveShareAccess(
 		row.organizationId != null &&
 		viewer?.memberOrgIds.has(row.organizationId) === true;
 
+	// `selected` adds a per-share email allowlist on top of owner/admin. A
+	// viewer qualifies via their signed-in email OR an account-less grant
+	// cookie's certified email (`grantedEmail`) — both re-checked against
+	// `share_member` here so removing an invitee revokes access at once.
+	let onAllowlist = false;
+	if (row.visibility === "selected" && !isOwner && !isAdmin) {
+		const candidates = [viewer?.email, grantedEmail]
+			.filter((e): e is string => Boolean(e))
+			.map(normalizeEmail);
+		if (candidates.length > 0) {
+			const members = await db
+				.select({ email: shareMember.email })
+				.from(shareMember)
+				.where(eq(shareMember.shareSlug, slug));
+			const allow = new Set(members.map((m) => normalizeEmail(m.email)));
+			onAllowlist = candidates.some((e) => allow.has(e));
+		}
+	}
+
 	// `workspace` is the canonical name; `team` is the legacy alias. Both
-	// mean "any signed-in member of the share's org". `selected` adds an
-	// allowlist on top — handled in the dedicated player endpoint, not
-	// here; this page-level resolver falls back to owner-only access for
-	// `selected` until the allowlist check is wired into this path.
+	// mean "any signed-in member of the share's org".
 	const canView =
 		row.visibility === "public" ||
 		isOwner ||
 		isAdmin ||
-		((row.visibility === "team" || row.visibility === "workspace") && inOrg);
+		((row.visibility === "team" || row.visibility === "workspace") && inOrg) ||
+		(row.visibility === "selected" && onAllowlist);
 
 	const canManage = isOwner || isAdmin;
 

--- a/apps/web/src/lib/share/client.ts
+++ b/apps/web/src/lib/share/client.ts
@@ -6,6 +6,8 @@
  * heard of Recast.
  */
 
+import { safeStorage } from "@recast/ui/persisted-state";
+
 const SID_KEY = "recast.share.sid";
 const NAME_KEY = "recast.share.name";
 
@@ -33,26 +35,25 @@ export type Engagement = {
 	myReactions: string[];
 };
 
-/** Stable anonymous fingerprint for this browser. Created lazily. */
+/** Stable anonymous fingerprint for this browser. Created lazily. Returns ""
+ *  during SSR (no window) so the server render stays identity-free. */
 export function shareSessionId(): string {
-	if (typeof localStorage === "undefined") return "";
-	let sid = localStorage.getItem(SID_KEY);
+	if (typeof window === "undefined") return "";
+	let sid = safeStorage.get<string>(SID_KEY, "");
 	if (!sid) {
 		sid = crypto.randomUUID();
-		localStorage.setItem(SID_KEY, sid);
+		safeStorage.set(SID_KEY, sid);
 	}
 	return sid;
 }
 
 export function storedViewerName(): string {
-	if (typeof localStorage === "undefined") return "";
-	return localStorage.getItem(NAME_KEY) ?? "";
+	return safeStorage.get<string>(NAME_KEY, "");
 }
 
 export function rememberViewerName(name: string): void {
-	if (typeof localStorage === "undefined") return;
 	const trimmed = name.trim();
-	if (trimmed) localStorage.setItem(NAME_KEY, trimmed);
+	if (trimmed) safeStorage.set(NAME_KEY, trimmed);
 }
 
 const EMPTY: Engagement = {

--- a/apps/web/src/lib/share/grant.ts
+++ b/apps/web/src/lib/share/grant.ts
@@ -1,0 +1,108 @@
+import { serverEnv } from "$lib/env/server";
+
+/**
+ * Account-less access grants for `selected` (invite-only) shares.
+ *
+ * Selected shares list invitees by email in `share_member`. A signed-in user
+ * whose email is on the list is allowed by the normal session path. But many
+ * invitees don't have — and shouldn't need — a Recast account (sign-up is
+ * waitlist-gated). This module gives them a **share-scoped** capability
+ * instead of a global session:
+ *
+ *   1. Invitee enters their email on the share page → `POST .../claim`.
+ *   2. If that email is on the share's allowlist, we email a verify link
+ *      carrying `grantToken(slug, email)` (an HMAC, not a secret to store).
+ *   3. Clicking the link → `GET .../claim/verify` recomputes the token,
+ *      and on a match sets an httpOnly grant cookie, then redirects back.
+ *   4. Every gated request re-derives the granted email from the cookie AND
+ *      re-checks it against `share_member` — so removing an invitee revokes
+ *      access immediately, with no token to invalidate.
+ *
+ * The token is deterministic per (slug, email), mirroring the password
+ * unlock-token design in `./password.ts`: the link is the capability, and
+ * membership is the authority. Keyed by BETTER_AUTH_SECRET, so it can't be
+ * forged and rotates with the secret.
+ */
+
+const GRANT_COOKIE_PREFIX = "recast_grant_";
+
+export function grantCookieName(slug: string): string {
+	return GRANT_COOKIE_PREFIX + slug;
+}
+
+/** Lowercase + trim — the canonical form stored in `share_member.email`. */
+export function normalizeEmail(email: string): string {
+	return email.trim().toLowerCase();
+}
+
+function hex(bytes: Uint8Array): string {
+	let out = "";
+	for (const b of bytes) out += b.toString(16).padStart(2, "0");
+	return out;
+}
+
+/** Deterministic HMAC-SHA-256 over (slug, normalized email), hex, 32 chars. */
+export async function grantToken(slug: string, email: string): Promise<string> {
+	const key = await crypto.subtle.importKey(
+		"raw",
+		new TextEncoder().encode(serverEnv().BETTER_AUTH_SECRET),
+		{ name: "HMAC", hash: "SHA-256" },
+		false,
+		["sign"],
+	);
+	const sig = await crypto.subtle.sign(
+		"HMAC",
+		key,
+		new TextEncoder().encode(`grant:${slug}:${normalizeEmail(email)}`),
+	);
+	return hex(new Uint8Array(sig)).slice(0, 32);
+}
+
+function constantTimeEquals(a: string, b: string): boolean {
+	if (a.length !== b.length) return false;
+	let mismatch = 0;
+	for (let i = 0; i < a.length; i++) {
+		mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	}
+	return mismatch === 0;
+}
+
+// URL-safe base64 of the (ASCII) email so it survives a cookie value next to
+// the hex token, separated by a "." that base64url never emits.
+function b64urlEncode(s: string): string {
+	return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+function b64urlDecode(s: string): string | null {
+	try {
+		const padded = s.replace(/-/g, "+").replace(/_/g, "/");
+		return atob(padded);
+	} catch {
+		return null;
+	}
+}
+
+/** Cookie value binding the verified email to its token: `<b64url(email)>.<token>`. */
+export async function grantCookieValue(slug: string, email: string): Promise<string> {
+	const token = await grantToken(slug, email);
+	return `${b64urlEncode(normalizeEmail(email))}.${token}`;
+}
+
+/**
+ * Parse a grant cookie and return the email it certifies for `slug`, or null
+ * if absent / malformed / forged. Callers MUST still verify the returned
+ * email is on the share's allowlist — this only proves the cookie is genuine.
+ */
+export async function readGrantedEmail(
+	slug: string,
+	cookieValue: string | undefined,
+): Promise<string | null> {
+	if (!cookieValue) return null;
+	const dot = cookieValue.lastIndexOf(".");
+	if (dot <= 0) return null;
+	const email = b64urlDecode(cookieValue.slice(0, dot));
+	const token = cookieValue.slice(dot + 1);
+	if (!email) return null;
+	const expected = await grantToken(slug, email);
+	if (!constantTimeEquals(token, expected)) return null;
+	return normalizeEmail(email);
+}

--- a/apps/web/src/lib/share/grant.ts
+++ b/apps/web/src/lib/share/grant.ts
@@ -58,7 +58,7 @@ export async function grantToken(slug: string, email: string): Promise<string> {
 	return hex(new Uint8Array(sig)).slice(0, 32);
 }
 
-function constantTimeEquals(a: string, b: string): boolean {
+export function constantTimeEquals(a: string, b: string): boolean {
 	if (a.length !== b.length) return false;
 	let mismatch = 0;
 	for (let i = 0; i < a.length; i++) {

--- a/apps/web/src/lib/storage/index.ts
+++ b/apps/web/src/lib/storage/index.ts
@@ -70,13 +70,16 @@ export function isStorageConfigured(): boolean {
 			);
 		case "azure": {
 			const account = env.AZURE_STORAGE_ACCOUNT ?? "";
-			// A connection string carries its own key, so the separate
-			// AZURE_STORAGE_KEY is only required when `account` is a bare name.
-			const isConnString = /(^|;)\s*AccountName=/i.test(account);
+			// A connection string is only self-sufficient when it carries BOTH
+			// AccountName= and AccountKey=. A SAS-based string has AccountName=
+			// but no key, so it still needs the separate AZURE_STORAGE_KEY —
+			// otherwise we'd report "configured" and then auth with an empty key.
+			const hasInlineKey =
+				/(^|;)\s*AccountName=/i.test(account) && /(^|;)\s*AccountKey=/i.test(account);
 			return Boolean(
 				account &&
 					env.AZURE_BLOB_CONTAINER &&
-					(isConnString || env.AZURE_STORAGE_KEY),
+					(hasInlineKey || env.AZURE_STORAGE_KEY),
 			);
 		}
 		case "gcs":

--- a/apps/web/src/lib/storage/index.ts
+++ b/apps/web/src/lib/storage/index.ts
@@ -68,10 +68,17 @@ export function isStorageConfigured(): boolean {
 			return Boolean(
 				env.CLOUDINARY_CLOUD_NAME && env.CLOUDINARY_API_KEY && env.CLOUDINARY_API_SECRET,
 			);
-		case "azure":
+		case "azure": {
+			const account = env.AZURE_STORAGE_ACCOUNT ?? "";
+			// A connection string carries its own key, so the separate
+			// AZURE_STORAGE_KEY is only required when `account` is a bare name.
+			const isConnString = /(^|;)\s*AccountName=/i.test(account);
 			return Boolean(
-				env.AZURE_STORAGE_ACCOUNT && env.AZURE_STORAGE_KEY && env.AZURE_BLOB_CONTAINER,
+				account &&
+					env.AZURE_BLOB_CONTAINER &&
+					(isConnString || env.AZURE_STORAGE_KEY),
 			);
+		}
 		case "gcs":
 			return Boolean(env.GCS_BUCKET && env.GCS_SERVICE_ACCOUNT_JSON);
 		default:
@@ -140,11 +147,20 @@ async function buildFiles(): Promise<{
 
 		case "azure": {
 			const { azure } = await import("files-sdk/azure");
+			// Accept either bare credentials (account name + key) OR a full
+			// connection string pasted into AZURE_STORAGE_ACCOUNT — a common
+			// footgun, since the portal hands you the connection string. When
+			// it's a connection string we parse the account name / key out of
+			// it (the separate AZURE_STORAGE_KEY then becomes optional).
+			const { accountName, accountKey } = resolveAzureCredentials(
+				env.AZURE_STORAGE_ACCOUNT!,
+				env.AZURE_STORAGE_KEY,
+			);
 			return {
 				files: new Files({
 					adapter: azure({
-						accountName: env.AZURE_STORAGE_ACCOUNT!,
-						accountKey: env.AZURE_STORAGE_KEY!,
+						accountName,
+						accountKey,
 						container: env.AZURE_BLOB_CONTAINER!,
 					}),
 				}),
@@ -286,6 +302,34 @@ export function publicObjectUrl(key: string): string | null {
 	const base = cached.publicBaseUrl;
 	if (!base) return null;
 	return `${base.replace(/\/$/, "")}/${encodeURI(key)}`;
+}
+
+/**
+ * Resolve Azure credentials from env, tolerating a full connection string
+ * pasted into the "account" slot (the portal hands you a connection string,
+ * not a bare account name — an easy mistake). Returns the account name + key
+ * the adapter needs. For a plain account name, the separate `keyRaw` is used.
+ */
+function resolveAzureCredentials(
+	accountRaw: string,
+	keyRaw: string | undefined,
+): { accountName: string; accountKey: string } {
+	// Connection string: "Key=Value;Key=Value;..." with AccountName= +
+	// AccountKey= pairs. The base64 AccountKey contains "=" but never ";",
+	// so splitting on ";" and the first "=" is safe.
+	if (/(^|;)\s*AccountName=/i.test(accountRaw)) {
+		const parts: Record<string, string> = {};
+		for (const seg of accountRaw.split(";")) {
+			const eq = seg.indexOf("=");
+			if (eq <= 0) continue;
+			parts[seg.slice(0, eq).trim().toLowerCase()] = seg.slice(eq + 1).trim();
+		}
+		return {
+			accountName: parts.accountname ?? accountRaw,
+			accountKey: parts.accountkey ?? keyRaw ?? "",
+		};
+	}
+	return { accountName: accountRaw, accountKey: keyRaw ?? "" };
 }
 
 function isNotFoundError(err: unknown): boolean {

--- a/apps/web/src/lib/storage/index.ts
+++ b/apps/web/src/lib/storage/index.ts
@@ -194,7 +194,7 @@ export function recastObjectKey(workspaceId: string, recastId: string): string {
 }
 
 export function posterObjectKey(workspaceId: string, recastId: string): string {
-	return `workspace/${workspaceId}/${recastId}.poster.jpg`;
+	return `workspace/${workspaceId}/${recastId}.poster.webp`;
 }
 
 /**

--- a/apps/web/src/lib/storage/index.ts
+++ b/apps/web/src/lib/storage/index.ts
@@ -289,6 +289,31 @@ export async function deleteObject(key: string): Promise<void> {
 }
 
 /**
+ * Resolve a stored `videoUrl` (or any object key) into something a browser
+ * can actually fetch. Uploads persist the *bare key* (e.g.
+ * `workspace/{ws}/{recast}.mp4`); for providers without a public base URL
+ * that key isn't directly playable, so we mint a short-lived signed GET —
+ * the same thing the share page does. Already-absolute URLs (legacy rows,
+ * public-CDN assets) and the unconfigured-storage case pass through
+ * unchanged, and a signing failure degrades to the raw value rather than
+ * throwing the whole page load.
+ */
+export async function resolvePlaybackUrl(
+	keyOrUrl: string | null | undefined,
+	expiresInSeconds?: number,
+): Promise<string> {
+	const value = keyOrUrl ?? "";
+	if (!value || /^https?:\/\//.test(value)) return value;
+	if (!isStorageConfigured()) return value;
+	try {
+		return await signDownloadUrl({ key: value, expiresInSeconds });
+	} catch (err) {
+		console.error("[storage] resolvePlaybackUrl sign failed", err);
+		return value;
+	}
+}
+
+/**
  * Public URL for the object when the provider exposes one (R2 with
  * custom domain, public S3, Cloudinary `secure_url`, etc.). Returns
  * null when only signed reads are possible.

--- a/apps/web/src/lib/storage/quota.ts
+++ b/apps/web/src/lib/storage/quota.ts
@@ -80,6 +80,7 @@ export async function getQuotaSnapshot(
 export type UploadDenial =
 	| { reason: "workspace_not_found" }
 	| { reason: "duration_over_cap"; capSec: number }
+	| { reason: "resolution_over_cap"; heightPx: number; capHeight: number }
 	| {
 			reason: "active_recasts_over_cap";
 			current: number;
@@ -92,6 +93,11 @@ export type UploadDenial =
 			capBytes: number;
 	  };
 
+// Encoders round to even (and occasionally +2/+4) dimensions, so allow a
+// small slack above the plan cap before rejecting — 720p content that lands
+// at 722–728 shouldn't be treated as "over 720p".
+const RESOLUTION_SLACK_PX = 8;
+
 /**
  * Pre-upload gate. Caller passes the **declared** file size and duration
  * from the desktop's local file metadata. Bytes are advisory at this
@@ -101,7 +107,7 @@ export type UploadDenial =
  */
 export function checkUploadAllowed(
 	snapshot: QuotaSnapshot,
-	req: { sizeBytes: number; durationSec: number },
+	req: { sizeBytes: number; durationSec: number; heightPx?: number },
 ): { ok: true } | { ok: false; denial: UploadDenial } {
 	const { limits, usage } = snapshot;
 
@@ -109,6 +115,24 @@ export function checkUploadAllowed(
 		return {
 			ok: false,
 			denial: { reason: "duration_over_cap", capSec: limits.maxDurationSec },
+		};
+	}
+
+	// Resolution gate. Free playback caps at 720p; Pro/Enterprise at 2160p.
+	// Enforced at the source (upload) so we never store frames we'd refuse to
+	// play back. `playbackMaxHeight` is Infinity-free (a concrete px per plan).
+	if (
+		req.heightPx != null &&
+		Number.isFinite(limits.playbackMaxHeight) &&
+		req.heightPx > limits.playbackMaxHeight + RESOLUTION_SLACK_PX
+	) {
+		return {
+			ok: false,
+			denial: {
+				reason: "resolution_over_cap",
+				heightPx: req.heightPx,
+				capHeight: limits.playbackMaxHeight,
+			},
 		};
 	}
 

--- a/apps/web/src/lib/workspace/guard.ts
+++ b/apps/web/src/lib/workspace/guard.ts
@@ -1,0 +1,53 @@
+import { error } from "@sveltejs/kit";
+import { and, eq } from "drizzle-orm";
+import { getAuth } from "$lib/auth/server";
+import { getDb } from "$lib/db";
+import { member, user } from "$lib/db/schema";
+
+/**
+ * Shared auth helpers for workspace-scoped resources (folders, tags, recast
+ * mutations). Centralizes the "signed-in + member of this workspace" check so
+ * the new endpoints don't each re-implement (and drift from) it.
+ */
+
+export type SessionUser = {
+	id: string;
+	email: string;
+	role?: string;
+	activeOrganizationId?: string | null;
+};
+
+/** Resolve the signed-in user or throw 401. */
+export async function requireUser(request: Request): Promise<SessionUser> {
+	const session = (await getAuth()
+		.api.getSession({ headers: request.headers })
+		.catch(() => null)) as { user: SessionUser } | null;
+	if (!session?.user) error(401, "Sign in required");
+	return session.user;
+}
+
+/**
+ * Assert the user is a member of `workspaceId` (or a global admin). Throws
+ * 403 otherwise. Owner-only folders/tags still live inside a workspace, so
+ * membership is the gate; per-folder permissions are a later concern.
+ */
+export async function assertWorkspaceMember(
+	userId: string,
+	workspaceId: string,
+): Promise<void> {
+	const db = getDb();
+	const [m] = await db
+		.select({ id: member.id })
+		.from(member)
+		.where(and(eq(member.userId, userId), eq(member.organizationId, workspaceId)))
+		.limit(1);
+	if (m) return;
+	// Global admins (re-read so a role change takes effect immediately) bypass.
+	const [u] = await db
+		.select({ role: user.role })
+		.from(user)
+		.where(eq(user.id, userId))
+		.limit(1);
+	if (u?.role === "admin") return;
+	error(403, "Not a member of this workspace");
+}

--- a/apps/web/src/routes/(auth)/+layout.svelte
+++ b/apps/web/src/routes/(auth)/+layout.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 	import { ArrowLeft } from "@lucide/svelte";
-	import { NavProgress } from "@recast/ui/nav-progress";
 
 	let { children } = $props();
 </script>
-<NavProgress />
+
 <div class="relative grid min-h-screen place-items-center px-6 py-16 text-foreground">
 	<div
 		aria-hidden="true"

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,66 +1,68 @@
 <script lang="ts">
-	import { dev } from "$app/environment";
-	import { page } from "$app/state";
-	import { analytics } from "$lib/analytics/client";
-	import { webConsent } from "$lib/analytics/consent.svelte";
-	import ConsentBanner from "$lib/components/ConsentBanner.svelte";
-	import { authClient } from "$lib/auth/client";
-	import ImpersonationBanner from "$lib/auth/components/ImpersonationBanner.svelte";
-	import {
-		DevThemeToggle,
-		Navbar,
-		SeoMeta,
-		ThemeShortcut,
-	} from "$lib/components";
-	import { Toaster } from "@recast/ui/sonner";
-	import { ModeWatcher } from "@recast/ui/theme";
-	import "../app.css";
+  import { dev } from "$app/environment";
+  import { page } from "$app/state";
+  import { analytics } from "$lib/analytics/client";
+  import { webConsent } from "$lib/analytics/consent.svelte";
+  import { authClient } from "$lib/auth/client";
+  import ImpersonationBanner from "$lib/auth/components/ImpersonationBanner.svelte";
+  import {
+    DevThemeToggle,
+    Navbar,
+    SeoMeta,
+    ThemeShortcut,
+  } from "$lib/components";
+  import ConsentBanner from "$lib/components/ConsentBanner.svelte";
+  import { NavProgress } from "@recast/ui/nav-progress";
+
+  import { Toaster } from "@recast/ui/sonner";
+  import { ModeWatcher } from "@recast/ui/theme";
+  import "../app.css";
 // Player theme — imported once at the root so any /share or dashboard
-	// route that mounts <RecastPlayer> picks up the branded CSS variables.
-	import "@recast/player/styles.css";
+  // route that mounts <RecastPlayer> picks up the branded CSS variables.
+  import "@recast/player/styles.css";
 
-	let { children } = $props();
+  let { children } = $props();
 
-	// The dashboard, auth, and waitlist screens ship their own focused
-	// shells — keep the marketing chrome off them.
-	const chromelessPaths = new Set([
-		"/login",
-		"/signup",
-		"/forgot-password",
-		"/reset-password",
-		"/waitlist",
-		"/device",
-	]);
-	const isChromeless = $derived(
-		page.url.pathname.startsWith("/dashboard") ||
-			page.url.pathname.startsWith("/admin") ||
-			page.url.pathname.startsWith("/onboarding") ||
-			page.url.pathname.startsWith("/share/") ||
-			page.url.pathname === "/accept-invitation" ||
-			page.url.pathname === "/verify-email" ||
-			chromelessPaths.has(page.url.pathname),
-	);
+  // The dashboard, auth, and waitlist screens ship their own focused
+  // shells — keep the marketing chrome off them.
+  const chromelessPaths = new Set([
+    "/login",
+    "/signup",
+    "/forgot-password",
+    "/reset-password",
+    "/waitlist",
+    "/device",
+  ]);
+  const isChromeless = $derived(
+    page.url.pathname.startsWith("/dashboard") ||
+      page.url.pathname.startsWith("/admin") ||
+      page.url.pathname.startsWith("/onboarding") ||
+      page.url.pathname.startsWith("/share/") ||
+      page.url.pathname === "/accept-invitation" ||
+      page.url.pathname === "/verify-email" ||
+      chromelessPaths.has(page.url.pathname),
+  );
 
-	// Returning visitor who already accepted → re-enable replay + persistent id
-	// before any events fire this session.
-	$effect(() => {
-		if (webConsent.hasAccepted) analytics.upgradePersistence();
-	});
+  // Returning visitor who already accepted → re-enable replay + persistent id
+  // before any events fire this session.
+  $effect(() => {
+    if (webConsent.hasAccepted) analytics.upgradePersistence();
+  });
 
-	// Tie events to the signed-in user (aliases the anonymous distinct id) and
-	// drop the identity on sign-out. Gated by product consent inside the client.
-	const session = authClient.useSession();
-	let lastUserId: string | null = null;
-	$effect(() => {
-		const userId = $session.data?.user?.id ?? null;
-		if (userId && userId !== lastUserId) {
-			analytics.identify(userId);
-			lastUserId = userId;
-		} else if (!userId && lastUserId) {
-			analytics.reset();
-			lastUserId = null;
-		}
-	});
+  // Tie events to the signed-in user (aliases the anonymous distinct id) and
+  // drop the identity on sign-out. Gated by product consent inside the client.
+  const session = authClient.useSession();
+  let lastUserId: string | null = null;
+  $effect(() => {
+    const userId = $session.data?.user?.id ?? null;
+    if (userId && userId !== lastUserId) {
+      analytics.identify(userId);
+      lastUserId = userId;
+    } else if (!userId && lastUserId) {
+      analytics.reset();
+      lastUserId = null;
+    }
+  });
 </script>
 
 <!-- Site-wide default social/SEO tags. Routes that need their own card (e.g.
@@ -68,13 +70,13 @@
 	 own <SeoMeta>; suppressing the default here keeps a single, authoritative
 	 set of og: tags instead of duplicates (scrapers take the first og:image). -->
 {#if !(page.data as { customSeo?: boolean }).customSeo}
-	<SeoMeta
-		title="Record. Polish. Share."
-		description="Recast turns a raw screen capture into a polished, shareable demo. Smart auto-edits and a friendly timeline anyone can drive. macOS, Windows, Linux."
-		pageTitle="Recast - Record. Polish. Share."
-	/>
+  <SeoMeta
+    title="Record. Polish. Share."
+    description="Recast turns a raw screen capture into a polished, shareable demo. Smart auto-edits and a friendly timeline anyone can drive. macOS, Windows, Linux."
+    pageTitle="Recast - Record. Polish. Share."
+  />
 {/if}
-
+<NavProgress />
 <ModeWatcher />
 <!-- Cmd/Ctrl+Shift+L from any route toggles light↔dark. Runs in prod
 	 (DevThemeToggle's floating chip is still dev-only). -->
@@ -85,16 +87,16 @@
 <ImpersonationBanner />
 
 {#if !isChromeless}
-	<div
-		aria-hidden="true"
-		class="bg-grid bg-grid-fade pointer-events-none fixed inset-0 -z-10 opacity-30"
-	></div>
+  <div
+    aria-hidden="true"
+    class="bg-grid bg-grid-fade pointer-events-none fixed inset-0 -z-10 opacity-30"
+  ></div>
 
-	<Navbar />
+  <Navbar />
 {/if}
 
 <div class="relative isolate flex min-h-screen flex-col overflow-x-hidden">
-	{@render children()}
+  {@render children()}
 </div>
 
 <Toaster position="bottom-right" duration={5000} />
@@ -102,5 +104,5 @@
 <ConsentBanner />
 
 {#if dev}
-	<DevThemeToggle />
+  <DevThemeToggle />
 {/if}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -245,9 +245,20 @@
 
 	// "Inside the editor" — honest tour of every tool a non-editor user will
 	// actually touch. Each card is tagged `auto` (it happens for you) or
-	// `manual` (you reach for it when you want control). The placeholder slot
-	// renders a dashed empty frame today so the layout is finalised before the
-	// real screenshots land — flip `image` to a path under /static when ready.
+	// `manual` (you reach for it when you want control).
+	//
+	// SCREENSHOT ASSET SLOTS — drop these PNG files into static/screenshots/
+	// to light up each card. Until a file exists, the matching card falls
+	// back to its `icon` rendered as the hero glyph (still looks deliberate,
+	// not "missing image"). Target dimensions: 880×560 (16:10), tightly
+	// cropped to the feature, dark mode. PNG ≤300 KB.
+	//
+	//   feat-smart-zoom.png       — editor canvas mid-zoom toward a click
+	//   feat-silence-trim.png     — timeline with silence regions highlighted
+	//   feat-cursor-smoothing.png — split / before-after of cursor path
+	//   feat-zoom-regions.png     — timeline with a manual focus region
+	//   feat-annotations.png      — frame with arrow + circle + text overlay
+	//   feat-camera-bubble.png    — webcam bubble showing shape/border options
 	type FeatureKind = "auto" | "manual";
 	const editorFeatures: Array<{
 		kind: FeatureKind;
@@ -262,7 +273,7 @@
 			title: "Smart zoom on clicks",
 			description:
 				"Recast watches your cursor, reads clicks and dwell, and zooms toward the moment that matters. You set zero keyframes.",
-			image: "/screenshots/preview_zoom.png",
+			image: "/screenshots/feat-smart-zoom.png",
 		},
 		{
 			kind: "auto",
@@ -270,7 +281,7 @@
 			title: "Silence trimming",
 			description:
 				"Detects dead-air segments (quiet audio + still cursor) and offers them up as one-click cuts. Toggle them off any time.",
-			image: null,
+			image: "/screenshots/feat-silence-trim.png",
 		},
 		{
 			kind: "auto",
@@ -278,7 +289,7 @@
 			title: "Cursor smoothing",
 			description:
 				"Velocity-aware easing kills the jitter, with optional snap-to-target so the path lands where you meant to point.",
-			image: "/screenshots/preview_cursor.png",
+			image: "/screenshots/feat-cursor-smoothing.png",
 		},
 		{
 			kind: "manual",
@@ -286,7 +297,7 @@
 			title: "Zoom regions on the timeline",
 			description:
 				"Drag any moment to add a focus region. The auto picks are just a starting point. Every position, scale, and easing is yours to tweak.",
-			image: null,
+			image: "/screenshots/feat-zoom-regions.png",
 		},
 		{
 			kind: "manual",
@@ -294,7 +305,7 @@
 			title: "Annotations & blur",
 			description:
 				"Drop arrows, rectangles, text, or a privacy blur straight on the frame. Layers live on the timeline alongside everything else.",
-			image: null,
+			image: "/screenshots/feat-annotations.png",
 		},
 		{
 			kind: "manual",
@@ -302,9 +313,14 @@
 			title: "Camera bubble",
 			description:
 				"Record yourself in a draggable bubble with shape, border, and follow-the-cursor motion. No second app. No green screen.",
-			image: null,
+			image: "/screenshots/feat-camera-bubble.png",
 		},
 	];
+
+	// Per-feature error flag. Flipped by the <img>'s onerror handler when the
+	// asset file isn't there yet — the rail card then falls back to its icon
+	// hero, so a half-produced screenshot batch never shows broken images.
+	let editorImgErrored = $state<Record<string, boolean>>({});
 
 	const kindChip: Record<FeatureKind, { label: string; dot: string; ring: string }> = {
 		auto: {
@@ -692,9 +708,12 @@
 									class="pointer-events-none absolute bottom-3 right-3 size-3 border-b border-r border-foreground/30"
 								></span>
 
-								{#if feature.image}
+								{#if feature.image && !editorImgErrored[feature.title]}
 									<!-- Real screenshot in a tilted plate. Hover eases the
-									     tilt down so the user can see the image flatter. -->
+									     tilt down so the user can see the image flatter.
+									     `onerror` flips the per-card flag so a missing
+									     asset falls back to the icon-hero branch below
+									     instead of rendering a broken-image glyph. -->
 									<div
 										class="absolute inset-6 origin-center overflow-hidden rounded-lg border border-border-low/60 shadow-craft-md transition-transform duration-500 group-hover/feat:scale-[1.02]"
 										style="transform: perspective(900px) rotateX(6deg) rotateY(-10deg); transform-origin: 50% 70%;"
@@ -705,6 +724,7 @@
 											loading="lazy"
 											decoding="async"
 											class="block size-full object-cover"
+											onerror={() => (editorImgErrored[feature.title] = true)}
 										/>
 									</div>
 								{:else}

--- a/apps/web/src/routes/api/folders/+server.ts
+++ b/apps/web/src/routes/api/folders/+server.ts
@@ -1,0 +1,105 @@
+import { error, json } from "@sveltejs/kit";
+import { and, eq } from "drizzle-orm";
+import { getDb } from "$lib/db";
+import { folder } from "$lib/db/schema";
+import { assertWorkspaceMember, requireUser } from "$lib/workspace/guard";
+import type { RequestHandler } from "./$types";
+
+const MAX_NAME = 80;
+const HEX = /^#[0-9a-fA-F]{6}$/;
+
+function cleanColor(v: unknown): string | null {
+	return typeof v === "string" && HEX.test(v.trim()) ? v.trim() : null;
+}
+
+/**
+ * Folders are nested via `parentId` + a materialized `path`. We build the
+ * path from IDs ("/<id>/<id>/") rather than names, so a rename never has to
+ * rewrite descendants — only a move does. `%`-prefix queries on `path` give
+ * cheap subtree reads without recursive CTEs.
+ */
+
+/** GET /api/folders?workspaceId=… — all folders in a workspace (flat; the UI builds the tree). */
+export const GET: RequestHandler = async ({ request, url }) => {
+	const u = await requireUser(request);
+	const workspaceId = url.searchParams.get("workspaceId");
+	if (!workspaceId) error(400, "workspaceId is required");
+	await assertWorkspaceMember(u.id, workspaceId);
+
+	const db = getDb();
+	const rows = await db
+		.select({
+			id: folder.id,
+			parentId: folder.parentId,
+			name: folder.name,
+			color: folder.color,
+			path: folder.path,
+		})
+		.from(folder)
+		.where(eq(folder.workspaceId, workspaceId));
+
+	return json({ ok: true, folders: rows });
+};
+
+/** POST /api/folders — create a folder. Body: { workspaceId, name, parentId?, color? } */
+export const POST: RequestHandler = async ({ request }) => {
+	const u = await requireUser(request);
+
+	let body: {
+		workspaceId?: unknown;
+		name?: unknown;
+		parentId?: unknown;
+		color?: unknown;
+	} = {};
+	try {
+		body = (await request.json()) as typeof body;
+	} catch {
+		error(400, "Invalid JSON body");
+	}
+
+	const workspaceId = typeof body.workspaceId === "string" ? body.workspaceId : "";
+	const name = typeof body.name === "string" ? body.name.trim().slice(0, MAX_NAME) : "";
+	const parentId = typeof body.parentId === "string" && body.parentId ? body.parentId : null;
+	if (!workspaceId) error(400, "workspaceId is required");
+	if (!name) error(400, "Folder name is required");
+
+	await assertWorkspaceMember(u.id, workspaceId);
+
+	const db = getDb();
+
+	// Resolve the parent's path (and confirm it's in the same workspace).
+	let parentPath = "/";
+	if (parentId) {
+		const [parent] = await db
+			.select({ path: folder.path })
+			.from(folder)
+			.where(and(eq(folder.id, parentId), eq(folder.workspaceId, workspaceId)))
+			.limit(1);
+		if (!parent) error(404, "Parent folder not found in this workspace");
+		parentPath = parent.path;
+	}
+
+	const id = crypto.randomUUID();
+	const path = `${parentPath}${id}/`;
+
+	try {
+		await db.insert(folder).values({
+			id,
+			workspaceId,
+			parentId,
+			name,
+			color: cleanColor(body.color),
+			path,
+			createdBy: u.id,
+		});
+	} catch (e) {
+		// Unique (workspace, parentId, name) — a sibling already has this name.
+		const msg = String((e as Error)?.message ?? e);
+		if (msg.includes("folder_parent_name_key")) {
+			error(409, "A folder with that name already exists here");
+		}
+		throw e;
+	}
+
+	return json({ ok: true, folder: { id, parentId, name, color: cleanColor(body.color), path } }, { status: 201 });
+};

--- a/apps/web/src/routes/api/folders/[id]/+server.ts
+++ b/apps/web/src/routes/api/folders/[id]/+server.ts
@@ -1,0 +1,161 @@
+import { error, json } from "@sveltejs/kit";
+import { and, eq, like, ne, sql } from "drizzle-orm";
+import { getDb } from "$lib/db";
+import { folder } from "$lib/db/schema";
+import { assertWorkspaceMember, requireUser } from "$lib/workspace/guard";
+import type { RequestHandler } from "./$types";
+
+const MAX_NAME = 80;
+const HEX = /^#[0-9a-fA-F]{6}$/;
+
+function cleanColor(v: unknown): string | null {
+	return typeof v === "string" && HEX.test(v.trim()) ? v.trim() : null;
+}
+
+async function loadFolder(id: string) {
+	const db = getDb();
+	const [f] = await db
+		.select({
+			id: folder.id,
+			workspaceId: folder.workspaceId,
+			parentId: folder.parentId,
+			path: folder.path,
+		})
+		.from(folder)
+		.where(eq(folder.id, id))
+		.limit(1);
+	return f ?? null;
+}
+
+/**
+ * PATCH /api/folders/[id] — rename / recolor / move.
+ * Body (only provided keys applied):
+ *   - name     : 1–80 chars
+ *   - color    : "#rrggbb" or null
+ *   - parentId : a folder id in the same workspace, or null for root (move)
+ *
+ * Paths are ID-based, so a rename leaves `path` untouched; a move rewrites
+ * this folder's `path` AND every descendant's (prefix swap), guarding
+ * against moving a folder into its own subtree.
+ */
+export const PATCH: RequestHandler = async ({ params, request }) => {
+	const u = await requireUser(request);
+	const f = await loadFolder(params.id);
+	if (!f) error(404, "Folder not found");
+	await assertWorkspaceMember(u.id, f.workspaceId);
+
+	let body: { name?: unknown; color?: unknown; parentId?: unknown } = {};
+	try {
+		body = (await request.json()) as typeof body;
+	} catch {
+		error(400, "Invalid JSON body");
+	}
+
+	const self: { name?: string; color?: string | null; parentId?: string | null; path?: string; updatedAt: Date } = {
+		updatedAt: new Date(),
+	};
+
+	if ("name" in body) {
+		const name = typeof body.name === "string" ? body.name.trim().slice(0, MAX_NAME) : "";
+		if (!name) error(400, "Folder name can't be empty");
+		self.name = name;
+	}
+	if ("color" in body) self.color = cleanColor(body.color);
+
+	const db = getDb();
+
+	// Move: resolve the destination parent + new path, with cycle protection.
+	let moved = false;
+	let oldPath = f.path;
+	let newPath = f.path;
+	if ("parentId" in body) {
+		const newParentId =
+			typeof body.parentId === "string" && body.parentId ? body.parentId : null;
+		if (newParentId === f.id) error(400, "A folder can't be its own parent");
+
+		let newParentPath = "/";
+		if (newParentId) {
+			const [parent] = await db
+				.select({ path: folder.path })
+				.from(folder)
+				.where(and(eq(folder.id, newParentId), eq(folder.workspaceId, f.workspaceId)))
+				.limit(1);
+			if (!parent) error(404, "Destination folder not found in this workspace");
+			// Moving into own subtree would orphan the tree — reject.
+			if (parent.path.startsWith(f.path)) {
+				error(400, "Can't move a folder into itself");
+			}
+			newParentPath = parent.path;
+		}
+		newPath = `${newParentPath}${f.id}/`;
+		if (newPath !== oldPath) {
+			moved = true;
+			self.parentId = newParentId;
+			self.path = newPath;
+		}
+	}
+
+	if (
+		!("name" in self) &&
+		!("color" in self) &&
+		!("parentId" in self)
+	) {
+		error(400, "Nothing to update");
+	}
+
+	try {
+		await db.transaction(async (tx) => {
+			if (moved) {
+				// Rewrite descendants first (prefix swap). Excludes self; self is
+				// updated below with its new parentId too.
+				await tx
+					.update(folder)
+					.set({
+						path: sql`${newPath} || substring(${folder.path} from ${oldPath.length + 1})`,
+						updatedAt: new Date(),
+					})
+					.where(
+						and(
+							eq(folder.workspaceId, f.workspaceId),
+							like(folder.path, `${oldPath}%`),
+							ne(folder.id, f.id),
+						),
+					);
+			}
+			await tx.update(folder).set(self).where(eq(folder.id, f.id));
+		});
+	} catch (e) {
+		const msg = String((e as Error)?.message ?? e);
+		if (msg.includes("folder_parent_name_key")) {
+			error(409, "A folder with that name already exists here");
+		}
+		throw e;
+	}
+
+	return json({
+		ok: true,
+		...(self.name !== undefined ? { name: self.name } : {}),
+		...("color" in self ? { color: self.color } : {}),
+		...(moved ? { parentId: self.parentId, path: self.path } : {}),
+	});
+};
+
+/**
+ * DELETE /api/folders/[id] — delete the folder and its entire subtree.
+ * Recasts inside any deleted folder fall back to root (`recast.folderId`
+ * SET NULL via FK). Local `.recast` files and cloud blobs are untouched.
+ */
+export const DELETE: RequestHandler = async ({ params, request }) => {
+	const u = await requireUser(request);
+	const f = await loadFolder(params.id);
+	if (!f) error(404, "Folder not found");
+	await assertWorkspaceMember(u.id, f.workspaceId);
+
+	const db = getDb();
+	// Subtree incl. self: every folder whose path begins with this one's.
+	await db
+		.delete(folder)
+		.where(and(eq(folder.workspaceId, f.workspaceId), like(folder.path, `${f.path}%`)));
+
+	return json({ ok: true });
+};

--- a/apps/web/src/routes/api/recasts/+server.ts
+++ b/apps/web/src/routes/api/recasts/+server.ts
@@ -99,6 +99,13 @@ export const GET: RequestHandler = async ({ request, url }) => {
 				ORDER BY ${share.createdAt} DESC
 				LIMIT 1
 			)`,
+			// Tag id array per recast (resolved against the workspace tag list
+			// by the client). `[]` when untagged.
+			tags: sql<string[]>`COALESCE((
+				SELECT json_agg(rt.tag_id)
+				FROM recast_tag rt
+				WHERE rt.recast_id = ${recast.id}
+			), '[]'::json)`,
 		})
 		.from(recast)
 		.where(where)
@@ -116,6 +123,7 @@ export const GET: RequestHandler = async ({ request, url }) => {
 			views: Number(r.views ?? 0),
 			createdAt: r.createdAt.getTime(),
 			lastViewedAt: r.lastViewedAt ? r.lastViewedAt.getTime() : null,
+			tags: r.tags ?? [],
 		})),
 	});
 };

--- a/apps/web/src/routes/api/recasts/+server.ts
+++ b/apps/web/src/routes/api/recasts/+server.ts
@@ -3,6 +3,7 @@ import { and, desc, eq, ne, sql } from "drizzle-orm";
 import { getAuth } from "$lib/auth/server";
 import { getDb } from "$lib/db";
 import { member, recast, share } from "$lib/db/schema";
+import { resolvePlaybackUrl } from "$lib/storage";
 import type { RequestHandler } from "./$types";
 
 type SessionShape = {
@@ -116,14 +117,19 @@ export const GET: RequestHandler = async ({ request, url }) => {
 	return json({
 		ok: true,
 		workspaceId,
-		recasts: rows.map((r) => ({
-			...r,
-			// Normalize SQL `bigint`s and `number`s to plain numbers.
-			sizeBytes: Number(r.sizeBytes),
-			views: Number(r.views ?? 0),
-			createdAt: r.createdAt.getTime(),
-			lastViewedAt: r.lastViewedAt ? r.lastViewedAt.getTime() : null,
-			tags: r.tags ?? [],
-		})),
+		recasts: await Promise.all(
+			rows.map(async (r) => ({
+				...r,
+				// `videoUrl` is a bare object key — sign it into a playable URL,
+				// matching the page loaders and the share page.
+				videoUrl: await resolvePlaybackUrl(r.videoUrl),
+				// Normalize SQL `bigint`s and `number`s to plain numbers.
+				sizeBytes: Number(r.sizeBytes),
+				views: Number(r.views ?? 0),
+				createdAt: r.createdAt.getTime(),
+				lastViewedAt: r.lastViewedAt ? r.lastViewedAt.getTime() : null,
+				tags: r.tags ?? [],
+			})),
+		),
 	});
 };

--- a/apps/web/src/routes/api/recasts/[id]/+server.ts
+++ b/apps/web/src/routes/api/recasts/[id]/+server.ts
@@ -1,13 +1,117 @@
 import { error, json } from "@sveltejs/kit";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { getAuth } from "$lib/auth/server";
 import { getDb } from "$lib/db";
-import { recast, user, workspaceUsage } from "$lib/db/schema";
+import { folder, recast, user, workspaceUsage } from "$lib/db/schema";
 import { decrementUsageOnDelete } from "$lib/storage/quota";
 import { deleteObject } from "$lib/storage";
 import type { RequestHandler } from "./$types";
 
 type SessionShape = { user: { id: string; role?: string } };
+
+const MAX_TITLE = 200;
+
+/** Owner-or-admin gate shared by PATCH and DELETE. Returns the recast row. */
+async function authorizeRecast(
+	request: Request,
+	recastId: string,
+): Promise<{
+	id: string;
+	ownerId: string;
+	workspaceId: string;
+	videoUrl: string;
+	sizeBytes: number;
+	status: string;
+}> {
+	const session = (await getAuth()
+		.api.getSession({ headers: request.headers })
+		.catch(() => null)) as SessionShape | null;
+	if (!session?.user) error(401, "Sign in required");
+
+	const db = getDb();
+	const [row] = await db
+		.select({
+			id: recast.id,
+			ownerId: recast.ownerId,
+			workspaceId: recast.workspaceId,
+			videoUrl: recast.videoUrl,
+			sizeBytes: recast.sizeBytes,
+			status: recast.status,
+		})
+		.from(recast)
+		.where(eq(recast.id, recastId))
+		.limit(1);
+	if (!row) error(404, "Recast not found");
+
+	const isOwner = row.ownerId === session.user.id;
+	if (!isOwner) {
+		const [u] = await db
+			.select({ role: user.role })
+			.from(user)
+			.where(eq(user.id, session.user.id))
+			.limit(1);
+		if (u?.role !== "admin") error(403, "Not allowed to modify this recast");
+	}
+	return row;
+}
+
+/**
+ * PATCH /api/recasts/[id]
+ *
+ * Rename and/or move a recast. Body (only provided keys are written):
+ *   - title    : 1–200 chars
+ *   - folderId : a folder id in the SAME workspace, or null to move to root
+ *
+ * Owner or global admin only.
+ */
+export const PATCH: RequestHandler = async ({ params, request }) => {
+	const row = await authorizeRecast(request, params.id);
+
+	let body: { title?: unknown; folderId?: unknown } = {};
+	try {
+		body = (await request.json()) as typeof body;
+	} catch {
+		error(400, "Invalid JSON body");
+	}
+
+	const patch: { title?: string; folderId?: string | null; updatedAt: Date } = {
+		updatedAt: new Date(),
+	};
+
+	if ("title" in body) {
+		const title = typeof body.title === "string" ? body.title.trim().slice(0, MAX_TITLE) : "";
+		if (!title) error(400, "Title can't be empty");
+		patch.title = title;
+	}
+
+	const db = getDb();
+	if ("folderId" in body) {
+		if (body.folderId === null) {
+			patch.folderId = null;
+		} else if (typeof body.folderId === "string") {
+			// The folder must exist and belong to the recast's workspace —
+			// otherwise a user could file a recast into another workspace's tree.
+			const [f] = await db
+				.select({ id: folder.id })
+				.from(folder)
+				.where(and(eq(folder.id, body.folderId), eq(folder.workspaceId, row.workspaceId)))
+				.limit(1);
+			if (!f) error(404, "Folder not found in this workspace");
+			patch.folderId = body.folderId;
+		} else {
+			error(400, "Invalid folderId");
+		}
+	}
+
+	if (!("title" in patch) && !("folderId" in patch)) error(400, "Nothing to update");
+
+	await db.update(recast).set(patch).where(eq(recast.id, row.id));
+	return json({
+		ok: true,
+		...(patch.title !== undefined ? { title: patch.title } : {}),
+		...("folderId" in patch ? { folderId: patch.folderId } : {}),
+	});
+};
 
 /**
  * DELETE /api/recasts/[id]

--- a/apps/web/src/routes/api/recasts/[id]/+server.ts
+++ b/apps/web/src/routes/api/recasts/[id]/+server.ts
@@ -165,13 +165,18 @@ export const DELETE: RequestHandler = async ({ params, request }) => {
 	}
 	if (!isOwner && !isAdmin) error(403, "Not allowed to delete this recast");
 
-	// Best-effort blob delete. Skip legacy/external absolute URLs (only
-	// bare R2 keys are ours to remove). Archived rows may already be blobless
-	// — a 404 from the provider is fine, so swallow errors and still drop the
-	// row rather than stranding it.
+	// Best-effort blob delete. Skip legacy/external absolute URLs (only bare
+	// object keys are ours to remove). Archived rows may already be blobless —
+	// a 404 from the provider is fine, so swallow errors and still drop the row
+	// rather than stranding it. A non-404 failure (e.g. an Azure/S3 auth or
+	// firewall 403) is logged with the key but still non-fatal: orphaning the
+	// blob is recoverable via the storage console; stranding the DB row isn't.
 	if (row.videoUrl && !/^https?:\/\//.test(row.videoUrl)) {
 		await deleteObject(row.videoUrl).catch((err) => {
-			console.error(`[recasts/delete] R2 delete failed for ${row.id}`, err);
+			console.error(
+				`[recasts/delete] blob delete failed for ${row.id} (key=${row.videoUrl}) — row still removed`,
+				err,
+			);
 		});
 	}
 

--- a/apps/web/src/routes/api/recasts/[id]/tags/+server.ts
+++ b/apps/web/src/routes/api/recasts/[id]/tags/+server.ts
@@ -1,0 +1,81 @@
+import { error, json } from "@sveltejs/kit";
+import { and, eq, inArray } from "drizzle-orm";
+import { getDb } from "$lib/db";
+import { recast, recastTag, tag, user } from "$lib/db/schema";
+import { requireUser } from "$lib/workspace/guard";
+import type { RequestHandler } from "./$types";
+
+/** Owner-or-admin gate; returns the recast's workspace for tag validation. */
+async function authorizeRecast(request: Request, recastId: string): Promise<{ workspaceId: string }> {
+	const u = await requireUser(request);
+	const db = getDb();
+	const [r] = await db
+		.select({ ownerId: recast.ownerId, workspaceId: recast.workspaceId })
+		.from(recast)
+		.where(eq(recast.id, recastId))
+		.limit(1);
+	if (!r) error(404, "Recast not found");
+	if (r.ownerId !== u.id) {
+		const [usr] = await db
+			.select({ role: user.role })
+			.from(user)
+			.where(eq(user.id, u.id))
+			.limit(1);
+		if (usr?.role !== "admin") error(403, "Not allowed to modify this recast");
+	}
+	return { workspaceId: r.workspaceId };
+}
+
+/** GET /api/recasts/[id]/tags — the recast's current tags. */
+export const GET: RequestHandler = async ({ params, request }) => {
+	await authorizeRecast(request, params.id);
+	const db = getDb();
+	const rows = await db
+		.select({ id: tag.id, name: tag.name, color: tag.color })
+		.from(recastTag)
+		.innerJoin(tag, eq(recastTag.tagId, tag.id))
+		.where(eq(recastTag.recastId, params.id));
+	return json({ ok: true, tags: rows });
+};
+
+/**
+ * PUT /api/recasts/[id]/tags — replace the recast's tag set wholesale.
+ * Body: { tagIds: string[] }. Every id must be a tag in the recast's own
+ * workspace. Empty array clears all tags.
+ */
+export const PUT: RequestHandler = async ({ params, request }) => {
+	const { workspaceId } = await authorizeRecast(request, params.id);
+
+	let body: { tagIds?: unknown } = {};
+	try {
+		body = (await request.json()) as typeof body;
+	} catch {
+		error(400, "Invalid JSON body");
+	}
+	if (!Array.isArray(body.tagIds)) error(400, "tagIds must be an array");
+	const unique = [...new Set(body.tagIds.filter((x): x is string => typeof x === "string"))];
+
+	const db = getDb();
+
+	// Reject ids that don't belong to this workspace — no cross-workspace tags.
+	if (unique.length > 0) {
+		const valid = await db
+			.select({ id: tag.id })
+			.from(tag)
+			.where(and(eq(tag.workspaceId, workspaceId), inArray(tag.id, unique)));
+		if (valid.length !== unique.length) {
+			error(400, "One or more tags don't belong to this workspace");
+		}
+	}
+
+	await db.transaction(async (tx) => {
+		await tx.delete(recastTag).where(eq(recastTag.recastId, params.id));
+		if (unique.length > 0) {
+			await tx
+				.insert(recastTag)
+				.values(unique.map((tagId) => ({ recastId: params.id, tagId })));
+		}
+	});
+
+	return json({ ok: true, tagIds: unique });
+};

--- a/apps/web/src/routes/api/share/[id]/claim/+server.ts
+++ b/apps/web/src/routes/api/share/[id]/claim/+server.ts
@@ -1,0 +1,92 @@
+import { error, json } from "@sveltejs/kit";
+import { and, eq } from "drizzle-orm";
+import { getDb } from "$lib/db";
+import { share, shareMember } from "$lib/db/schema";
+import { sendEmail } from "$lib/email";
+import {
+	ctaButton,
+	fallbackLink,
+	heading,
+	muted,
+	paragraph,
+	strong,
+	wrap,
+} from "$lib/email/layout";
+import { grantToken, normalizeEmail } from "$lib/share/grant";
+import type { RequestHandler } from "./$types";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * POST /api/share/[id]/claim
+ *
+ * Account-less access request for a `selected` (invite-only) share. The
+ * viewer submits an email; if it's on the share's allowlist we email a
+ * one-click verify link (see ../claim/verify). Mirrors a magic link, but
+ * scoped to this share — it never creates a Recast account, which matters
+ * because sign-up is waitlist-gated.
+ *
+ * Response is intentionally generic ("if you're on the list, check your
+ * mail") so the endpoint can't be used to enumerate who was invited.
+ */
+export const POST: RequestHandler = async ({ params, request, url }) => {
+	let body: { email?: unknown } = {};
+	try {
+		body = (await request.json()) as typeof body;
+	} catch {
+		error(400, "Invalid JSON body");
+	}
+
+	const email = typeof body.email === "string" ? normalizeEmail(body.email) : "";
+	if (!EMAIL_RE.test(email)) error(400, "Enter a valid email address");
+
+	const db = getDb();
+	const [s] = await db
+		.select({ slug: share.slug, visibility: share.visibility })
+		.from(share)
+		.where(eq(share.slug, params.id))
+		.limit(1);
+	if (!s) error(404, "Share not found");
+	if (s.visibility !== "selected") {
+		error(400, "This share isn't invite-only");
+	}
+
+	// On the allowlist? If not, fall through to the same generic reply so the
+	// caller can't tell invited emails from non-invited ones.
+	const [allowed] = await db
+		.select({ id: shareMember.id })
+		.from(shareMember)
+		.where(and(eq(shareMember.shareSlug, s.slug), eq(shareMember.email, email)))
+		.limit(1);
+
+	if (allowed) {
+		const token = await grantToken(s.slug, email);
+		const verifyUrl = `${url.origin}/api/share/${encodeURIComponent(
+			s.slug,
+		)}/claim/verify?e=${encodeURIComponent(email)}&t=${token}`;
+		const shareUrl = `${url.origin}/share/${encodeURIComponent(s.slug)}`;
+
+		await sendEmail({
+			to: email,
+			subject: "Your access link for a Recast recording",
+			text: `You were invited to view a private Recast recording.\n\nOpen this link to get access:\n${verifyUrl}\n\nThe recording lives at ${shareUrl}. If you didn't expect this, you can ignore this email.`,
+			html: wrap({
+				subject: "Your Recast access link",
+				preheader: "Open the recording you were invited to.",
+				body: [
+					heading("You're on the list"),
+					paragraph(
+						`You were invited to view a private Recast recording. Click below to unlock it — no account needed.`,
+					),
+					ctaButton("View the recording", verifyUrl, "accent"),
+					fallbackLink(verifyUrl),
+					muted(
+						`This link is tied to ${strong(email)}. If you didn't request access, you can ignore this email.`,
+					),
+				].join("\n"),
+			}),
+		});
+	}
+
+	return json({ ok: true });
+};

--- a/apps/web/src/routes/api/share/[id]/claim/verify/+server.ts
+++ b/apps/web/src/routes/api/share/[id]/claim/verify/+server.ts
@@ -4,6 +4,7 @@ import { dev } from "$app/environment";
 import { getDb } from "$lib/db";
 import { share, shareMember } from "$lib/db/schema";
 import {
+	constantTimeEquals,
 	grantCookieName,
 	grantCookieValue,
 	grantToken,
@@ -31,8 +32,9 @@ export const GET: RequestHandler = async ({ params, url, cookies }) => {
 	if (!email || !token) redirect(303, `${sharePath}?claim=invalid`);
 
 	const expected = await grantToken(slug, email);
-	// Length-equal compare; tokens are fixed-length hex so this is fine.
-	if (token.length !== expected.length || token !== expected) {
+	// Constant-time compare — this validates an HMAC-derived capability token,
+	// so avoid leaking a timing side-channel on the prefix match.
+	if (!constantTimeEquals(token, expected)) {
 		redirect(303, `${sharePath}?claim=invalid`);
 	}
 

--- a/apps/web/src/routes/api/share/[id]/claim/verify/+server.ts
+++ b/apps/web/src/routes/api/share/[id]/claim/verify/+server.ts
@@ -1,0 +1,66 @@
+import { redirect } from "@sveltejs/kit";
+import { and, eq } from "drizzle-orm";
+import { dev } from "$app/environment";
+import { getDb } from "$lib/db";
+import { share, shareMember } from "$lib/db/schema";
+import {
+	grantCookieName,
+	grantCookieValue,
+	grantToken,
+	normalizeEmail,
+} from "$lib/share/grant";
+import type { RequestHandler } from "./$types";
+
+const GRANT_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+
+/**
+ * GET /api/share/[id]/claim/verify?e=<email>&t=<token>
+ *
+ * The target of the emailed access link. Recomputes the grant token; on a
+ * match (and a still-valid allowlist membership) it sets the httpOnly grant
+ * cookie and bounces the viewer to the share page, now unlocked. Any failure
+ * lands on the share page with `?claim=invalid` so the UI can re-prompt
+ * rather than dead-end.
+ */
+export const GET: RequestHandler = async ({ params, url, cookies }) => {
+	const slug = params.id;
+	const sharePath = `/share/${encodeURIComponent(slug)}`;
+
+	const email = normalizeEmail(url.searchParams.get("e") ?? "");
+	const token = url.searchParams.get("t") ?? "";
+	if (!email || !token) redirect(303, `${sharePath}?claim=invalid`);
+
+	const expected = await grantToken(slug, email);
+	// Length-equal compare; tokens are fixed-length hex so this is fine.
+	if (token.length !== expected.length || token !== expected) {
+		redirect(303, `${sharePath}?claim=invalid`);
+	}
+
+	// Re-check the allowlist + that the share is still invite-only. An owner
+	// who removed the invitee (or changed visibility) revokes the link here.
+	const db = getDb();
+	const [s] = await db
+		.select({ visibility: share.visibility })
+		.from(share)
+		.where(eq(share.slug, slug))
+		.limit(1);
+	if (!s || s.visibility !== "selected") {
+		redirect(303, `${sharePath}?claim=invalid`);
+	}
+	const [allowed] = await db
+		.select({ id: shareMember.id })
+		.from(shareMember)
+		.where(and(eq(shareMember.shareSlug, slug), eq(shareMember.email, email)))
+		.limit(1);
+	if (!allowed) redirect(303, `${sharePath}?claim=invalid`);
+
+	cookies.set(grantCookieName(slug), await grantCookieValue(slug, email), {
+		path: "/",
+		httpOnly: true,
+		secure: !dev,
+		sameSite: "lax",
+		maxAge: GRANT_MAX_AGE,
+	});
+
+	redirect(303, sharePath);
+};

--- a/apps/web/src/routes/api/share/[id]/video/+server.ts
+++ b/apps/web/src/routes/api/share/[id]/video/+server.ts
@@ -8,6 +8,7 @@ import {
 	unlockCookieName,
 	unlockToken,
 } from "$lib/share/password";
+import { grantCookieName, normalizeEmail, readGrantedEmail } from "$lib/share/grant";
 import { isStorageConfigured, signDownloadUrl } from "$lib/storage";
 import type { RequestHandler } from "./$types";
 
@@ -88,25 +89,35 @@ export const GET: RequestHandler = async ({ params, request, cookies }) => {
 		}
 
 		case "selected": {
-			if (!session?.user) error(401, "Sign in required");
-			// Match by userId first (resolved at invite time), falling back
-			// to the email — invites issued before the user existed are only
-			// keyed by email until they're claimed.
-			const allowed = await db
-				.select({ id: shareMember.id })
+			// Owner short-circuits.
+			if (session?.user && s.ownerId === session.user.id) break;
+
+			// Identity can come from a signed-in email OR an account-less grant
+			// cookie (see $lib/share/grant) — both re-checked against the
+			// allowlist below so a removed invitee loses access immediately.
+			const grantedEmail = await readGrantedEmail(
+				s.slug,
+				cookies.get(grantCookieName(s.slug)),
+			);
+			const candidates = [session?.user?.email, grantedEmail]
+				.filter((e): e is string => Boolean(e))
+				.map(normalizeEmail);
+
+			if (candidates.length === 0) {
+				// No session and no grant — signal the player to render the
+				// "request access" prompt rather than a bare 401.
+				return json(
+					{ ok: false, reason: "claim_required" },
+					{ status: 401 },
+				);
+			}
+
+			const members = await db
+				.select({ email: shareMember.email })
 				.from(shareMember)
-				.where(
-					and(
-						eq(shareMember.shareSlug, s.slug),
-						// userId OR email — split into two queries because Drizzle's
-						// OR clause + nullable column is awkward. Owner is always
-						// allowed; check that first to short-circuit.
-						eq(shareMember.email, session.user.email),
-					),
-				)
-				.limit(1);
-			const isOwner = s.ownerId === session.user.id;
-			if (!isOwner && allowed.length === 0) {
+				.where(eq(shareMember.shareSlug, s.slug));
+			const allow = new Set(members.map((m) => normalizeEmail(m.email)));
+			if (!candidates.some((e) => allow.has(e))) {
 				error(403, "Not on the access list");
 			}
 			break;

--- a/apps/web/src/routes/api/share/[id]/view/+server.ts
+++ b/apps/web/src/routes/api/share/[id]/view/+server.ts
@@ -1,0 +1,115 @@
+import { error, json } from "@sveltejs/kit";
+import { and, desc, eq, sql } from "drizzle-orm";
+import { getDb } from "$lib/db";
+import { recast, share, shareView } from "$lib/db/schema";
+import type { RequestHandler } from "./$types";
+
+/**
+ * POST /api/share/[id]/view
+ *
+ * Records viewer engagement. Two events from the player:
+ *   - "start": a new view began — inserts a `share_view` row, bumps the
+ *     cached `share.viewsCount`, and stamps `recast.lastViewedAt`.
+ *   - "ended": playback finished — refreshes `lastViewedAt` and marks the
+ *     session's latest row complete (watch %).
+ *
+ * `lastViewedAt` is the important one: the Free-tier expiry sweep archives
+ * recasts with no views in N days off this column, so without these writes
+ * every Free recast would expire regardless of real engagement.
+ *
+ * Identity is the anonymous `sessionId` fingerprint — viewers never need an
+ * account. We don't gate on visibility here: the client only calls this once
+ * the page loader has already granted access, and the worst a forged call can
+ * do is inflate a view count / keep a recast alive, which is low-stakes.
+ *
+ * Body: { sessionId, event: "start" | "ended", watchPct? }
+ */
+export const POST: RequestHandler = async ({ params, request }) => {
+	let body: {
+		sessionId?: unknown;
+		event?: unknown;
+		watchPct?: unknown;
+	} = {};
+	try {
+		body = (await request.json()) as typeof body;
+	} catch {
+		error(400, "Invalid JSON body");
+	}
+
+	const sessionId =
+		typeof body.sessionId === "string" ? body.sessionId.trim().slice(0, 128) : "";
+	if (!sessionId) error(400, "Missing session");
+	const event = body.event === "ended" ? "ended" : "start";
+	const watchPct =
+		typeof body.watchPct === "number" && Number.isFinite(body.watchPct)
+			? Math.min(100, Math.max(0, Math.round(body.watchPct)))
+			: 0;
+
+	const db = getDb();
+	const [s] = await db
+		.select({
+			slug: share.slug,
+			recastId: share.recastId,
+			expiresAt: share.expiresAt,
+		})
+		.from(share)
+		.where(eq(share.slug, params.id))
+		.limit(1);
+	if (!s) error(404, "Share not found");
+	if (s.expiresAt && s.expiresAt.getTime() < Date.now()) {
+		return json({ ok: false, reason: "expired" }, { status: 410 });
+	}
+
+	// Best-effort geo + UA from edge headers (Vercel / Cloudflare). Truncated
+	// so a hostile UA can't bloat the row.
+	const country =
+		request.headers.get("x-vercel-ip-country") ??
+		request.headers.get("cf-ipcountry") ??
+		null;
+	const userAgent = request.headers.get("user-agent")?.slice(0, 512) ?? null;
+	const now = new Date();
+
+	await db.transaction(async (tx) => {
+		if (event === "start") {
+			await tx.insert(shareView).values({
+				id: crypto.randomUUID(),
+				shareId: s.slug,
+				sessionId,
+				country,
+				userAgent,
+				watchPct,
+				completed: false,
+			});
+			await tx
+				.update(share)
+				.set({ viewsCount: sql`${share.viewsCount} + 1` })
+				.where(eq(share.slug, s.slug));
+		} else {
+			// "ended" — refine this session's most recent row, if any. (A view
+			// that ends without a recorded "start" — e.g. a fast autoplay — just
+			// refreshes lastViewedAt below; we don't fabricate a view row.)
+			const [latest] = await tx
+				.select({ id: shareView.id })
+				.from(shareView)
+				.where(and(eq(shareView.shareId, s.slug), eq(shareView.sessionId, sessionId)))
+				.orderBy(desc(shareView.createdAt))
+				.limit(1);
+			if (latest) {
+				await tx
+					.update(shareView)
+					.set({
+						watchPct: sql`GREATEST(${shareView.watchPct}, ${watchPct})`,
+						completed: true,
+					})
+					.where(eq(shareView.id, latest.id));
+			}
+		}
+
+		await tx
+			.update(recast)
+			.set({ lastViewedAt: now })
+			.where(eq(recast.id, s.recastId));
+	});
+
+	return json({ ok: true });
+};

--- a/apps/web/src/routes/api/tags/+server.ts
+++ b/apps/web/src/routes/api/tags/+server.ts
@@ -1,0 +1,74 @@
+import { error, json } from "@sveltejs/kit";
+import { and, eq } from "drizzle-orm";
+import { getDb } from "$lib/db";
+import { tag } from "$lib/db/schema";
+import { assertWorkspaceMember, requireUser } from "$lib/workspace/guard";
+import type { RequestHandler } from "./$types";
+
+const MAX_NAME = 40;
+const HEX = /^#[0-9a-fA-F]{6}$/;
+
+function cleanColor(v: unknown): string | null {
+	return typeof v === "string" && HEX.test(v.trim()) ? v.trim() : null;
+}
+
+/** GET /api/tags?workspaceId=… — all tags in a workspace. */
+export const GET: RequestHandler = async ({ request, url }) => {
+	const u = await requireUser(request);
+	const workspaceId = url.searchParams.get("workspaceId");
+	if (!workspaceId) error(400, "workspaceId is required");
+	await assertWorkspaceMember(u.id, workspaceId);
+
+	const db = getDb();
+	const rows = await db
+		.select({ id: tag.id, name: tag.name, color: tag.color })
+		.from(tag)
+		.where(eq(tag.workspaceId, workspaceId));
+
+	return json({ ok: true, tags: rows });
+};
+
+/**
+ * POST /api/tags — create a tag. Body: { workspaceId, name, color? }
+ * Idempotent on (workspace, name): re-creating an existing tag returns it
+ * (200) rather than erroring, so the UI's "type to create" stays friendly.
+ */
+export const POST: RequestHandler = async ({ request }) => {
+	const u = await requireUser(request);
+
+	let body: { workspaceId?: unknown; name?: unknown; color?: unknown } = {};
+	try {
+		body = (await request.json()) as typeof body;
+	} catch {
+		error(400, "Invalid JSON body");
+	}
+
+	const workspaceId = typeof body.workspaceId === "string" ? body.workspaceId : "";
+	const name = typeof body.name === "string" ? body.name.trim().slice(0, MAX_NAME) : "";
+	if (!workspaceId) error(400, "workspaceId is required");
+	if (!name) error(400, "Tag name is required");
+
+	await assertWorkspaceMember(u.id, workspaceId);
+
+	const db = getDb();
+	const id = crypto.randomUUID();
+	const color = cleanColor(body.color);
+
+	const inserted = await db
+		.insert(tag)
+		.values({ id, workspaceId, name, color })
+		.onConflictDoNothing({ target: [tag.workspaceId, tag.name] })
+		.returning({ id: tag.id, name: tag.name, color: tag.color });
+
+	if (inserted[0]) {
+		return json({ ok: true, tag: inserted[0] }, { status: 201 });
+	}
+
+	// Already existed — return the existing row.
+	const [existing] = await db
+		.select({ id: tag.id, name: tag.name, color: tag.color })
+		.from(tag)
+		.where(and(eq(tag.workspaceId, workspaceId), eq(tag.name, name)))
+		.limit(1);
+	return json({ ok: true, tag: existing });
+};

--- a/apps/web/src/routes/api/tags/+server.ts
+++ b/apps/web/src/routes/api/tags/+server.ts
@@ -70,5 +70,8 @@ export const POST: RequestHandler = async ({ request }) => {
 		.from(tag)
 		.where(and(eq(tag.workspaceId, workspaceId), eq(tag.name, name)))
 		.limit(1);
+	// The conflict fired but the row is gone (concurrent delete / collation
+	// mismatch). Don't ship a 200 with `tag: undefined` — fail loudly instead.
+	if (!existing) error(500, "Tag creation conflicted but the existing tag could not be found");
 	return json({ ok: true, tag: existing });
 };

--- a/apps/web/src/routes/api/tags/[id]/+server.ts
+++ b/apps/web/src/routes/api/tags/[id]/+server.ts
@@ -1,0 +1,70 @@
+import { error, json } from "@sveltejs/kit";
+import { eq } from "drizzle-orm";
+import { getDb } from "$lib/db";
+import { tag } from "$lib/db/schema";
+import { assertWorkspaceMember, requireUser } from "$lib/workspace/guard";
+import type { RequestHandler } from "./$types";
+
+const MAX_NAME = 40;
+const HEX = /^#[0-9a-fA-F]{6}$/;
+
+function cleanColor(v: unknown): string | null {
+	return typeof v === "string" && HEX.test(v.trim()) ? v.trim() : null;
+}
+
+async function loadTag(id: string) {
+	const db = getDb();
+	const [t] = await db
+		.select({ id: tag.id, workspaceId: tag.workspaceId })
+		.from(tag)
+		.where(eq(tag.id, id))
+		.limit(1);
+	return t ?? null;
+}
+
+/** PATCH /api/tags/[id] — rename / recolor. Body: { name?, color? } */
+export const PATCH: RequestHandler = async ({ params, request }) => {
+	const u = await requireUser(request);
+	const t = await loadTag(params.id);
+	if (!t) error(404, "Tag not found");
+	await assertWorkspaceMember(u.id, t.workspaceId);
+
+	let body: { name?: unknown; color?: unknown } = {};
+	try {
+		body = (await request.json()) as typeof body;
+	} catch {
+		error(400, "Invalid JSON body");
+	}
+
+	const patch: { name?: string; color?: string | null } = {};
+	if ("name" in body) {
+		const name = typeof body.name === "string" ? body.name.trim().slice(0, MAX_NAME) : "";
+		if (!name) error(400, "Tag name can't be empty");
+		patch.name = name;
+	}
+	if ("color" in body) patch.color = cleanColor(body.color);
+	if (Object.keys(patch).length === 0) error(400, "Nothing to update");
+
+	const db = getDb();
+	try {
+		await db.update(tag).set(patch).where(eq(tag.id, t.id));
+	} catch (e) {
+		if (String((e as Error)?.message ?? e).includes("tag_workspace_name_key")) {
+			error(409, "A tag with that name already exists");
+		}
+		throw e;
+	}
+	return json({ ok: true, ...patch });
+};
+
+/** DELETE /api/tags/[id] — remove a tag (its recast assignments cascade). */
+export const DELETE: RequestHandler = async ({ params, request }) => {
+	const u = await requireUser(request);
+	const t = await loadTag(params.id);
+	if (!t) error(404, "Tag not found");
+	await assertWorkspaceMember(u.id, t.workspaceId);
+
+	const db = getDb();
+	await db.delete(tag).where(eq(tag.id, t.id));
+	return json({ ok: true });
+};

--- a/apps/web/src/routes/api/uploads/complete/+server.ts
+++ b/apps/web/src/routes/api/uploads/complete/+server.ts
@@ -5,7 +5,13 @@ import { getAuth } from "$lib/auth/server";
 import { getDb } from "$lib/db";
 import { recast } from "$lib/db/schema";
 import { bumpUsageOnUpload, getQuotaSnapshot } from "$lib/storage/quota";
-import { deleteObject, isStorageConfigured, statObject } from "$lib/storage";
+import {
+	deleteObject,
+	isStorageConfigured,
+	posterObjectKey,
+	publicObjectUrl,
+	statObject,
+} from "$lib/storage";
 import type { RequestHandler } from "./$types";
 
 type SessionShape = { user: { id: string } };
@@ -16,6 +22,8 @@ const BodySchema = z.object({
 	height: z.number().int().positive().optional(),
 	fps: z.number().int().positive().max(240).optional(),
 	durationSec: z.number().int().nonnegative().max(24 * 60 * 60).optional(),
+	/** Client PUT a poster WebP to the signed URL from /init. */
+	hasPoster: z.boolean().optional(),
 });
 
 /**
@@ -103,6 +111,30 @@ export const POST: RequestHandler = async ({ request }) => {
 	// past the cap, refuse and clean up.
 	const snapshot = await getQuotaSnapshot(row.workspaceId);
 	if (snapshot) {
+		// Resolution backstop — mirrors the init gate so a client that lied
+		// about (or skipped) `height` at init can't slip an over-cap file
+		// through. Reject + clean up rather than publish a frame we'd refuse
+		// to play back.
+		if (
+			body.height != null &&
+			Number.isFinite(snapshot.limits.playbackMaxHeight) &&
+			body.height > snapshot.limits.playbackMaxHeight + 8
+		) {
+			await deleteObject(row.videoUrl).catch(() => {});
+			await db.delete(recast).where(eq(recast.id, row.id));
+			return json(
+				{
+					ok: false,
+					denial: {
+						reason: "resolution_over_cap",
+						heightPx: body.height,
+						capHeight: snapshot.limits.playbackMaxHeight,
+					},
+				},
+				{ status: 402 },
+			);
+		}
+
 		const projected = snapshot.usage.storageBytes + actualBytes;
 		if (projected > snapshot.limits.storageBytes) {
 			await deleteObject(row.videoUrl).catch(() => {});
@@ -122,6 +154,17 @@ export const POST: RequestHandler = async ({ request }) => {
 		}
 	}
 
+	// Poster: the client PUT a WebP frame to the signed URL from /init. We
+	// store an absolute public URL (posters aren't sensitive and benefit from
+	// CDN caching; the video itself stays signed/gated). If the provider has
+	// no public base configured, `publicObjectUrl` returns null and we leave
+	// posterUrl unset — cards fall back to their placeholder.
+	let posterUrl: string | undefined;
+	if (body.hasPoster) {
+		posterUrl =
+			publicObjectUrl(posterObjectKey(row.workspaceId, row.id)) ?? undefined;
+	}
+
 	await db.transaction(async (tx) => {
 		await tx
 			.update(recast)
@@ -131,6 +174,7 @@ export const POST: RequestHandler = async ({ request }) => {
 				height: body.height,
 				fps: body.fps,
 				durationSec: body.durationSec ?? undefined,
+				posterUrl,
 				status: "published",
 				updatedAt: new Date(),
 			})

--- a/apps/web/src/routes/api/uploads/init/+server.ts
+++ b/apps/web/src/routes/api/uploads/init/+server.ts
@@ -11,6 +11,7 @@ import {
 } from "$lib/storage/quota";
 import {
 	isStorageConfigured,
+	posterObjectKey,
 	recastObjectKey,
 	signUploadUrl,
 } from "$lib/storage";
@@ -97,6 +98,7 @@ export const POST: RequestHandler = async ({ request }) => {
 	const gate = checkUploadAllowed(snapshot, {
 		sizeBytes: body.sizeBytes,
 		durationSec: body.durationSec,
+		heightPx: body.height,
 	});
 	if (!gate.ok) {
 		return json(
@@ -138,6 +140,20 @@ export const POST: RequestHandler = async ({ request }) => {
 		error(500, "Could not generate upload URL");
 	}
 
+	// Also sign a poster PUT (a single WebP frame). Best-effort and
+	// non-fatal: if it fails, the client simply skips the poster and the
+	// recast keeps a null `posterUrl`. The video is the only required asset.
+	let posterUpload;
+	try {
+		posterUpload = await signUploadUrl({
+			key: posterObjectKey(workspaceId, recastId),
+			contentType: "image/webp",
+		});
+	} catch (err) {
+		console.error("[uploads/init] poster sign failed (non-fatal)", err);
+		posterUpload = undefined;
+	}
+
 	// `upload` is a discriminated union from files-sdk:
 	//   PUT  → { method: "PUT", url, headers? }
 	//   POST → { method: "POST", url, fields }
@@ -147,6 +163,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		recastId,
 		key,
 		upload,
+		posterUpload,
 		expiresInSeconds: 15 * 60,
 	});
 };
@@ -156,8 +173,9 @@ function denialStatus(d: UploadDenial): number {
 		case "workspace_not_found":
 			return 404;
 		case "duration_over_cap":
+		case "resolution_over_cap":
 		case "active_recasts_over_cap":
 		case "storage_over_cap":
-			return 402; // Payment Required — quota gate
+			return 402; // Payment Required — quota / plan gate
 	}
 }

--- a/apps/web/src/routes/dashboard/+page.server.ts
+++ b/apps/web/src/routes/dashboard/+page.server.ts
@@ -1,6 +1,7 @@
 import { desc, eq, sql } from "drizzle-orm";
 import { getDb } from "$lib/db";
 import { recast, share } from "$lib/db/schema";
+import { resolvePlaybackUrl } from "$lib/storage";
 import type { PageServerLoad } from "./$types";
 
 /**
@@ -47,14 +48,19 @@ export const load: PageServerLoad = async ({ parent }) => {
 		.limit(12);
 
 	return {
-		recasts: recasts
-			.filter((r) => r.status !== "archived")
-			.map((r) => ({
-				...r,
-				sizeBytes: Number(r.sizeBytes),
-				views: Number(r.views ?? 0),
-				createdAt: r.createdAt.getTime(),
-			})),
+		// `videoUrl` is a bare object key — sign it into a playable URL (mirrors
+		// the share page; signing is local, and the list is capped at 12 here).
+		recasts: await Promise.all(
+			recasts
+				.filter((r) => r.status !== "archived")
+				.map(async (r) => ({
+					...r,
+					videoUrl: await resolvePlaybackUrl(r.videoUrl),
+					sizeBytes: Number(r.sizeBytes),
+					views: Number(r.views ?? 0),
+					createdAt: r.createdAt.getTime(),
+				})),
+		),
 	};
 };
 

--- a/apps/web/src/routes/dashboard/+page.svelte
+++ b/apps/web/src/routes/dashboard/+page.svelte
@@ -31,6 +31,10 @@
 			source: r.source as Recast["source"],
 			provider: r.provider,
 			views: r.views,
+			// The home overview doesn't surface folders/tags — default them so
+			// the shared Recast shape stays satisfied.
+			folderId: null,
+			tags: [],
 			// `videoUrl` here is the R2 key (or external URL). The share
 			// page signs it before playback; the dashboard card just uses
 			// the poster + title, so leaving it un-signed is fine.

--- a/apps/web/src/routes/dashboard/recasts/+page.server.ts
+++ b/apps/web/src/routes/dashboard/recasts/+page.server.ts
@@ -1,58 +1,86 @@
 import { desc, eq, ne, and, sql } from "drizzle-orm";
 import { getDb } from "$lib/db";
-import { recast, share } from "$lib/db/schema";
+import { folder, recast, share, tag } from "$lib/db/schema";
 import type { PageServerLoad } from "./$types";
 
 /**
  * Full library loader. Larger limit than the home page; archived rows
  * are excluded since they live behind their own tab (not built yet —
  * trivial follow-up: parametrize on `?status=archived`).
+ *
+ * Returns the recast list (each with its `folderId` + `tags` id array),
+ * plus the workspace's folder tree and tag set, so the library can render
+ * organization without extra client round-trips on first paint.
  */
 export const load: PageServerLoad = async ({ parent }) => {
 	const { activeOrganization } = await parent();
 	const db = getDb();
+	const workspaceId = activeOrganization.id;
 
-	const rows = await db
-		.select({
-			id: recast.id,
-			title: recast.title,
-			durationSec: recast.durationSec,
-			sizeBytes: recast.sizeBytes,
-			source: recast.source,
-			provider: recast.provider,
-			status: recast.status,
-			videoUrl: recast.videoUrl,
-			posterUrl: recast.posterUrl,
-			createdAt: recast.createdAt,
-			views: sql<number>`COALESCE((
-				SELECT SUM(${share.viewsCount})
-				FROM ${share}
-				WHERE ${share.recastId} = ${recast.id}
-			), 0)`,
-			latestShareSlug: sql<string | null>`(
-				SELECT ${share.slug}
-				FROM ${share}
-				WHERE ${share.recastId} = ${recast.id}
-				ORDER BY ${share.createdAt} DESC
-				LIMIT 1
-			)`,
-		})
-		.from(recast)
-		.where(
-			and(
-				eq(recast.workspaceId, activeOrganization.id),
-				ne(recast.status, "archived"),
-			),
-		)
-		.orderBy(desc(recast.createdAt))
-		.limit(200);
+	const [rows, folders, tags] = await Promise.all([
+		db
+			.select({
+				id: recast.id,
+				title: recast.title,
+				durationSec: recast.durationSec,
+				sizeBytes: recast.sizeBytes,
+				source: recast.source,
+				provider: recast.provider,
+				status: recast.status,
+				folderId: recast.folderId,
+				videoUrl: recast.videoUrl,
+				posterUrl: recast.posterUrl,
+				createdAt: recast.createdAt,
+				views: sql<number>`COALESCE((
+					SELECT SUM(${share.viewsCount})
+					FROM ${share}
+					WHERE ${share.recastId} = ${recast.id}
+				), 0)`,
+				latestShareSlug: sql<string | null>`(
+					SELECT ${share.slug}
+					FROM ${share}
+					WHERE ${share.recastId} = ${recast.id}
+					ORDER BY ${share.createdAt} DESC
+					LIMIT 1
+				)`,
+				// Tag id array per recast — resolved against the `tags` list
+				// below in the UI. `[]` when untagged.
+				tags: sql<string[]>`COALESCE((
+					SELECT json_agg(rt.tag_id)
+					FROM recast_tag rt
+					WHERE rt.recast_id = ${recast.id}
+				), '[]'::json)`,
+			})
+			.from(recast)
+			.where(and(eq(recast.workspaceId, workspaceId), ne(recast.status, "archived")))
+			.orderBy(desc(recast.createdAt))
+			.limit(200),
+		db
+			.select({
+				id: folder.id,
+				parentId: folder.parentId,
+				name: folder.name,
+				color: folder.color,
+				path: folder.path,
+			})
+			.from(folder)
+			.where(eq(folder.workspaceId, workspaceId)),
+		db
+			.select({ id: tag.id, name: tag.name, color: tag.color })
+			.from(tag)
+			.where(eq(tag.workspaceId, workspaceId)),
+	]);
 
 	return {
+		workspaceId,
 		recasts: rows.map((r) => ({
 			...r,
 			sizeBytes: Number(r.sizeBytes),
 			views: Number(r.views ?? 0),
 			createdAt: r.createdAt.getTime(),
+			tags: r.tags ?? [],
 		})),
+		folders,
+		tags,
 	};
 };

--- a/apps/web/src/routes/dashboard/recasts/+page.server.ts
+++ b/apps/web/src/routes/dashboard/recasts/+page.server.ts
@@ -2,6 +2,7 @@ import { and, desc, eq, isNull, ne, sql } from "drizzle-orm";
 import { getDb } from "$lib/db";
 import { folder, recast, share, tag } from "$lib/db/schema";
 import { QUOTA } from "$lib/db/schema/usage";
+import { resolvePlaybackUrl } from "$lib/storage";
 import type { PageServerLoad } from "./$types";
 
 // Archived rows only ever belong to Free workspaces (Pro/Enterprise never
@@ -104,13 +105,18 @@ export const load: PageServerLoad = async ({ parent }) => {
 
 	return {
 		workspaceId,
-		recasts: rows.map((r) => ({
-			...r,
-			sizeBytes: Number(r.sizeBytes),
-			views: Number(r.views ?? 0),
-			createdAt: r.createdAt.getTime(),
-			tags: r.tags ?? [],
-		})),
+		// `videoUrl` is stored as a bare object key; sign it into a playable URL
+		// the same way the share page does (signing is local/cheap per row).
+		recasts: await Promise.all(
+			rows.map(async (r) => ({
+				...r,
+				videoUrl: await resolvePlaybackUrl(r.videoUrl),
+				sizeBytes: Number(r.sizeBytes),
+				views: Number(r.views ?? 0),
+				createdAt: r.createdAt.getTime(),
+				tags: r.tags ?? [],
+			})),
+		),
 		archived: archivedRows.map((r) => {
 			const archivedMs = (r.archivedAt ?? r.createdAt).getTime();
 			return {

--- a/apps/web/src/routes/dashboard/recasts/+page.server.ts
+++ b/apps/web/src/routes/dashboard/recasts/+page.server.ts
@@ -1,23 +1,33 @@
-import { desc, eq, ne, and, sql } from "drizzle-orm";
+import { and, desc, eq, isNull, ne, sql } from "drizzle-orm";
 import { getDb } from "$lib/db";
 import { folder, recast, share, tag } from "$lib/db/schema";
+import { QUOTA } from "$lib/db/schema/usage";
 import type { PageServerLoad } from "./$types";
 
+// Archived rows only ever belong to Free workspaces (Pro/Enterprise never
+// auto-archive), so the Free hard-delete window is the correct countdown for
+// every archived recast we surface.
+const HARD_DELETE_DAYS = QUOTA.free.hardDeleteAfterArchiveDays ?? 16;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 /**
- * Full library loader. Larger limit than the home page; archived rows
- * are excluded since they live behind their own tab (not built yet —
- * trivial follow-up: parametrize on `?status=archived`).
+ * Full library loader. Larger limit than the home page.
  *
- * Returns the recast list (each with its `folderId` + `tags` id array),
- * plus the workspace's folder tree and tag set, so the library can render
- * organization without extra client round-trips on first paint.
+ * Returns the active recast list (each with its `folderId` + `tags` id
+ * array), plus the workspace's folder tree and tag set, so the library can
+ * render organization without extra client round-trips on first paint.
+ *
+ * Also returns the workspace's `archived` recasts — blobless rows the expiry
+ * job parked after 14 days with no views. These power the "Archived" tab,
+ * which lets the owner delete them outright or re-upload from desktop before
+ * the hard-delete sweep purges them at `archivedAt + 16d`.
  */
 export const load: PageServerLoad = async ({ parent }) => {
 	const { activeOrganization } = await parent();
 	const db = getDb();
 	const workspaceId = activeOrganization.id;
 
-	const [rows, folders, tags] = await Promise.all([
+	const [rows, archivedRows, folders, tags] = await Promise.all([
 		db
 			.select({
 				id: recast.id,
@@ -57,6 +67,27 @@ export const load: PageServerLoad = async ({ parent }) => {
 			.limit(200),
 		db
 			.select({
+				id: recast.id,
+				title: recast.title,
+				durationSec: recast.durationSec,
+				sizeBytes: recast.sizeBytes,
+				posterUrl: recast.posterUrl,
+				archivedAt: recast.archivedAt,
+				createdAt: recast.createdAt,
+			})
+			.from(recast)
+			.where(
+				and(
+					eq(recast.workspaceId, workspaceId),
+					eq(recast.status, "archived"),
+					// Rows the hard-delete sweep has tombstoned are effectively gone.
+					isNull(recast.deletedAt),
+				),
+			)
+			.orderBy(desc(recast.archivedAt))
+			.limit(100),
+		db
+			.select({
 				id: folder.id,
 				parentId: folder.parentId,
 				name: folder.name,
@@ -80,6 +111,19 @@ export const load: PageServerLoad = async ({ parent }) => {
 			createdAt: r.createdAt.getTime(),
 			tags: r.tags ?? [],
 		})),
+		archived: archivedRows.map((r) => {
+			const archivedMs = (r.archivedAt ?? r.createdAt).getTime();
+			return {
+				id: r.id,
+				title: r.title,
+				durationSec: r.durationSec,
+				sizeBytes: Number(r.sizeBytes),
+				posterUrl: r.posterUrl,
+				archivedAt: archivedMs,
+				// When the hard-delete sweep will purge the row + poster for good.
+				deletesAt: archivedMs + HARD_DELETE_DAYS * DAY_MS,
+			};
+		}),
 		folders,
 		tags,
 	};

--- a/apps/web/src/routes/dashboard/recasts/+page.svelte
+++ b/apps/web/src/routes/dashboard/recasts/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { invalidateAll } from "$app/navigation";
 	import * as api from "$lib/dashboard/api";
 	import ArchivedCard, { type ArchivedRecast } from "$lib/dashboard/components/ArchivedCard.svelte";
 	import FolderRail, { type FolderSelection } from "$lib/dashboard/components/FolderRail.svelte";
@@ -10,16 +11,15 @@
 	import { focusOnMount } from "$lib/dashboard/focus";
 	import { formatBytes } from "$lib/dashboard/format";
 	import { foldersStore, tagsStore } from "$lib/dashboard/library.svelte";
-	import { UPLOAD_ACCEPT, uploadRecastFile, type UploadPhase } from "$lib/dashboard/upload";
 	import {
 	  recastsStore,
 	  type Recast,
 	  type RecordingSource,
 	} from "$lib/dashboard/store.svelte";
-	import { invalidateAll } from "$app/navigation";
-	import { Chip } from "@recast/ui/chip";
+	import { UPLOAD_ACCEPT, uploadRecastFile, type UploadPhase } from "$lib/dashboard/upload";
 	import { Archive, Cloud, Film, FolderOpen, HardDrive, Library, LoaderCircle, Plus, Search, Settings2, Upload, Video, X } from "@lucide/svelte";
 	import { Button } from "@recast/ui/button";
+	import { Chip } from "@recast/ui/chip";
 	import * as Select from "@recast/ui/select";
 	import { toast } from "@recast/ui/sonner";
 	import { untrack } from "svelte";
@@ -260,7 +260,7 @@
 
 	async function copyLink(rec: Recast) {
 		try {
-			await navigator.clipboard.writeText(`https://recast.nexonauts.com/v/${rec.id}`);
+			await navigator.clipboard.writeText(`https://recast.li/share/${rec.id}`);
 			toast.success("Share link copied to clipboard.");
 		} catch {
 			toast.error("Couldn't access the clipboard.");

--- a/apps/web/src/routes/dashboard/recasts/+page.svelte
+++ b/apps/web/src/routes/dashboard/recasts/+page.svelte
@@ -1,27 +1,32 @@
 <script lang="ts">
+	import * as api from "$lib/dashboard/api";
+	import FolderRail, { type FolderSelection } from "$lib/dashboard/components/FolderRail.svelte";
 	import PlayerDialog from "$lib/dashboard/components/PlayerDialog.svelte";
 	import RecastCard from "$lib/dashboard/components/RecastCard.svelte";
 	import RenameDialog from "$lib/dashboard/components/RenameDialog.svelte";
 	import StatCard from "$lib/dashboard/components/StatCard.svelte";
+	import { focusOnMount } from "$lib/dashboard/focus";
 	import { formatBytes } from "$lib/dashboard/format";
+	import { foldersStore, tagsStore } from "$lib/dashboard/library.svelte";
 	import {
 	  recastsStore,
 	  settingsStore,
 	  type Recast,
 	  type RecordingSource,
 	} from "$lib/dashboard/store.svelte";
-	import { Cloud, Film, HardDrive, LoaderCircle, Search, Upload, Video, X } from "@lucide/svelte";
+	import { Chip } from "@recast/ui/chip";
+	import { Cloud, Film, FolderOpen, HardDrive, LoaderCircle, Plus, Search, Upload, Video, X } from "@lucide/svelte";
 	import { Button } from "@recast/ui/button";
 	import * as Select from "@recast/ui/select";
 	import { toast } from "@recast/ui/sonner";
 	import { untrack } from "svelte";
 	import { flip } from "svelte/animate";
 	import { cubicOut } from "svelte/easing";
-	import { fly, scale } from "svelte/transition";
+	import { fly, scale, slide } from "svelte/transition";
 
 	let { data } = $props();
 
-	// Hydrate from the server. Same shape mapping as the home page.
+	// Hydrate recasts + folders + tags from the server.
 	$effect(() => {
 		const mapped = data.recasts.map((r) => ({
 			id: r.id,
@@ -32,25 +37,38 @@
 			source: r.source as Recast["source"],
 			provider: r.provider,
 			views: r.views,
+			folderId: r.folderId ?? null,
+			tags: r.tags ?? [],
 			videoUrl: r.videoUrl,
 			posterUrl: r.posterUrl ?? "",
 		}));
-		// `hydrate` writes (and `persist` reads back) `recastsStore.items`.
-		// Untrack it so the effect depends only on `data.recasts`, not on the
-		// state it mutates — otherwise it re-triggers itself forever.
-		untrack(() => recastsStore.hydrate(mapped));
+		const folders = data.folders;
+		const tags = data.tags;
+		untrack(() => {
+			recastsStore.hydrate(mapped);
+			foldersStore.hydrate(folders);
+			tagsStore.hydrate(tags);
+		});
 	});
+
+	const workspaceId = $derived(data.workspaceId);
 
 	type SortKey = "recent" | "oldest" | "name" | "largest";
 
 	let query = $state("");
 	let activeFilter = $state<RecordingSource | "all">("all");
 	let sortKey = $state<string>("recent");
+	let selectedFolder = $state<FolderSelection>("all");
+	let selectedTagIds = $state<string[]>([]);
 
 	let playing = $state<Recast | null>(null);
 	let renaming = $state<Recast | null>(null);
 	let uploading = $state(false);
 	let fileInput = $state<HTMLInputElement | null>(null);
+
+	// Inline tag creation in the filter bar.
+	let creatingTag = $state(false);
+	let newTagName = $state("");
 
 	const filters: { label: string; value: RecordingSource | "all" }[] = [
 		{ label: "All", value: "all" },
@@ -65,11 +83,24 @@
 		{ label: "Largest first", value: "largest" },
 	];
 
+	function matchesFolder(r: Recast): boolean {
+		if (selectedFolder === "all") return true;
+		if (selectedFolder === "root") return !r.folderId;
+		return r.folderId === selectedFolder;
+	}
+	// Tag filter is OR — show recasts carrying ANY of the selected tags.
+	function matchesTags(r: Recast): boolean {
+		if (selectedTagIds.length === 0) return true;
+		return selectedTagIds.some((id) => r.tags.includes(id));
+	}
+
 	const visible = $derived.by(() => {
 		const q = query.trim().toLowerCase();
 		const list = recastsStore.items.filter(
 			(r) =>
 				(activeFilter === "all" || r.source === activeFilter) &&
+				matchesFolder(r) &&
+				matchesTags(r) &&
 				r.title.toLowerCase().includes(q),
 		);
 		return [...list].sort((a, b) => {
@@ -93,9 +124,28 @@
 	]);
 
 	const hasRecasts = $derived(recastsStore.items.length > 0);
-	const sortLabel = $derived(
-		sorts.find((s) => s.value === sortKey)?.label ?? "Sort",
+	const filtersActive = $derived(
+		query.trim() !== "" || activeFilter !== "all" || selectedFolder !== "all" || selectedTagIds.length > 0,
 	);
+	const sortLabel = $derived(sorts.find((s) => s.value === sortKey)?.label ?? "Sort");
+	const folderCrumb = $derived(
+		typeof selectedFolder === "string" && selectedFolder !== "all" && selectedFolder !== "root"
+			? foldersStore.breadcrumb(selectedFolder)
+			: [],
+	);
+
+	function clearFilters() {
+		query = "";
+		activeFilter = "all";
+		selectedFolder = "all";
+		selectedTagIds = [];
+	}
+
+	function toggleTagFilter(id: string) {
+		selectedTagIds = selectedTagIds.includes(id)
+			? selectedTagIds.filter((t) => t !== id)
+			: [...selectedTagIds, id];
+	}
 
 	function readDuration(url: string): Promise<number> {
 		return new Promise((resolve) => {
@@ -111,7 +161,6 @@
 		const input = e.currentTarget as HTMLInputElement;
 		const file = input.files?.[0];
 		if (!file) return;
-
 		uploading = true;
 		try {
 			await toast.promise(
@@ -119,7 +168,6 @@
 					const url = URL.createObjectURL(file);
 					const durationSec = await readDuration(url);
 					const destination = settingsStore.value.preferences.defaultDestination;
-
 					recastsStore.add({
 						id: crypto.randomUUID(),
 						title: file.name.replace(/\.[^.]+$/, "") || "Untitled recast",
@@ -129,6 +177,8 @@
 						source: destination,
 						provider: destination === "cloud" ? "Cloudinary" : null,
 						views: 0,
+						folderId: selectedFolder !== "all" && selectedFolder !== "root" ? selectedFolder : null,
+						tags: [],
 						videoUrl: url,
 						posterUrl: "",
 					});
@@ -145,35 +195,86 @@
 		}
 	}
 
-	function doRename(rec: Recast, title: string) {
-		recastsStore.rename(rec.id, title);
+	async function doRename(rec: Recast, title: string) {
 		renaming = null;
-		toast.success("Recast renamed.");
+		const prev = rec.title;
+		recastsStore.rename(rec.id, title);
+		try {
+			await api.renameRecast(rec.id, title);
+			toast.success("Recast renamed.");
+		} catch (e) {
+			recastsStore.rename(rec.id, prev);
+			toast.error((e as Error)?.message ?? "Couldn't rename.");
+		}
 	}
 
 	function toggleSource(rec: Recast) {
+		// Local-only concept in the dashboard mock; the real cloud upload is the
+		// desktop "Share to Cloud" flow.
 		const next: RecordingSource = rec.source === "cloud" ? "local" : "cloud";
 		recastsStore.setSource(rec.id, next);
-		toast.success(
-			next === "cloud" ? "Uploaded to Cloudinary." : "Moved to local storage.",
-		);
+		toast.success(next === "cloud" ? "Uploaded to Cloudinary." : "Moved to local storage.");
+	}
+
+	async function moveRecast(rec: Recast, folderId: string | null) {
+		if (rec.folderId === folderId) return;
+		const prev = rec.folderId;
+		recastsStore.move(rec.id, folderId);
+		try {
+			await api.moveRecast(rec.id, folderId);
+			const name = folderId ? foldersStore.get(folderId)?.name ?? "folder" : "No folder";
+			toast.success(`Moved to ${name}.`);
+		} catch (e) {
+			recastsStore.move(rec.id, prev);
+			toast.error((e as Error)?.message ?? "Couldn't move recast.");
+		}
+	}
+
+	async function toggleTag(rec: Recast, tagId: string) {
+		const prev = rec.tags;
+		const next = prev.includes(tagId) ? prev.filter((t) => t !== tagId) : [...prev, tagId];
+		recastsStore.setTags(rec.id, next);
+		try {
+			await api.setRecastTags(rec.id, next);
+		} catch (e) {
+			recastsStore.setTags(rec.id, prev);
+			toast.error((e as Error)?.message ?? "Couldn't update tags.");
+		}
 	}
 
 	async function copyLink(rec: Recast) {
 		try {
-			await navigator.clipboard.writeText(
-				`https://recast.nexonauts.com/v/${rec.id}`,
-			);
+			await navigator.clipboard.writeText(`https://recast.nexonauts.com/v/${rec.id}`);
 			toast.success("Share link copied to clipboard.");
 		} catch {
 			toast.error("Couldn't access the clipboard.");
 		}
 	}
 
-	function deleteRecast(rec: Recast) {
+	async function deleteRecast(rec: Recast) {
+		const snapshot = recastsStore.items;
 		recastsStore.remove(rec.id);
 		if (playing?.id === rec.id) playing = null;
-		toast.success(`“${rec.title}” deleted.`);
+		try {
+			await api.deleteRecast(rec.id);
+			toast.success(`“${rec.title}” deleted.`);
+		} catch (e) {
+			recastsStore.hydrate(snapshot); // restore
+			toast.error((e as Error)?.message ?? "Couldn't delete recast.");
+		}
+	}
+
+	async function createTag() {
+		const name = newTagName.trim();
+		creatingTag = false;
+		newTagName = "";
+		if (!name) return;
+		try {
+			const tag = await api.createTag({ workspaceId, name });
+			tagsStore.add(tag);
+		} catch (e) {
+			toast.error((e as Error)?.message ?? "Couldn't create tag.");
+		}
 	}
 </script>
 
@@ -181,13 +282,7 @@
 	<title>Recasts - Recast Dashboard</title>
 </svelte:head>
 
-<input
-	bind:this={fileInput}
-	type="file"
-	accept="video/*"
-	class="hidden"
-	onchange={onFilePicked}
-/>
+<input bind:this={fileInput} type="file" accept="video/*" class="hidden" onchange={onFilePicked} />
 
 <!-- Header -->
 <header
@@ -195,19 +290,11 @@
 	in:fly={{ y: 12, duration: 500, easing: cubicOut }}
 >
 	<div>
-		<h1 class="text-2xl font-semibold tracking-tight text-foreground">
-			Recasts
-		</h1>
-		<p class="mt-1 text-sm text-muted-foreground">
-			All your recasts — captured, uploaded, shared.
-		</p>
+		<h1 class="text-2xl font-semibold tracking-tight text-foreground">Recasts</h1>
+		<p class="mt-1 text-sm text-muted-foreground">All your recasts — captured, uploaded, shared.</p>
 	</div>
 	<Button class="gap-2" disabled={uploading} onclick={() => fileInput?.click()}>
-		{#if uploading}
-			<LoaderCircle class="size-4 animate-spin" />
-		{:else}
-			<Upload class="size-4" />
-		{/if}
+		{#if uploading}<LoaderCircle class="size-4 animate-spin" />{:else}<Upload class="size-4" />{/if}
 		{uploading ? "Adding…" : "Upload recast"}
 	</Button>
 </header>
@@ -221,132 +308,172 @@
 	{/each}
 </div>
 
-<!-- Toolbar -->
-<div
-	class="mt-8 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between"
-	in:fly={{ y: 12, duration: 480, delay: 280, easing: cubicOut }}
->
-	<div class="flex items-center gap-2 rounded-lg border border-border-low/70 bg-card/50 px-3 py-2 backdrop-blur-sm lg:w-72">
-		<Search class="size-4 shrink-0 text-muted-foreground" />
-		<input
-			type="text"
-			bind:value={query}
-			placeholder="Search recasts…"
-			class="w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/70"
-		/>
-		{#if query}
-			<button
-				type="button"
-				onclick={() => (query = "")}
-				aria-label="Clear search"
-				class="grid size-5 place-items-center rounded text-muted-foreground transition-colors hover:text-foreground"
-			>
-				<X class="size-3.5" />
-			</button>
-		{/if}
-	</div>
+<!-- Library: folder rail + content -->
+<div class="mt-8 flex flex-col gap-6 lg:flex-row" in:fly={{ y: 12, duration: 480, delay: 240, easing: cubicOut }}>
+	<FolderRail
+		{workspaceId}
+		selected={selectedFolder}
+		onselect={(s) => (selectedFolder = s)}
+		onDropRecast={(recastId, folderId) => {
+			const rec = recastsStore.items.find((r) => r.id === recastId);
+			if (rec) moveRecast(rec, folderId);
+		}}
+	/>
 
-	<div class="flex items-center gap-2">
-		<div class="flex items-center gap-1 rounded-lg border border-border-low/60 bg-card/40 p-1">
-			{#each filters as f (f.value)}
-				<button
-					type="button"
-					onclick={() => (activeFilter = f.value)}
-					class="rounded-md px-3 py-1.5 text-xs font-semibold transition-colors duration-200
-						{activeFilter === f.value
-						? 'bg-primary/12 text-foreground'
-						: 'text-muted-foreground hover:text-foreground'}"
-				>
-					{f.label}
-				</button>
-			{/each}
+	<div class="min-w-0 flex-1">
+		<!-- Toolbar -->
+		<div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+			<div class="flex items-center gap-2 rounded-lg border border-border-low/70 bg-card/50 px-3 py-2 backdrop-blur-sm lg:w-72">
+				<Search class="size-4 shrink-0 text-muted-foreground" />
+				<input
+					type="text"
+					bind:value={query}
+					placeholder="Search recasts…"
+					class="w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/70"
+				/>
+				{#if query}
+					<button type="button" onclick={() => (query = "")} aria-label="Clear search" class="grid size-5 place-items-center rounded text-muted-foreground transition-colors hover:text-foreground">
+						<X class="size-3.5" />
+					</button>
+				{/if}
+			</div>
+
+			<div class="flex items-center gap-2">
+				<div class="flex items-center gap-1 rounded-lg border border-border-low/60 bg-card/40 p-1">
+					{#each filters as f (f.value)}
+						<button
+							type="button"
+							onclick={() => (activeFilter = f.value)}
+							class="rounded-md px-3 py-1.5 text-xs font-semibold transition-colors duration-200
+								{activeFilter === f.value ? 'bg-primary/12 text-foreground' : 'text-muted-foreground hover:text-foreground'}"
+						>
+							{f.label}
+						</button>
+					{/each}
+				</div>
+
+				<Select.Root type="single" bind:value={sortKey}>
+					<Select.Trigger aria-label="Sort recasts" class="w-40 border-border-low/60 bg-card/40 text-xs font-semibold hover:border-border-low">
+						{sortLabel}
+					</Select.Trigger>
+					<Select.Content class="p-1">
+						{#each sorts as s (s.value)}
+							<Select.Item value={s.value} label={s.label}>{s.label}</Select.Item>
+						{/each}
+					</Select.Content>
+				</Select.Root>
+			</div>
 		</div>
 
-		<Select.Root type="single" bind:value={sortKey}>
-			<Select.Trigger
-				aria-label="Sort recasts"
-				class="w-40 border-border-low/60 bg-card/40 text-xs font-semibold hover:border-border-low"
-			>
-				{sortLabel}
-			</Select.Trigger>
-			<Select.Content class="p-1">
-				{#each sorts as s (s.value)}
-					<Select.Item value={s.value} label={s.label}>{s.label}</Select.Item>
-				{/each}
-			</Select.Content>
-		</Select.Root>
-	</div>
-</div>
-
-<!-- Grid -->
-{#if visible.length > 0}
-	<div class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-		{#each visible as rec (rec.id)}
-			<div
-				animate:flip={{ duration: 320, easing: cubicOut }}
-				in:scale={{ start: 0.97, duration: 300, easing: cubicOut }}
-				out:scale={{ start: 0.97, duration: 170, easing: cubicOut }}
-			>
-				<RecastCard
-					recast={rec}
-					onplay={() => (playing = rec)}
-					onrename={() => (renaming = rec)}
-					oncopylink={() => copyLink(rec)}
-					ontogglesource={() => toggleSource(rec)}
-					ondelete={() => deleteRecast(rec)}
+		<!-- Tag filter chips -->
+		<div class="mt-3 flex flex-wrap items-center gap-1.5">
+			{#each tagsStore.sorted as t (t.id)}
+				<Chip
+					label={t.name}
+					color={t.color}
+					selected={selectedTagIds.includes(t.id)}
+					onclick={() => toggleTagFilter(t.id)}
 				/>
+			{/each}
+			{#if creatingTag}
+				<input
+					bind:value={newTagName}
+					onblur={createTag}
+					onkeydown={(e) => {
+						if (e.key === "Enter") e.currentTarget.blur();
+						if (e.key === "Escape") {
+							creatingTag = false;
+							newTagName = "";
+						}
+					}}
+					placeholder="Tag name"
+					class="h-7 w-28 rounded-full border border-primary/50 bg-background px-2.5 text-xs outline-none placeholder:text-muted-foreground/60"
+					use:focusOnMount
+				/>
+			{:else}
+				<button
+					type="button"
+					onclick={() => (creatingTag = true)}
+					class="inline-flex items-center gap-1 rounded-full border border-dashed border-border-low/70 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground"
+				>
+					<Plus class="size-3" /> New tag
+				</button>
+			{/if}
+			{#if selectedTagIds.length > 0}
+				<button type="button" onclick={() => (selectedTagIds = [])} class="ml-1 text-[11px] font-medium text-muted-foreground hover:text-foreground hover:underline">
+					Clear tags
+				</button>
+			{/if}
+		</div>
+
+		<!-- Folder context line -->
+		{#if folderCrumb.length > 0}
+			<div class="mt-4 flex items-center gap-1.5 text-sm text-muted-foreground" in:slide={{ duration: 200, easing: cubicOut }}>
+				<FolderOpen class="size-4 text-primary" />
+				{#each folderCrumb as f, i (f.id)}
+					<button type="button" onclick={() => (selectedFolder = f.id)} class="transition-colors hover:text-foreground {i === folderCrumb.length - 1 ? 'font-medium text-foreground' : ''}">
+						{f.name}
+					</button>
+					{#if i < folderCrumb.length - 1}<span class="text-muted-foreground/50">/</span>{/if}
+				{/each}
+				<span class="ml-1 font-mono text-[10px] tabular-nums">({visible.length})</span>
 			</div>
-		{/each}
-	</div>
-{:else}
-	<div
-		class="mt-6 flex flex-col items-center justify-center rounded-xl border border-dashed border-border-low/70 py-20 text-center"
-		in:fly={{ y: 12, duration: 360, easing: cubicOut }}
-	>
-		<span class="glass-chip grid size-12 place-items-center rounded-xl text-muted-foreground">
-			<Film class="size-5" />
-		</span>
-		{#if hasRecasts}
-			<h3 class="mt-4 text-sm font-semibold text-foreground">No recasts found</h3>
-			<p class="mt-1 max-w-xs text-xs text-muted-foreground">
-				Nothing matches your search and filters.
-			</p>
-			<Button
-				variant="outline"
-				size="sm"
-				class="mt-5"
-				onclick={() => {
-					query = "";
-					activeFilter = "all";
-				}}
-			>
-				Clear filters
-			</Button>
+		{/if}
+
+		<!-- Grid -->
+		{#if visible.length > 0}
+			<div class="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+				{#each visible as rec (rec.id)}
+					<div
+						animate:flip={{ duration: 320, easing: cubicOut }}
+						in:scale={{ start: 0.97, duration: 300, easing: cubicOut }}
+						out:scale={{ start: 0.97, duration: 170, easing: cubicOut }}
+					>
+						<RecastCard
+							recast={rec}
+							folders={foldersStore.items}
+							tags={tagsStore.items}
+							onplay={() => (playing = rec)}
+							onrename={() => (renaming = rec)}
+							oncopylink={() => copyLink(rec)}
+							ontogglesource={() => toggleSource(rec)}
+							onmove={(folderId) => moveRecast(rec, folderId)}
+							ontoggletag={(tagId) => toggleTag(rec, tagId)}
+							ondelete={() => deleteRecast(rec)}
+						/>
+					</div>
+				{/each}
+			</div>
 		{:else}
-			<h3 class="mt-4 text-sm font-semibold text-foreground">No recasts yet</h3>
-			<p class="mt-1 max-w-xs text-xs text-muted-foreground">
-				Upload a video, or capture one with the Recast desktop app.
-			</p>
-			<Button size="sm" class="mt-5 gap-2" disabled={uploading} onclick={() => fileInput?.click()}>
-				{#if uploading}
-					<LoaderCircle class="size-3.5 animate-spin" />
+			<div class="mt-5 flex flex-col items-center justify-center rounded-xl border border-dashed border-border-low/70 py-20 text-center" in:fly={{ y: 12, duration: 360, easing: cubicOut }}>
+				<span class="glass-chip grid size-12 place-items-center rounded-xl text-muted-foreground">
+					<Film class="size-5" />
+				</span>
+				{#if !hasRecasts}
+					<h3 class="mt-4 text-sm font-semibold text-foreground">No recasts yet</h3>
+					<p class="mt-1 max-w-xs text-xs text-muted-foreground">Upload a video, or capture one with the Recast desktop app.</p>
+					<Button size="sm" class="mt-5 gap-2" disabled={uploading} onclick={() => fileInput?.click()}>
+						{#if uploading}<LoaderCircle class="size-3.5 animate-spin" />{:else}<Upload class="size-3.5" />{/if}
+						{uploading ? "Adding…" : "Upload recast"}
+					</Button>
+				{:else if filtersActive}
+					<h3 class="mt-4 text-sm font-semibold text-foreground">No recasts match</h3>
+					<p class="mt-1 max-w-xs text-xs text-muted-foreground">Nothing here matches your search, folder, and tag filters.</p>
+					<Button variant="outline" size="sm" class="mt-5" onclick={clearFilters}>Clear filters</Button>
 				{:else}
-					<Upload class="size-3.5" />
+					<h3 class="mt-4 text-sm font-semibold text-foreground">This folder is empty</h3>
+					<p class="mt-1 max-w-xs text-xs text-muted-foreground">Drag a recast onto it, or use “Move to” from a recast's menu.</p>
 				{/if}
-				{uploading ? "Adding…" : "Upload recast"}
-			</Button>
+			</div>
 		{/if}
 	</div>
-{/if}
+</div>
 
 {#if playing}
 	<PlayerDialog
 		recast={playing}
 		onclose={() => (playing = null)}
 		onengagement={(event) => {
-			// Single-bump-per-open: the player's `started` latch guarantees
-			// `view-start` fires once. The other events (progress/ended) feed
-			// into analytics later — no-op for now.
 			if (event.type === "view-start" && playing) {
 				recastsStore.incrementViews(playing.id);
 			}

--- a/apps/web/src/routes/dashboard/recasts/+page.svelte
+++ b/apps/web/src/routes/dashboard/recasts/+page.svelte
@@ -10,12 +10,13 @@
 	import { focusOnMount } from "$lib/dashboard/focus";
 	import { formatBytes } from "$lib/dashboard/format";
 	import { foldersStore, tagsStore } from "$lib/dashboard/library.svelte";
+	import { UPLOAD_ACCEPT, uploadRecastFile, type UploadPhase } from "$lib/dashboard/upload";
 	import {
 	  recastsStore,
-	  settingsStore,
 	  type Recast,
 	  type RecordingSource,
 	} from "$lib/dashboard/store.svelte";
+	import { invalidateAll } from "$app/navigation";
 	import { Chip } from "@recast/ui/chip";
 	import { Archive, Cloud, Film, FolderOpen, HardDrive, Library, LoaderCircle, Plus, Search, Settings2, Upload, Video, X } from "@lucide/svelte";
 	import { Button } from "@recast/ui/button";
@@ -78,7 +79,19 @@
 	let playing = $state<Recast | null>(null);
 	let renaming = $state<Recast | null>(null);
 	let uploading = $state(false);
+	let uploadPhase = $state<UploadPhase>("preparing");
+	let uploadPct = $state(0);
 	let fileInput = $state<HTMLInputElement | null>(null);
+
+	const uploadLabel = $derived(
+		uploadPhase === "uploading"
+			? `Uploading ${uploadPct}%`
+			: uploadPhase === "finalizing"
+				? "Finalizing…"
+				: uploadPhase === "sharing"
+					? "Creating link…"
+					: "Preparing…",
+	);
 
 	// Inline tag creation in the filter bar.
 	let creatingTag = $state(false);
@@ -162,48 +175,36 @@
 			: [...selectedTagIds, id];
 	}
 
-	function readDuration(url: string): Promise<number> {
-		return new Promise((resolve) => {
-			const v = document.createElement("video");
-			v.preload = "metadata";
-			v.onloadedmetadata = () => resolve(v.duration || 0);
-			v.onerror = () => resolve(0);
-			v.src = url;
-		});
-	}
-
 	async function onFilePicked(e: Event) {
 		const input = e.currentTarget as HTMLInputElement;
 		const file = input.files?.[0];
 		if (!file) return;
 		uploading = true;
+		uploadPhase = "preparing";
+		uploadPct = 0;
 		try {
-			await toast.promise(
-				(async () => {
-					const url = URL.createObjectURL(file);
-					const durationSec = await readDuration(url);
-					const destination = settingsStore.value.preferences.defaultDestination;
-					recastsStore.add({
-						id: crypto.randomUUID(),
-						title: file.name.replace(/\.[^.]+$/, "") || "Untitled recast",
-						durationSec,
-						createdAt: Date.now(),
-						sizeBytes: file.size,
-						source: destination,
-						provider: destination === "cloud" ? "Cloudinary" : null,
-						views: 0,
-						folderId: selectedFolder !== "all" && selectedFolder !== "root" ? selectedFolder : null,
-						tags: [],
-						videoUrl: url,
-						posterUrl: "",
-					});
-				})(),
-				{
-					loading: `Adding “${file.name}”…`,
-					success: `“${file.name}” added to your library.`,
-					error: (err) => (err as Error)?.message ?? "Couldn't add that file.",
-				},
+			const result = await uploadRecastFile(file, {
+				workspaceId,
+				onPhase: (p) => (uploadPhase = p),
+				onProgress: (pct) => (uploadPct = pct),
+			});
+			// Pull the real, server-published recast into the list (with its
+			// share slug, poster, signed-on-read video, etc.).
+			await invalidateAll();
+			let copied = false;
+			try {
+				await navigator.clipboard.writeText(result.shareUrl);
+				copied = true;
+			} catch {
+				copied = false;
+			}
+			toast.success(
+				copied
+					? `“${file.name}” uploaded — share link copied to clipboard.`
+					: `“${file.name}” uploaded and shared.`,
 			);
+		} catch (err) {
+			toast.error((err as Error)?.message ?? "Couldn't upload that file.");
 		} finally {
 			uploading = false;
 			input.value = "";
@@ -309,7 +310,7 @@
 	<title>Recasts - Recast Dashboard</title>
 </svelte:head>
 
-<input bind:this={fileInput} type="file" accept="video/*" class="hidden" onchange={onFilePicked} />
+<input bind:this={fileInput} type="file" accept={UPLOAD_ACCEPT} class="hidden" onchange={onFilePicked} />
 
 <!-- Header -->
 <header
@@ -322,7 +323,7 @@
 	</div>
 	<Button class="gap-2" disabled={uploading} onclick={() => fileInput?.click()}>
 		{#if uploading}<LoaderCircle class="size-4 animate-spin" />{:else}<Upload class="size-4" />{/if}
-		{uploading ? "Adding…" : "Upload recast"}
+		{uploading ? uploadLabel : "Upload recast"}
 	</Button>
 </header>
 
@@ -513,10 +514,10 @@
 				</span>
 				{#if !hasRecasts}
 					<h3 class="mt-4 text-sm font-semibold text-foreground">No recasts yet</h3>
-					<p class="mt-1 max-w-xs text-xs text-muted-foreground">Upload a video, or capture one with the Recast desktop app.</p>
+					<p class="mt-1 max-w-xs text-xs text-muted-foreground">Upload an MP4, or capture and export one with the Recast desktop app.</p>
 					<Button size="sm" class="mt-5 gap-2" disabled={uploading} onclick={() => fileInput?.click()}>
 						{#if uploading}<LoaderCircle class="size-3.5 animate-spin" />{:else}<Upload class="size-3.5" />{/if}
-						{uploading ? "Adding…" : "Upload recast"}
+						{uploading ? uploadLabel : "Upload recast"}
 					</Button>
 				{:else if filtersActive}
 					<h3 class="mt-4 text-sm font-semibold text-foreground">No recasts match</h3>

--- a/apps/web/src/routes/dashboard/recasts/+page.svelte
+++ b/apps/web/src/routes/dashboard/recasts/+page.svelte
@@ -6,6 +6,7 @@
 	import RecastCard from "$lib/dashboard/components/RecastCard.svelte";
 	import RenameDialog from "$lib/dashboard/components/RenameDialog.svelte";
 	import StatCard from "$lib/dashboard/components/StatCard.svelte";
+	import TagManagerDialog from "$lib/dashboard/components/TagManagerDialog.svelte";
 	import { focusOnMount } from "$lib/dashboard/focus";
 	import { formatBytes } from "$lib/dashboard/format";
 	import { foldersStore, tagsStore } from "$lib/dashboard/library.svelte";
@@ -16,7 +17,7 @@
 	  type RecordingSource,
 	} from "$lib/dashboard/store.svelte";
 	import { Chip } from "@recast/ui/chip";
-	import { Archive, Cloud, Film, FolderOpen, HardDrive, Library, LoaderCircle, Plus, Search, Upload, Video, X } from "@lucide/svelte";
+	import { Archive, Cloud, Film, FolderOpen, HardDrive, Library, LoaderCircle, Plus, Search, Settings2, Upload, Video, X } from "@lucide/svelte";
 	import { Button } from "@recast/ui/button";
 	import * as Select from "@recast/ui/select";
 	import { toast } from "@recast/ui/sonner";
@@ -82,6 +83,7 @@
 	// Inline tag creation in the filter bar.
 	let creatingTag = $state(false);
 	let newTagName = $state("");
+	let managingTags = $state(false);
 
 	const filters: { label: string; value: RecordingSource | "all" }[] = [
 		{ label: "All", value: "all" },
@@ -450,6 +452,15 @@
 					<Plus class="size-3" /> New tag
 				</button>
 			{/if}
+			{#if tagsStore.items.length > 0}
+				<button
+					type="button"
+					onclick={() => (managingTags = true)}
+					class="inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-foreground/8 hover:text-foreground"
+				>
+					<Settings2 class="size-3" /> Manage
+				</button>
+			{/if}
 			{#if selectedTagIds.length > 0}
 				<button type="button" onclick={() => (selectedTagIds = [])} class="ml-1 text-[11px] font-medium text-muted-foreground hover:text-foreground hover:underline">
 					Clear tags
@@ -571,4 +582,8 @@
 		onclose={() => (renaming = null)}
 		onsave={(title) => renaming && doRename(renaming, title)}
 	/>
+{/if}
+
+{#if managingTags}
+	<TagManagerDialog onclose={() => (managingTags = false)} />
 {/if}

--- a/apps/web/src/routes/dashboard/recasts/+page.svelte
+++ b/apps/web/src/routes/dashboard/recasts/+page.svelte
@@ -44,6 +44,7 @@
 			tags: r.tags ?? [],
 			videoUrl: r.videoUrl,
 			posterUrl: r.posterUrl ?? "",
+			latestShareSlug: r.latestShareSlug ?? null,
 		}));
 		const folders = data.folders;
 		const tags = data.tags;
@@ -260,10 +261,20 @@
 
 	async function copyLink(rec: Recast) {
 		try {
-			await navigator.clipboard.writeText(`https://recast.li/share/${rec.id}`);
+			// The public link is keyed by the share SLUG, not the recast id, and
+			// lives on this same origin. If the recast was never shared, mint a
+			// link first (public — same default as the upload flow) and cache the
+			// slug so a second click doesn't create a duplicate share.
+			let slug = rec.latestShareSlug ?? null;
+			if (!slug) {
+				const { slug: newSlug } = await api.shareRecast(rec.id);
+				slug = newSlug;
+				recastsStore.setShareSlug(rec.id, slug);
+			}
+			await navigator.clipboard.writeText(`${location.origin}/share/${slug}`);
 			toast.success("Share link copied to clipboard.");
-		} catch {
-			toast.error("Couldn't access the clipboard.");
+		} catch (e) {
+			toast.error((e as Error)?.message ?? "Couldn't copy the share link.");
 		}
 	}
 

--- a/apps/web/src/routes/dashboard/recasts/+page.svelte
+++ b/apps/web/src/routes/dashboard/recasts/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as api from "$lib/dashboard/api";
+	import ArchivedCard, { type ArchivedRecast } from "$lib/dashboard/components/ArchivedCard.svelte";
 	import FolderRail, { type FolderSelection } from "$lib/dashboard/components/FolderRail.svelte";
 	import PlayerDialog from "$lib/dashboard/components/PlayerDialog.svelte";
 	import RecastCard from "$lib/dashboard/components/RecastCard.svelte";
@@ -15,7 +16,7 @@
 	  type RecordingSource,
 	} from "$lib/dashboard/store.svelte";
 	import { Chip } from "@recast/ui/chip";
-	import { Cloud, Film, FolderOpen, HardDrive, LoaderCircle, Plus, Search, Upload, Video, X } from "@lucide/svelte";
+	import { Archive, Cloud, Film, FolderOpen, HardDrive, Library, LoaderCircle, Plus, Search, Upload, Video, X } from "@lucide/svelte";
 	import { Button } from "@recast/ui/button";
 	import * as Select from "@recast/ui/select";
 	import { toast } from "@recast/ui/sonner";
@@ -52,6 +53,18 @@
 	});
 
 	const workspaceId = $derived(data.workspaceId);
+
+	// Archived recasts live in their own tab. Keep a local copy so a delete can
+	// drop the card optimistically; re-seed whenever the loader returns fresh
+	// data (e.g. after invalidateAll()).
+	let archived = $state<ArchivedRecast[]>([]);
+	$effect(() => {
+		const next = data.archived;
+		untrack(() => (archived = next));
+	});
+
+	type View = "library" | "archived";
+	let view = $state<View>("library");
 
 	type SortKey = "recent" | "oldest" | "name" | "largest";
 
@@ -264,6 +277,18 @@
 		}
 	}
 
+	async function deleteArchived(rec: ArchivedRecast) {
+		const snapshot = archived;
+		archived = archived.filter((a) => a.id !== rec.id);
+		try {
+			await api.deleteRecast(rec.id);
+			toast.success(`“${rec.title}” deleted permanently.`);
+		} catch (e) {
+			archived = snapshot; // restore
+			toast.error((e as Error)?.message ?? "Couldn't delete recast.");
+		}
+	}
+
 	async function createTag() {
 		const name = newTagName.trim();
 		creatingTag = false;
@@ -308,8 +333,34 @@
 	{/each}
 </div>
 
+<!-- View tabs: Library / Archived -->
+<div class="mt-8 flex items-center gap-1 border-b border-border-low/60" in:fly={{ y: 12, duration: 480, delay: 200, easing: cubicOut }}>
+	<button
+		type="button"
+		onclick={() => (view = "library")}
+		class="-mb-px flex items-center gap-1.5 border-b-2 px-3 py-2 text-sm font-semibold transition-colors
+			{view === 'library' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}"
+	>
+		<Library class="size-4" />
+		Library
+	</button>
+	<button
+		type="button"
+		onclick={() => (view = "archived")}
+		class="-mb-px flex items-center gap-1.5 border-b-2 px-3 py-2 text-sm font-semibold transition-colors
+			{view === 'archived' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}"
+	>
+		<Archive class="size-4" />
+		Archived
+		{#if archived.length > 0}
+			<span class="rounded-full bg-foreground/10 px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-muted-foreground">{archived.length}</span>
+		{/if}
+	</button>
+</div>
+
+{#if view === "library"}
 <!-- Library: folder rail + content -->
-<div class="mt-8 flex flex-col gap-6 lg:flex-row" in:fly={{ y: 12, duration: 480, delay: 240, easing: cubicOut }}>
+<div class="mt-6 flex flex-col gap-6 lg:flex-row" in:fly={{ y: 12, duration: 480, delay: 80, easing: cubicOut }}>
 	<FolderRail
 		{workspaceId}
 		selected={selectedFolder}
@@ -468,6 +519,39 @@
 		{/if}
 	</div>
 </div>
+{:else}
+	<!-- Archived tab -->
+	<div class="mt-6" in:fly={{ y: 12, duration: 480, delay: 80, easing: cubicOut }}>
+		{#if archived.length > 0}
+			<p class="mb-5 max-w-2xl text-sm text-muted-foreground">
+				Recasts here lost their cloud file after 14 days without views — only the
+				details remain. Re-share from the Recast desktop app to bring one back, or
+				delete it for good. Each is purged automatically 16 days after archiving.
+			</p>
+			<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+				{#each archived as rec (rec.id)}
+					<div
+						animate:flip={{ duration: 320, easing: cubicOut }}
+						in:scale={{ start: 0.97, duration: 300, easing: cubicOut }}
+						out:scale={{ start: 0.97, duration: 170, easing: cubicOut }}
+					>
+						<ArchivedCard recast={rec} ondelete={() => deleteArchived(rec)} />
+					</div>
+				{/each}
+			</div>
+		{:else}
+			<div class="flex flex-col items-center justify-center rounded-xl border border-dashed border-border-low/70 py-20 text-center">
+				<span class="glass-chip grid size-12 place-items-center rounded-xl text-muted-foreground">
+					<Archive class="size-5" />
+				</span>
+				<h3 class="mt-4 text-sm font-semibold text-foreground">Nothing archived</h3>
+				<p class="mt-1 max-w-xs text-xs text-muted-foreground">
+					Unwatched recasts on the Free plan are archived after 14 days. Anything parked here will show up so you can restore or remove it.
+				</p>
+			</div>
+		{/if}
+	</div>
+{/if}
 
 {#if playing}
 	<PlayerDialog

--- a/apps/web/src/routes/share/[id]/+page.server.ts
+++ b/apps/web/src/routes/share/[id]/+page.server.ts
@@ -4,6 +4,7 @@ import { getAuth } from "$lib/auth/server";
 import { getDb } from "$lib/db";
 import { share } from "$lib/db/schema";
 import { loadViewer, resolveShareAccess, type ResolvedShare } from "$lib/share/access";
+import { grantCookieName, readGrantedEmail } from "$lib/share/grant";
 import {
 	constantTimeEquals,
 	unlockCookieName,
@@ -74,7 +75,17 @@ export const load: PageServerLoad = async ({ params, request, cookies }) => {
 		.catch(() => null)) as SessionShape | null;
 
 	const viewer = await loadViewer(session?.user.id ?? null);
-	const access: DemoOrResolved = await resolveShareAccess(params.id, viewer);
+	// Account-less invitee grant (selected shares). Verified here; the
+	// resolver re-checks the email against the allowlist.
+	const grantedEmail = await readGrantedEmail(
+		params.id,
+		cookies.get(grantCookieName(params.id)),
+	);
+	const access: DemoOrResolved = await resolveShareAccess(
+		params.id,
+		viewer,
+		grantedEmail,
+	);
 
 	if ("reason" in access && access.reason === "not-found") {
 		error(404, "Share link not found");

--- a/apps/web/src/routes/share/[id]/+page.svelte
+++ b/apps/web/src/routes/share/[id]/+page.svelte
@@ -238,6 +238,35 @@
 		smoothedTime.set(currentTime);
 	});
 
+	// First-party view recording. Bumps the cached view count AND — critically
+	// — refreshes `recast.lastViewedAt`, which the Free-tier expiry sweep keys
+	// off (without this, watched recasts still archive at 14 days). Anonymous:
+	// keyed only by the share session fingerprint. Skipped for the demo (no
+	// real share row) and SSR. `keepalive` lets the "ended" beacon survive a
+	// tab close.
+	let viewStartSent = false;
+	function recordView(event: "start" | "ended") {
+		if (!browser || isDemo || !slug) return;
+		if (event === "start") {
+			if (viewStartSent) return;
+			viewStartSent = true;
+		}
+		try {
+			void fetch(`/api/share/${slug}/view`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					sessionId: shareSessionId(),
+					event,
+					watchPct: Math.round(watchedPct),
+				}),
+				keepalive: true,
+			}).catch(() => {});
+		} catch {
+			// Never let a metrics beacon disrupt playback.
+		}
+	}
+
 	function onEngagement(e: {
 		type: "view-start" | "progress" | "ended";
 		percent?: number;
@@ -246,17 +275,22 @@
 		if (e.type === "view-start") {
 			isPlaying = true;
 			ended = false;
+			recordView("start");
 		}
 		if (e.type === "progress") {
 			currentTime = e.currentTime ?? currentTime;
 			watchedPct = e.percent ?? watchedPct;
 			isPlaying = true;
 			ended = false;
+			// Some players jump straight to progress without a view-start; the
+			// guard makes this idempotent so we still record the view once.
+			recordView("start");
 		}
 		if (e.type === "ended") {
 			watchedPct = 100;
 			isPlaying = false;
 			ended = true;
+			recordView("ended");
 		}
 	}
 

--- a/apps/web/src/routes/share/[id]/+page.svelte
+++ b/apps/web/src/routes/share/[id]/+page.svelte
@@ -73,6 +73,32 @@
 	const okAccess = $derived(access.ok ? access : null);
 	const deniedAccess = $derived(access.ok ? null : access);
 	const recast = $derived(okAccess?.recast);
+
+	// ── Account-less invitee claim (selected shares) ──────────────────────
+	// A denied viewer of a `selected` share can request an email access link.
+	let claimEmail = $state("");
+	let claimState = $state<"idle" | "sending" | "sent">("idle");
+	// The verify endpoint bounces back with ?claim=invalid on a bad/expired link.
+	const claimInvalid = $derived(page.url.searchParams.get("claim") === "invalid");
+
+	async function submitClaim(e: SubmitEvent) {
+		e.preventDefault();
+		const email = claimEmail.trim();
+		if (!email || claimState === "sending") return;
+		claimState = "sending";
+		try {
+			const res = await fetch(`/api/share/${page.params.id}/claim`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ email }),
+			});
+			if (!res.ok) throw new Error((await res.text()) || "Couldn't send the link.");
+			claimState = "sent";
+		} catch (err) {
+			claimState = "idle";
+			toast.error((err as Error)?.message ?? "Couldn't send the link.");
+		}
+	}
 	const shareMeta = $derived(okAccess?.share);
 	const canManage = $derived(okAccess?.canManage ?? false);
 	const slug = $derived(shareMeta?.slug ?? recast?.id ?? "");
@@ -719,7 +745,9 @@
 				<div class="min-w-0">
 					<h1 class="text-lg font-semibold tracking-tight">You don't have access</h1>
 					<p class="mt-1 text-sm text-muted-foreground">
-						{#if deniedAccess.visibility === "team"}
+						{#if deniedAccess.visibility === "selected"}
+							This recording is shared with specific people. Enter your email to get a one-time access link — no account needed.
+						{:else if deniedAccess.visibility === "team"}
 							This recast is shared with a specific team. Ask the owner to add you, or sign in with an account that's a member.
 						{:else if deniedAccess.visibility === "private"}
 							This recast is private. Only the owner can view it.
@@ -730,6 +758,48 @@
 				</div>
 			</div>
 
+			{#if deniedAccess.visibility === "selected"}
+				<!-- Invite-only: email-based access claim. -->
+				{#if claimState === "sent"}
+					<div class="mt-5 rounded-xl border border-primary/30 bg-primary/8 p-4 text-sm" in:fly={{ y: 8, duration: 240, easing: cubicOut }}>
+						<p class="flex items-center gap-2 font-medium text-foreground">
+							<Check class="size-4 text-primary" />
+							Check your inbox
+						</p>
+						<p class="mt-1 text-muted-foreground">
+							If <span class="font-medium text-foreground">{claimEmail}</span> is on the access list, we've sent a link to open this recording.
+						</p>
+					</div>
+				{:else}
+					<form class="mt-5 flex flex-col gap-2" onsubmit={submitClaim}>
+						{#if claimInvalid}
+							<p class="text-xs text-destructive" in:slide={{ duration: 160 }}>
+								That access link is invalid or has expired. Enter your email to get a fresh one.
+							</p>
+						{/if}
+						<div class="flex flex-col gap-2 sm:flex-row">
+							<Input
+								type="email"
+								bind:value={claimEmail}
+								placeholder="you@company.com"
+								autocomplete="email"
+								required
+								class="flex-1"
+							/>
+							<Button type="submit" class="gap-2" disabled={claimState === "sending"}>
+								<Mail class="size-3.5" />
+								{claimState === "sending" ? "Sending…" : "Email me a link"}
+							</Button>
+						</div>
+					</form>
+					<div class="mt-2">
+						<Button href="/dashboard" variant="outline" class="w-full gap-2">
+							<LayoutDashboard class="size-3.5" />
+							Back to dashboard
+						</Button>
+					</div>
+				{/if}
+			{:else}
 			<div class="mt-5 flex flex-col gap-2">
 				{#if deniedAccess.sameTeam && deniedAccess.ownerEmail}
 					<Button
@@ -750,6 +820,7 @@
 					Back to dashboard
 				</Button>
 			</div>
+			{/if}
 		</div>
 	</div>
 {:else if requiresPassword}

--- a/packages/player/src/RecastPlayer.svelte
+++ b/packages/player/src/RecastPlayer.svelte
@@ -92,6 +92,7 @@
 		controls = {},
 		branding = DEFAULT_BRANDING,
 		aspectRatio = null,
+		autohide = null,
 		objectFit = "contain",
 		ariaLabel = "",
 		className = "",
@@ -112,6 +113,12 @@
 	let activeTooltipId = $state<string | null>(null);
 
 	const isHls = $derived(/\.m3u8(\?|#|$)/i.test(src));
+	// A negative `autohide` means "never hide the controls". media-chrome's
+	// `autohide` attribute only suppresses the inactivity *timer* — the
+	// controller still starts in `user-inactive` on connect, so an autoplaying
+	// clip hides its bar until the first pointer move. Pinning the control bar
+	// with `noautohide` is what actually keeps it visible from frame one.
+	const pinControls = $derived(typeof autohide === "number" && autohide < 0);
 	const mergedControls = $derived({ ...DEFAULT_CONTROLS, ...controls });
 	const mergedFeatures = $derived({ ...DEFAULT_FEATURES, ...features });
 	const showCaptions = $derived(mergedControls.captions && showMenu);
@@ -536,6 +543,7 @@
 	role="region"
 	tabindex="0"
 	defaultsubtitles
+	autohide={autohide ?? undefined}
 	onkeydown={handleKeyDown}
 >
 	{#if isHls}
@@ -670,7 +678,7 @@
 		</media-play-button>
 	{/if}
 
-	<media-control-bar class="recast-control-bar">
+	<media-control-bar class="recast-control-bar" noautohide={pinControls ? "" : undefined}>
 		<media-play-button class="recast-btn" aria-label="Play or pause">
 			<span slot="play" class="recast-icon"><Play class="size-4 translate-x-[0.5px]" /></span>
 			<span slot="pause" class="recast-icon"><Pause class="size-4" /></span>

--- a/packages/player/src/types.ts
+++ b/packages/player/src/types.ts
@@ -141,6 +141,16 @@ export type RecastPlayerProps = {
 	controls?: Partial<RecastPlayerControls>;
 	branding?: RecastPlayerBranding | null;
 	aspectRatio?: number | string | null;
+	/**
+	 * Seconds of pointer inactivity before the control bar auto-hides during
+	 * playback (media-chrome's `autohide`). Pass a negative value (e.g. `-1`)
+	 * to keep the controls permanently visible — the right call for framed
+	 * preview surfaces (the dashboard/desktop player dialogs) where the video
+	 * may autoplay and would otherwise hide its controls before the viewer
+	 * ever moves the pointer. Omitted → media-chrome's 2s default (immersive
+	 * share page).
+	 */
+	autohide?: number | null;
 	objectFit?: "contain" | "cover" | "fill" | "none" | "scale-down";
 	ariaLabel?: string;
 	className?: string;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,6 +16,10 @@
       "svelte": "./src/components/ui/button/index.ts",
       "default": "./src/components/ui/button/index.ts"
     },
+    "./chip": {
+      "svelte": "./src/components/ui/chip/index.ts",
+      "default": "./src/components/ui/chip/index.ts"
+    },
     "./button-group": {
       "svelte": "./src/components/ui/button-group/index.ts",
       "default": "./src/components/ui/button-group/index.ts"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -163,6 +163,10 @@
     "./utils": {
       "svelte": "./src/lib/utils.ts",
       "default": "./src/lib/utils.ts"
+    },
+    "./persisted-state": {
+      "svelte": "./src/lib/state/persisted-state.svelte.ts",
+      "default": "./src/lib/state/persisted-state.svelte.ts"
     }
   },
   "peerDependencies": {

--- a/packages/ui/src/components/ui/chip/chip.svelte
+++ b/packages/ui/src/components/ui/chip/chip.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	/**
+	 * Compact pill for tags / filters. Two shapes:
+	 *   - default: a toggle button (use `selected` + `onclick`) — filter chips.
+	 *   - removable: a static pill with an inline remove button — assigned tags.
+	 * Optional `color` renders a leading dot (hex). Dependency-free (no icon lib).
+	 */
+	import { cn } from "@recast/ui/utils";
+
+	let {
+		label,
+		color = null,
+		selected = false,
+		removable = false,
+		onclick,
+		onremove,
+		class: className,
+	}: {
+		label: string;
+		color?: string | null;
+		selected?: boolean;
+		removable?: boolean;
+		onclick?: () => void;
+		onremove?: () => void;
+		class?: string;
+	} = $props();
+
+	const base =
+		"inline-flex w-fit max-w-full shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors";
+	const tone = $derived(
+		selected
+			? "border-primary/40 bg-primary/12 text-foreground"
+			: "border-border-low/60 bg-foreground/3 text-muted-foreground hover:border-border hover:bg-foreground/8 hover:text-foreground",
+	);
+</script>
+
+{#if removable}
+	<div data-slot="chip" class={cn(base, tone, className)}>
+		{#if color}
+			<span class="size-2 shrink-0 rounded-full" style="background:{color}"></span>
+		{/if}
+		<span class="truncate">{label}</span>
+		<button
+			type="button"
+			aria-label={`Remove ${label}`}
+			onclick={onremove}
+			class="-mr-1 ml-0.5 grid size-4 shrink-0 place-items-center rounded-full leading-none text-muted-foreground/70 transition-colors hover:bg-foreground/10 hover:text-foreground"
+		>
+			×
+		</button>
+	</div>
+{:else}
+	<button
+		type="button"
+		data-slot="chip"
+		aria-pressed={selected}
+		{onclick}
+		class={cn(base, tone, className)}
+	>
+		{#if color}
+			<span class="size-2 shrink-0 rounded-full" style="background:{color}"></span>
+		{/if}
+		<span class="truncate">{label}</span>
+	</button>
+{/if}

--- a/packages/ui/src/components/ui/chip/index.ts
+++ b/packages/ui/src/components/ui/chip/index.ts
@@ -1,0 +1,1 @@
+export { default as Chip } from "./chip.svelte";

--- a/packages/ui/src/components/ui/dropdown-menu/dropdown-menu-sub-content.svelte
+++ b/packages/ui/src/components/ui/dropdown-menu/dropdown-menu-sub-content.svelte
@@ -1,17 +1,29 @@
 <script lang="ts">
 	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
-	import { CRAFT_OVERLAY_ANIMATION, cn } from "@recast/ui/utils";
+	import { CRAFT_OVERLAY_ANIMATION, cn, type WithoutChildrenOrChild } from "@recast/ui/utils";
+	import DropdownMenuPortal from "./dropdown-menu-portal.svelte";
+	import type { ComponentProps } from "svelte";
 
 	let {
 		ref = $bindable(null),
 		class: className,
+		portalProps,
 		...restProps
-	}: DropdownMenuPrimitive.SubContentProps = $props();
+	}: DropdownMenuPrimitive.SubContentProps & {
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof DropdownMenuPortal>>;
+	} = $props();
 </script>
 
-<DropdownMenuPrimitive.SubContent
-	bind:ref
-	data-slot="dropdown-menu-sub-content"
-	class={cn(CRAFT_OVERLAY_ANIMATION, "origin-(--bits-floating-transform-origin) ring-foreground/10 text-popover-foreground min-w-[96px] rounded-lg p-1 shadow-lg ring-1 w-auto relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!", className)}
-	{...restProps}
-/>
+<!-- Portal the submenu to <body>, same as the root Content. Without this the
+     SubContent renders *inside* the scrollable Content (which carries
+     `overflow-x-hidden overflow-y-auto` for long menus), so a submenu opening
+     to the side gets clipped. Floating-ui anchors it off the SubTrigger
+     regardless of DOM location, so portaling is safe and fixes the clipping. -->
+<DropdownMenuPortal {...portalProps}>
+	<DropdownMenuPrimitive.SubContent
+		bind:ref
+		data-slot="dropdown-menu-sub-content"
+		class={cn(CRAFT_OVERLAY_ANIMATION, "origin-(--bits-floating-transform-origin) ring-foreground/10 text-popover-foreground min-w-[96px] rounded-lg p-1 shadow-lg ring-1 w-auto relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!", className)}
+		{...restProps}
+	/>
+</DropdownMenuPortal>

--- a/packages/ui/src/lib/state/persisted-state.svelte.ts
+++ b/packages/ui/src/lib/state/persisted-state.svelte.ts
@@ -1,0 +1,336 @@
+/**
+ * `PersistedState` — a Svelte 5 rune-module port of the React
+ * `useSyncExternalStore`-backed `useStorage` hook. One reactive value, one
+ * storage key, kept in sync across every Tauri window / browser tab that
+ * shares the same storage origin.
+ *
+ * Usage (idiomatic Svelte — the value lives on `.current`, like `runed`):
+ *
+ *   const flags = new PersistedState("recast-experimental-flags", DEFAULTS);
+ *   flags.current;            // reactive read (templates, $derived, $effect)
+ *   flags.current = next;     // writes through to storage + broadcasts
+ *   flags.reset();            // clear the key, revert to the initial value
+ *
+ * For non-reactive call sites (SDK bootstrap, install-id reads, one-shot
+ * route reads) use the `safeStorage` helper at the bottom — same null /
+ * parse / quota safety, no reactivity overhead.
+ *
+ * Robustness contract — every one of these is handled, none of them throw:
+ *   - missing key / `null`        → the initial value
+ *   - no `window` (SSR / preview) → the initial value, storage untouched
+ *   - malformed JSON / bad data   → the initial value, `onError` fired
+ *   - partial / stale object shape → shallow-merged over the initial, so a
+ *                                    field added after the value was written
+ *                                    keeps its default instead of going
+ *                                    `undefined`
+ *   - quota / private-mode writes  → swallowed best-effort
+ */
+
+type StorageArea = "local" | "session";
+
+export interface Serializer<T> {
+	serialize: (value: T) => string;
+	deserialize: (raw: string) => T;
+}
+
+export type PersistedErrorContext = "read" | "deserialize" | "write" | "remove";
+
+export interface PersistedStateOptions<T> {
+	/** Which web storage to back onto. Defaults to `"local"`. */
+	storage?: StorageArea;
+	/**
+	 * Listen for writes from other windows/tabs (and other instances in this
+	 * same document) and re-read when the key changes. Defaults to `true`.
+	 */
+	syncTabs?: boolean;
+	/**
+	 * Override how the value is (de)serialized. Defaults to a type-aware
+	 * serializer inferred from `initialValue` — strings stored raw, numbers /
+	 * booleans coerced, everything else JSON. Inferring from the initial value
+	 * keeps backward-compatibility with keys that were written as raw strings.
+	 */
+	serializer?: Serializer<T>;
+	/**
+	 * Observe parse / quota failures instead of letting them pass silently.
+	 * The value still falls back safely; this is purely for telemetry.
+	 */
+	onError?: (error: unknown, context: PersistedErrorContext, key: string) => void;
+}
+
+const SAME_DOC_EVENT = "recast:persisted-state";
+
+interface SameDocDetail {
+	key: string;
+	area: StorageArea;
+	source: number;
+}
+
+let instanceCounter = 0;
+
+const isBrowser = typeof window !== "undefined";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	if (typeof value !== "object" || value === null) return false;
+	const proto = Object.getPrototypeOf(value);
+	return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Build a serializer from the *initial* value's runtime type. This mirrors the
+ * React hook's branching and, crucially, keeps reading values that earlier
+ * code wrote as raw (un-quoted) strings.
+ */
+export function inferSerializer<T>(initialValue: T): Serializer<T> {
+	const type = typeof initialValue;
+
+	if (type === "string") {
+		return {
+			serialize: (v) => v as unknown as string,
+			deserialize: (raw) => raw as unknown as T,
+		};
+	}
+
+	if (type === "number") {
+		return {
+			serialize: (v) => String(v),
+			deserialize: (raw) => {
+				const parsed = Number(raw);
+				return (Number.isNaN(parsed) ? initialValue : parsed) as T;
+			},
+		};
+	}
+
+	if (type === "boolean") {
+		return {
+			serialize: (v) => String(v),
+			deserialize: (raw) => (raw === "true") as unknown as T,
+		};
+	}
+
+	// object | array | null | bigint | symbol | function → JSON, with a couple
+	// of shape guards so genuinely corrupt data falls back instead of poisoning
+	// the reactive value.
+	return {
+		serialize: (v) => JSON.stringify(v),
+		deserialize: (raw) => {
+			const parsed: unknown = JSON.parse(raw);
+			// An array key that deserialized to a non-array is corrupt — bail to
+			// the initial via the caller's catch.
+			if (Array.isArray(initialValue) && !Array.isArray(parsed)) {
+				throw new TypeError("expected an array");
+			}
+			// Stale / partial object shapes keep their defaults for missing keys.
+			if (isPlainObject(initialValue) && isPlainObject(parsed)) {
+				return { ...(initialValue as object), ...(parsed as object) } as T;
+			}
+			return parsed as T;
+		},
+	};
+}
+
+export class PersistedState<T> {
+	#key: string;
+	#initial: T;
+	#storage: StorageArea;
+	#serializer: Serializer<T>;
+	#syncTabs: boolean;
+	#onError?: PersistedStateOptions<T>["onError"];
+	#id = ++instanceCounter;
+
+	#current = $state<T>() as T;
+
+	#onStorage?: (event: StorageEvent) => void;
+	#onSameDoc?: (event: Event) => void;
+
+	constructor(key: string, initialValue: T, options: PersistedStateOptions<T> = {}) {
+		this.#key = key;
+		this.#initial = initialValue;
+		this.#storage = options.storage ?? "local";
+		this.#serializer = options.serializer ?? inferSerializer(initialValue);
+		this.#syncTabs = options.syncTabs ?? true;
+		this.#onError = options.onError;
+
+		// Read the persisted value synchronously so the very first reactive read
+		// already reflects storage — no flash of the default on hydrate.
+		this.#current = this.#read();
+
+		if (isBrowser && this.#syncTabs) this.#subscribe();
+	}
+
+	get current(): T {
+		return this.#current;
+	}
+
+	set current(value: T) {
+		this.#current = value;
+		this.#write(value);
+		this.#broadcast();
+	}
+
+	/** Clear the stored value and revert the reactive value to the initial. */
+	reset(): void {
+		this.#current = this.#initial;
+		if (isBrowser) {
+			try {
+				this.#area().removeItem(this.#key);
+			} catch (error) {
+				this.#onError?.(error, "remove", this.#key);
+			}
+		}
+		this.#broadcast();
+	}
+
+	/**
+	 * Detach the cross-context listeners. Only needed for component-scoped
+	 * instances — module-level singletons live for the page's lifetime and
+	 * never need teardown.
+	 */
+	dispose(): void {
+		if (!isBrowser) return;
+		if (this.#onStorage) window.removeEventListener("storage", this.#onStorage);
+		if (this.#onSameDoc) window.removeEventListener(SAME_DOC_EVENT, this.#onSameDoc);
+		this.#onStorage = undefined;
+		this.#onSameDoc = undefined;
+	}
+
+	#area(): Storage {
+		return this.#storage === "session" ? window.sessionStorage : window.localStorage;
+	}
+
+	#read(): T {
+		if (!isBrowser) return this.#initial;
+
+		let raw: string | null;
+		try {
+			raw = this.#area().getItem(this.#key);
+		} catch (error) {
+			// Storage disabled entirely (some private modes throw on access).
+			this.#onError?.(error, "read", this.#key);
+			return this.#initial;
+		}
+
+		if (raw === null) return this.#initial;
+
+		try {
+			return this.#serializer.deserialize(raw);
+		} catch (error) {
+			this.#onError?.(error, "deserialize", this.#key);
+			return this.#initial;
+		}
+	}
+
+	#write(value: T): void {
+		if (!isBrowser) return;
+		try {
+			this.#area().setItem(this.#key, this.#serializer.serialize(value));
+		} catch (error) {
+			// Quota exceeded / private mode — best effort, the rune still updated.
+			this.#onError?.(error, "write", this.#key);
+		}
+	}
+
+	/** Tell same-document instances of this key to re-read. */
+	#broadcast(): void {
+		if (!isBrowser || !this.#syncTabs) return;
+		const detail: SameDocDetail = { key: this.#key, area: this.#storage, source: this.#id };
+		window.dispatchEvent(new CustomEvent(SAME_DOC_EVENT, { detail }));
+	}
+
+	#subscribe(): void {
+		// Cross-document: native `storage` events fire in *other* windows/tabs
+		// that share this origin (Tauri v2 webviews do). `event.key` is null on a
+		// `clear()`, which we also honour by re-reading.
+		this.#onStorage = (event: StorageEvent) => {
+			if (event.key !== null && event.key !== this.#key) return;
+			if (event.storageArea && event.storageArea !== this.#area()) return;
+			this.#current = this.#read();
+		};
+
+		// Same-document: native `storage` does NOT fire in the window that wrote
+		// it, so a second instance of the same key in this document wouldn't see
+		// the change. The custom channel covers that; the source guard stops an
+		// instance from reacting to its own write.
+		this.#onSameDoc = (event: Event) => {
+			const detail = (event as CustomEvent<SameDocDetail>).detail;
+			if (!detail || detail.key !== this.#key || detail.area !== this.#storage) return;
+			if (detail.source === this.#id) return;
+			this.#current = this.#read();
+		};
+
+		window.addEventListener("storage", this.#onStorage);
+		window.addEventListener(SAME_DOC_EVENT, this.#onSameDoc);
+	}
+}
+
+/**
+ * Convenience factory for when a `new` reads awkwardly at the call site.
+ * Returns the same `PersistedState` instance — read/write via `.current`.
+ */
+export function persisted<T>(
+	key: string,
+	initialValue: T,
+	options?: PersistedStateOptions<T>,
+): PersistedState<T> {
+	return new PersistedState(key, initialValue, options);
+}
+
+interface SafeStorageOptions<T> {
+	storage?: StorageArea;
+	serializer?: Serializer<T>;
+	onError?: (error: unknown, context: PersistedErrorContext, key: string) => void;
+}
+
+function area(storage: StorageArea): Storage {
+	return storage === "session" ? window.sessionStorage : window.localStorage;
+}
+
+/**
+ * Non-reactive twin of `PersistedState` for call sites that just need a safe
+ * read/write — SDK bootstrap, anonymous install-id, one-shot route reads —
+ * without paying for a reactive rune or cross-tab listeners. Same null / parse
+ * / quota guarantees.
+ */
+export const safeStorage = {
+	get<T>(key: string, fallback: T, options: SafeStorageOptions<T> = {}): T {
+		if (!isBrowser) return fallback;
+		const storage = options.storage ?? "local";
+		const serializer = options.serializer ?? inferSerializer(fallback);
+
+		let raw: string | null;
+		try {
+			raw = area(storage).getItem(key);
+		} catch (error) {
+			options.onError?.(error, "read", key);
+			return fallback;
+		}
+		if (raw === null) return fallback;
+
+		try {
+			return serializer.deserialize(raw);
+		} catch (error) {
+			options.onError?.(error, "deserialize", key);
+			return fallback;
+		}
+	},
+
+	set<T>(key: string, value: T, options: SafeStorageOptions<T> = {}): void {
+		if (!isBrowser) return;
+		const storage = options.storage ?? "local";
+		const serializer = options.serializer ?? inferSerializer(value);
+		try {
+			area(storage).setItem(key, serializer.serialize(value));
+		} catch (error) {
+			options.onError?.(error, "write", key);
+		}
+	},
+
+	remove(key: string, options: Pick<SafeStorageOptions<unknown>, "storage" | "onError"> = {}): void {
+		if (!isBrowser) return;
+		const storage = options.storage ?? "local";
+		try {
+			area(storage).removeItem(key);
+		} catch (error) {
+			options.onError?.(error, "remove", key);
+		}
+	},
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1057.0
         version: 3.1057.0
+      '@azure/storage-blob':
+        specifier: ^12.26.0
+        version: 12.26.0
       '@fontsource-variable/instrument-sans':
         specifier: ^5.2.8
         version: 5.2.8
@@ -174,7 +177,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.17)(postgres@3.4.9)
       files-sdk:
         specifier: ^1.6.0
-        version: 1.6.0(@aws-sdk/client-s3@3.1057.0)(@aws-sdk/s3-presigned-post@3.1057.0)(@aws-sdk/s3-request-presigner@3.1057.0)(zod@4.4.3)
+        version: 1.6.0(@aws-sdk/client-s3@3.1057.0)(@aws-sdk/s3-presigned-post@3.1057.0)(@aws-sdk/s3-request-presigner@3.1057.0)(@azure/core-auth@1.10.1)(@azure/storage-blob@12.26.0)(zod@4.4.3)
       gsap:
         specifier: ^3.15.0
         version: 3.15.0
@@ -460,6 +463,57 @@ packages:
 
   '@aws/lambda-invoke-store@0.2.4':
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/abort-controller@2.1.2':
+    resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-auth@1.10.1':
+    resolution: {integrity: sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-client@1.10.1':
+    resolution: {integrity: sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-http-compat@2.4.0':
+    resolution: {integrity: sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@azure/core-client': ^1.10.0
+      '@azure/core-rest-pipeline': ^1.22.0
+
+  '@azure/core-lro@2.7.2':
+    resolution: {integrity: sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-paging@1.6.2':
+    resolution: {integrity: sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-rest-pipeline@1.23.0':
+    resolution: {integrity: sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-tracing@1.3.1':
+    resolution: {integrity: sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-util@1.13.1':
+    resolution: {integrity: sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-xml@1.5.1':
+    resolution: {integrity: sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/logger@1.3.0':
+    resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/storage-blob@12.26.0':
+    resolution: {integrity: sha512-SriLPKezypIsiZ+TtlFfE46uuBIap2HeaQVS78e1P7rz5OSbq0rsd52WE1mC5f7vAeLiXqv7I7oRhL3WFZEw3Q==}
     engines: {node: '>=18.0.0'}
 
   '@babel/runtime@7.29.2':
@@ -2125,6 +2179,10 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@typespec/ts-http-runtime@0.3.5':
+    resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
+    engines: {node: '>=20.0.0'}
+
   '@unpic/core@1.0.3':
     resolution: {integrity: sha512-aum9YNVUGso7MjGLD0Rp/08kywCGLqZ03/q6VQBFFakDBOXWEc8D4kPGcZ8v5wEnGRex3lE+++bOuucBp3KJ/w==}
 
@@ -2141,6 +2199,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -2562,6 +2624,10 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
@@ -2800,6 +2866,14 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -3907,6 +3981,103 @@ snapshots:
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
+
+  '@azure/abort-controller@2.1.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-auth@1.10.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-util': 1.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-client@1.10.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-http-compat@2.4.0(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.23.0)':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+
+  '@azure/core-lro@2.7.2':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-paging@1.6.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-rest-pipeline@1.23.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      '@typespec/ts-http-runtime': 0.3.5
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-tracing@1.3.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-util@1.13.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@typespec/ts-http-runtime': 0.3.5
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-xml@1.5.1':
+    dependencies:
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@azure/logger@1.3.0':
+    dependencies:
+      '@typespec/ts-http-runtime': 0.3.5
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/storage-blob@12.26.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-http-compat': 2.4.0(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.23.0)
+      '@azure/core-lro': 2.7.2
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/core-xml': 1.5.1
+      '@azure/logger': 1.3.0
+      events: 3.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/runtime@7.29.2': {}
 
@@ -5250,6 +5421,14 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
+  '@typespec/ts-http-runtime@0.3.5':
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@unpic/core@1.0.3':
     dependencies:
       unpic: 4.2.2
@@ -5267,6 +5446,8 @@ snapshots:
     optional: true
 
   acorn@8.16.0: {}
+
+  agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -5458,7 +5639,6 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optional: true
 
   deepmerge@4.3.1: {}
 
@@ -5657,6 +5837,8 @@ snapshots:
   etag@1.8.1:
     optional: true
 
+  events@3.3.0: {}
+
   eventsource-parser@3.1.0:
     optional: true
 
@@ -5745,13 +5927,15 @@ snapshots:
 
   fflate@0.4.8: {}
 
-  files-sdk@1.6.0(@aws-sdk/client-s3@3.1057.0)(@aws-sdk/s3-presigned-post@3.1057.0)(@aws-sdk/s3-request-presigner@3.1057.0)(zod@4.4.3):
+  files-sdk@1.6.0(@aws-sdk/client-s3@3.1057.0)(@aws-sdk/s3-presigned-post@3.1057.0)(@aws-sdk/s3-request-presigner@3.1057.0)(@azure/core-auth@1.10.1)(@azure/storage-blob@12.26.0)(zod@4.4.3):
     dependencies:
       commander: 14.0.3
     optionalDependencies:
       '@aws-sdk/client-s3': 3.1057.0
       '@aws-sdk/s3-presigned-post': 3.1057.0
       '@aws-sdk/s3-request-presigner': 3.1057.0
+      '@azure/core-auth': 1.10.1
+      '@azure/storage-blob': 12.26.0
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
@@ -5874,6 +6058,20 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
     optional: true
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-id@4.1.3: {}
 
@@ -6059,8 +6257,7 @@ snapshots:
 
   mrmime@2.0.1: {}
 
-  ms@2.1.3:
-    optional: true
+  ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 


### PR DESCRIPTION
- Implemented GET and POST endpoints for tags in `api/tags/+server.ts` to retrieve and create tags within a workspace.
- Added PATCH and DELETE endpoints in `api/tags/[id]/+server.ts` for updating and removing tags.
- Updated the dashboard to include folder and tag management in `dashboard/recasts/+page.server.ts` and `dashboard/recasts/+page.svelte`.
- Enhanced the UI with a new Chip component for tag filtering and management in `packages/ui`.
- Improved recast handling with folder and tag associations, including filtering capabilities.
- Added view recording functionality in the share page to track engagement metrics.