### PR TITLE
feat(desktop): export frame-rate control, plus recording stability & UX fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,14 @@ See [`.changeset/README.md`](.changeset/README.md) for the full flow.
 `pnpm release:prepare <version>` consumes pending changesets and the current
 `[Unreleased]` block into a new dated section.
 
-## [Unreleased]
+## [0.2.5] — 2026-06-09
+
+### Fixed
+- Exported videos no longer open to a black screen stuck on "media loading" in the in-app player on release builds — the player now streams the file from the start instead of waiting on a tail fetch that never completed, so exports play back immediately.
+- macOS and Linux: the app no longer freezes after a recording finishes. Saving a recording — flushing the encoder, finalizing the file, and the camera pause-trim re-encode — ran on the UI thread and locked the whole window until it completed. It now runs off the main thread. (Windows was unaffected because it renders the UI in a separate process.)
+- macOS and Linux: starting a recording, listing recordings/exports, picking a microphone, and "reveal in file manager" no longer briefly freeze the window — these all moved off the UI thread for the same reason.
+- Long recordings could freeze mid-capture: the encoder's FFmpeg progress output filled an OS pipe buffer that was never drained, stalling the encoder and the recording. Its output is now drained continuously.
+- A recording that fails to start partway through no longer leaves orphaned capture/encoder processes running in the background.
 
 ## [0.2.4] — 2026-06-07
 

--- a/apps/desktop/docs/cross-platform-support-plan.md
+++ b/apps/desktop/docs/cross-platform-support-plan.md
@@ -1,36 +1,95 @@
 # Cross-Platform Support Plan — macOS & Linux
 
-> Status: **Planning** · Created 2026-05-19 · Owner: Kanak
+> Status: **Code-complete, verification-gated** · Created 2026-05-19 ·
+> Last updated 2026-06-08 · Owner: Kanak
 >
-> Today the app is fully functional **only on Windows**. Recording still
-> "works" on macOS/Linux in that a video file is produced, but several
-> capture subsystems silently degrade to stubs (silent audio, no cursor
-> track, camera errors). Linux screen capture is written but unverified.
-> This document inventories what is missing and sequences the work.
+> **Original framing (2026-05-19):** the app was fully functional only on
+> Windows; macOS/Linux produced a file but silently degraded several capture
+> subsystems to stubs (silent audio, no cursor track, camera errors), and
+> Linux screen capture was written but unverified.
+>
+> **Where we are now (2026-06-08):** every capture subsystem — screen, system
+> audio, microphone, camera, cursor, device enumeration — is *implemented* on
+> all three OSes. The remaining distance to production is **runtime
+> verification on real macOS/Linux hardware**, not missing code. macOS is in
+> active testing (a real macOS build surfaced and we fixed a post-recording
+> UI-freeze; see the 2026-06-08 hardening note). Linux has not yet had a
+> hardware pass. See the **[readiness scorecard](#readiness-scorecard--2026-06-08)**
+> for the per-OS gap.
+
+---
+
+<a name="readiness-scorecard--2026-06-08"></a>
+
+## 0. Readiness scorecard — 2026-06-08
+
+"Code complete" = the path is written and compiles in CI for that target.
+"Production-ready" = a real user on that OS can record → edit → export without
+hitting a known-broken path, verified on hardware.
+
+| OS | Code complete | Production-ready | What's actually left |
+|---|---|---|---|
+| **Windows** | 100% | **~100% — shipping** | Verified, in users' hands. The reference platform. |
+| **macOS** | ~95% | **~75%** | (a) Out-of-the-box **system audio** needs BlackHole/virtual driver — native ScreenCaptureKit loopback is implemented but **default-off** behind the `sckit-loopback` Cargo feature (upstream SDK-symbol issue). (b) Hardware verification of capture + the TCC permission flow + Retina/multi-monitor. (c) Deferred capture-read robustness (a stalled device can hang `stop()`). (d) Developer-ID signing + **notarization** (identity task, gates a no-warnings download). (e) First-run permissions UX. |
+| **Linux** | ~90% | **~60%** | (a) **Zero hardware verification yet** — biggest unknown. Portal+PipeWire (Wayland) and XGetImage (X11) are written + audit-fixed (F1) but never run on a real session. (b) Wayland: cursor double-render (`CursorMode::Embedded`) and a portal dialog on every record (no `restore_token` persistence). (c) X11 perf TODOs: XShm fast path unwired, ~4× over-capture (F4); window-occlusion not handled. (d) Functional sign-off on GNOME + KDE + an X11 session. |
+
+**One-line answer to "how far behind?":** Windows is done. **macOS is roughly
+one focused hardware-test + audio-default + notarization cycle from a public
+beta.** **Linux is one hardware bring-up cycle behind macOS** — the code is
+there, but nothing has run on a real Linux session, so confidence is lowest.
+
+### Stability hardening landed 2026-06-08 (cross-cutting, helps macOS/Linux most)
+A pass over the recording IPC surface fixed a class of freeze/hang that only
+*manifests* on macOS/Linux (their in-process WebView renders on the same main
+thread Tauri runs sync commands on; Windows' out-of-process WebView2 masked it):
+
+- `start_recording` / `stop_recording`, `get_audio_devices`,
+  `list_recasts` / `list_exports`, `open_file_location` were **synchronous**
+  commands doing process-spawn / thread-join / device-enum / disk work on the
+  UI thread → converted to `async` + `spawn_blocking`. (`stop_recording` was
+  the post-record freeze a macOS tester reported.)
+- Encoder **stderr-pipe deadlock**: FFmpeg's progress output filled the
+  undrained ~64KB stderr pipe on long recordings → froze the encode
+  mid-capture. Now drained continuously on a side thread.
+- Recording **start-failure orphan cascade**: a partial `start()` failure left
+  capture/encoder threads (and their FFmpeg children) running forever; now torn
+  down on the error path.
+- A compile-time regression guard keeps `start`/`stop_recording` async.
+
+**Still open (deferred, needs on-device validation):** interruptible/timeout
+reads in `capture/platform/macos.rs` and `linux_x11.rs` so a device stall
+(permission revoked mid-record, hung X server) can't block `stop()`.
 
 ---
 
 ## 1. Current state by platform
 
+Legend: ✅ verified on hardware · 🟢 implemented, compiles in CI, **not yet
+hardware-verified** · ⚠️ implemented with a known limitation · ❌ stub/no-op.
+(Updated 2026-06-08 — the rows the original plan marked "❌ empty list" for
+device enumeration are now implemented.)
+
 | Subsystem | Windows | Linux | macOS |
 |---|---|---|---|
-| Screen capture | ✅ DXGI Desktop Duplication | ⚠️ Wayland (portal+PipeWire, F1 fix landed) & X11 written, awaiting hardware test | ✅ FFmpeg AVFoundation (replaces xcap) |
-| System audio (loopback) | ✅ WASAPI | ✅ FFmpeg pulse `.monitor` (silence fallback if no PA) | ⚠️ BlackHole/Soundflower/Loopback/VB-Cable if installed; silence + log otherwise. SCKit native loopback is scaffolded but **deferred pending API verification** (see below) |
-| Microphone | ✅ WASAPI | ✅ FFmpeg pulse `default` | ✅ FFmpeg avfoundation `:0` |
-| Camera / webcam | ✅ FFmpeg DirectShow | ✅ FFmpeg V4L2 | ✅ FFmpeg AVFoundation |
-| Cursor sampling | ✅ Win32 GetCursorPos | ✅ device_query (xcb) | ✅ device_query (CoreGraphics) |
-| Reveal in file manager | ✅ `explorer /select,` | ✅ D-Bus `FileManager1.ShowItems` + xdg-open fallback | ✅ `open -R` |
-| Audio device list | ✅ WASAPI enumerate | ❌ empty list | ❌ empty list |
-| Camera device list | ✅ FFmpeg `-list_devices` | ❌ empty list | ❌ empty list |
-| Window capture-exclusion | ✅ `SetWindowDisplayAffinity` | ❌ no-op | ❌ no-op |
-| Reveal file in explorer | ✅ `explorer /select` | ❌ no-op | ❌ no-op |
-| Video encoding | ✅ FFmpeg (NVENC/x264) | ✅ portable | ✅ portable |
-| Delete to trash | ✅ `trash` crate | ✅ portable | ✅ portable |
+| Screen capture | ✅ DXGI Desktop Duplication | 🟢 Wayland (portal+PipeWire, F1 fix landed) & X11 (XGetImage) — written, awaiting hardware test | 🟢 FFmpeg AVFoundation (replaces xcap) |
+| System audio (loopback) | ✅ WASAPI | 🟢 FFmpeg pulse `.monitor` (silence fallback if no PA) | ⚠️ Default path = BlackHole/Soundflower/Loopback/VB-Cable if installed, else silence + actionable log. Native **ScreenCaptureKit loopback is now implemented** but **default-off** behind the `sckit-loopback` Cargo feature (upstream apple-metal SDK-symbol issue) |
+| Microphone | ✅ WASAPI | 🟢 FFmpeg pulse `default` | 🟢 FFmpeg avfoundation `:0` |
+| Camera / webcam | ✅ FFmpeg DirectShow | 🟢 FFmpeg V4L2 | 🟢 FFmpeg AVFoundation |
+| Cursor sampling | ✅ Win32 GetCursorPos | 🟢 device_query (xcb / XWayland) | 🟢 device_query (CoreGraphics) |
+| Reveal in file manager | ✅ `explorer /select,` | 🟢 D-Bus `FileManager1.ShowItems` + xdg-open fallback | 🟢 `open -R` |
+| Audio device list | ✅ WASAPI enumerate | 🟢 `pactl list short sources` (`.monitor` filtered) | 🟢 AVFoundation listing parsed |
+| Camera device list | ✅ FFmpeg `-list_devices` | 🟢 `/dev/video*` + sysfs V4L2-capture filter | 🟢 AVFoundation listing (screens filtered) |
+| Capture capabilities probe | ✅ `capture_capabilities` | 🟢 `capture_capabilities` | 🟢 `capture_capabilities` |
+| Window capture-exclusion | ✅ `SetWindowDisplayAffinity` | ❌ no-op (deferred) | ❌ no-op (deferred) |
+| Video encoding | ✅ FFmpeg (NVENC/x264) | 🟢 FFmpeg (x264, hw if present) | 🟢 FFmpeg (x264, VideoToolbox if present) |
+| Delete to trash | ✅ `trash` crate | 🟢 `trash` crate | 🟢 `trash` crate |
 
 **Good news:** the architecture already has a clean per-module
 `platform/{windows,fallback,...}.rs` abstraction with `#[cfg]` dispatch, so
 each gap is an additive, isolated file — no refactor required. FFmpeg is the
-codec/format abstraction layer and is already cross-platform.
+codec/format abstraction layer and is already cross-platform. **The 🟢 rows are
+the whole story now: code is written and green in CI on every target; the
+distance to ✅ is a person sitting in front of a Mac / a Linux box.**
 
 ---
 
@@ -114,9 +173,11 @@ panel sends "Default"/empty (matches the Windows path). Listing logic:
   "Capture screen N" pseudo-devices.
 - Linux — picks the lowest-numbered `/dev/video*` node up to 16.
 
-**Not done** (follow-up): wiring `commands/system.rs::get_camera_devices`
-for macOS/Linux so the in-app picker populates instead of leaning on
-the auto-first-device fallback.
+**Follow-up — done (since 2026-05-19):**
+`commands/system.rs::get_camera_devices` now enumerates on macOS (AVFoundation
+listing, "Capture screen" pseudo-devices filtered) and Linux (`/dev/video*` +
+sysfs `V4L2_CAP_VIDEO_CAPTURE` filter), so the in-app picker populates instead
+of leaning on the auto-first-device fallback. (Hardware-unverified.)
 
 ### Phase 4 — Audio capture *(done 2026-05-19, with documented caveat)*
 Landed as one shared file
@@ -130,16 +191,16 @@ samples when not paused. A stop-watcher thread sends FFmpeg a graceful
 **Loopback sources (three-tier resolution chain, top tier deferred):**
 - **macOS — ScreenCaptureKit** (`audio/platform/macos_sckit.rs`): the
   only built-in macOS API for system audio without a virtual driver,
-  and the path every modern recorder uses. **Currently a placeholder
-  that returns `Err` so the chain falls through.** First attempt used
-  the `screencapturekit` crate but the assumed module layout
-  (`sc_content_filter`, `sc_stream`, ...) doesn't match the current
-  crates.io release, and iterating blind from a non-macOS dev host
-  burns CI cycles without signal. The file documents exactly what
-  needs to happen to wire it (verify crate's current API or switch to
-  `objc2-screen-capture-kit`, then implement `try_start` against
-  `SCShareableContent`/`SCStream`/`CMSampleBuffer`). When wired this
-  will share the Screen Recording TCC prompt with Phase 5 video, so
+  and the path every modern recorder uses. **Now implemented** against
+  the `screencapturekit` 6.0 crate (`SCShareableContent` → `SCStream`
+  with an audio handler → `CMSampleBuffer` Float32→s16le, pause
+  semantics matched to WASAPI). **Gated default-off behind the
+  `sckit-loopback` Cargo feature** because the build currently trips an
+  upstream apple-metal SDK-symbol issue on the CI SDK; the file carries
+  a Mac-reviewer smoke-test checklist. Until it's enabled by default,
+  the *effective* macOS loopback is the BlackHole/virtual-driver tier
+  below — **this is the single biggest macOS out-of-the-box gap.** When
+  on, it shares the Screen Recording TCC prompt with Phase 5 video, so
   there is no second permission cost.
 - **macOS — BlackHole / virtual driver** (FFmpeg avfoundation): scans
   for BlackHole / Soundflower / Loopback / VB-Cable and routes through
@@ -154,8 +215,11 @@ user-supplied device id falls through if non-empty/non-"default". Mic
 failure surfaces as an error — there's no silent fallback for an
 explicitly-enabled mic.
 
-**Not done** (follow-up): `commands/system.rs::get_audio_devices` for
-macOS/Linux so the mic picker enumerates instead of always defaulting.
+**Follow-up — done (since 2026-05-19):**
+`commands/system.rs::get_audio_devices` now enumerates on macOS (AVFoundation
+listing) and Linux (`pactl list short sources`, `.monitor` sources filtered
+out), so the mic picker populates instead of always defaulting.
+(Hardware-unverified.)
 
 ### Phase 5 — macOS screen capture *(done 2026-05-19, with planned 5b)*
 Landed as
@@ -246,9 +310,17 @@ download experience.
 and ScreenCaptureKit bring-up (Phase 5). De-risk these early with a spike
 before committing the rest of Phase 4–5.
 
-**Suggested milestones:**
-- **M1 — Linux beta:** Phases 0, 1, 2 (Linux), 3 (Linux), 4 (Linux).
-- **M2 — macOS beta:** Phases 2, 3, 4, 5 (macOS) + 6 + 7.
+**Suggested milestones (re-sequenced 2026-06-08 — all code now landed, so these
+are *verification* milestones, not build milestones):**
+- **M1 — macOS beta** *(now the nearer milestone — macOS is already in active
+  testing):* hardware pass on capture + TCC permissions + Retina/multi-monitor;
+  decide system-audio default (enable `sckit-loopback` once the SDK-symbol issue
+  clears, or ship the BlackHole-guided path with clear in-app messaging); land
+  the deferred capture-read timeout; Developer-ID signing + notarization (Phase
+  7). Ship behind a "macOS preview" label.
+- **M2 — Linux beta:** first real hardware bring-up on GNOME + KDE (Wayland) and
+  an X11 session; fix Wayland cursor double-render + portal-every-record; X11
+  perf (XShm / over-capture) only if a tested display needs it.
 
 ---
 

--- a/apps/desktop/src-tauri/src/commands/editor.rs
+++ b/apps/desktop/src-tauri/src/commands/editor.rs
@@ -868,6 +868,23 @@ pub async fn export_video(
     // fallback when the render state has no Trim node (duration == 0).
     let source_duration = metadata.duration.max(0.0);
     let profile = resolve_export_profile(&request.quality);
+    // Output frame rate (MP4/WebM). Default = source rate, so the export keeps
+    // the original smoothness with no resampling. A user selection is clamped to
+    // never exceed the source — we only ever downsample, never duplicate frames
+    // (which would bloat the file without adding motion). The target drives the
+    // composite background rate, the looped-input rate, and the cursor overlay
+    // rate so the whole graph runs at one consistent rate (see the 25fps-default
+    // judder bug fixed alongside this). GIF ignores it (uses gif_settings.fps).
+    let source_fps = if metadata.fps.is_finite() && metadata.fps >= 1.0 {
+        metadata.fps
+    } else {
+        60.0
+    };
+    let target_fps = request
+        .fps
+        .filter(|f| f.is_finite() && *f >= 1.0)
+        .map(|f| f.min(source_fps))
+        .unwrap_or(source_fps);
     // Encoder effort axis, orthogonal to the resolution profile. Defaults to
     // Balanced (historical settings) when absent/unknown.
     let speed = ExportSpeed::from_request(request.speed.as_deref().unwrap_or("balanced"));
@@ -996,6 +1013,7 @@ pub async fn export_video(
             SourceVideoMetadata {
                 width: metadata.width,
                 height: metadata.height,
+                fps: target_fps,
             },
             &static_root(),
             1,
@@ -1025,7 +1043,7 @@ pub async fn export_video(
                     source_width: metadata.width,
                     source_height: metadata.height,
                     padding: canvas_padding,
-                    fps: metadata.fps.round().max(1.0) as u32,
+                    fps: target_fps.round().max(1.0) as u32,
                     duration_secs: overlay_duration,
                     trim_start,
                     render_state: request.render_state.clone(),
@@ -1063,8 +1081,15 @@ pub async fn export_video(
     }
     args.extend(["-i".to_string(), source_video.to_string_lossy().to_string()]);
 
+    // `-loop 1` on a still image defaults to 25 fps. A wallpaper/gradient/image
+    // background is the BASE of the composite overlay, so leaving it at 25 fps
+    // would force the whole export to 25 fps (frame-dropping the 60 fps source
+    // into judder). Pin every looped image input to the source frame rate.
+    let loop_fps = target_fps;
     for input in &export_plan.extra_inputs {
         args.extend([
+            "-framerate".to_string(),
+            format!("{loop_fps}"),
             "-loop".to_string(),
             "1".to_string(),
             "-i".to_string(),

--- a/apps/desktop/src-tauri/src/commands/recording.rs
+++ b/apps/desktop/src-tauri/src/commands/recording.rs
@@ -154,7 +154,11 @@ pub async fn stop_recording(state: State<'_, AppState>) -> Result<String, String
             video: ProjectVideoMetadata {
                 width: artifacts.capture_target.crop.width,
                 height: artifacts.capture_target.crop.height,
-                fps: crate::recording::RECORDING_FPS,
+                // The pacer + encoder ran at the session's chosen capture rate
+                // (default 60); persist that, not a hard-coded const, so the
+                // editor and export source-fps detection are correct for
+                // high-refresh recordings.
+                fps: artifacts.stats.nominal_fps,
                 duration_ms: artifacts.stats.duration_ms,
             },
             media: Some(ProjectMediaMetadata {

--- a/apps/desktop/src-tauri/src/commands/recording.rs
+++ b/apps/desktop/src-tauri/src/commands/recording.rs
@@ -24,144 +24,179 @@ fn exports_dir(state: &State<'_, AppState>) -> PathBuf {
 }
 
 #[tauri::command]
-pub fn start_recording(
+pub async fn start_recording(
     target_type: String,
     target_id: u32,
     region: Option<RegionRect>,
     options: Option<RecordingOptions>,
     state: State<'_, AppState>,
 ) -> Result<RecordingStartResult, String> {
-    // On Wayland the compositor refuses direct framebuffer access — the
-    // user-supplied target_type/target_id/region are essentially advisory
-    // because the *real* source is whatever the user picks in the
-    // xdg-desktop-portal dialog. We negotiate the portal stream up front
-    // (this blocks while the dialog is on screen), use the portal's
-    // returned dimensions as authoritative, and stash the stream handle
-    // for the capture thread to pick up. See
-    // `capture::platform::linux_wayland` for the full lifecycle.
-    #[cfg(target_os = "linux")]
-    let target = {
-        if std::env::var_os("WAYLAND_DISPLAY").is_some() {
-            let stream = crate::capture::platform::linux_wayland::acquire_portal_stream()
-                .map_err(|e| format!("Wayland portal handshake failed: {e:#}"))?;
-            let kind = if target_type == "window" {
-                crate::recording::CaptureKind::Window
+    // Resolving the capture target enumerates monitors/windows (xcap's
+    // `Monitor::all`/`Window::all` can stall hundreds of ms), on Wayland
+    // negotiates the xdg-desktop-portal dialog, and `start()` then spawns the
+    // capture/encoder/audio/camera processes — all blocking. Tauri runs sync
+    // commands on the main thread, which on macOS (WKWebView) and Linux
+    // (WebKitGTK) also renders the UI, so doing this inline froze the window
+    // while "Start" was pressed (Windows' out-of-process WebView2 masked it).
+    // Mirror `stop_recording`: push the whole blocking body onto a worker so
+    // the UI thread — including the Wayland portal dialog — stays responsive.
+    let manager = state.recording_manager.clone();
+    let output_dir = get_active_output_dir(&state);
+
+    tauri::async_runtime::spawn_blocking(move || -> Result<RecordingStartResult, String> {
+        // On Wayland the compositor refuses direct framebuffer access — the
+        // user-supplied target_type/target_id/region are essentially advisory
+        // because the *real* source is whatever the user picks in the
+        // xdg-desktop-portal dialog. We negotiate the portal stream up front
+        // (this blocks while the dialog is on screen), use the portal's
+        // returned dimensions as authoritative, and stash the stream handle
+        // for the capture thread to pick up. See
+        // `capture::platform::linux_wayland` for the full lifecycle.
+        #[cfg(target_os = "linux")]
+        let target = {
+            if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+                let stream = crate::capture::platform::linux_wayland::acquire_portal_stream()
+                    .map_err(|e| format!("Wayland portal handshake failed: {e:#}"))?;
+                let kind = if target_type == "window" {
+                    crate::recording::CaptureKind::Window
+                } else if target_type == "region" {
+                    crate::recording::CaptureKind::Region
+                } else {
+                    crate::recording::CaptureKind::Display
+                };
+                let area = crate::recording::CaptureArea {
+                    x: 0,
+                    y: 0,
+                    width: stream.width,
+                    height: stream.height,
+                };
+                let target = CaptureTarget {
+                    kind,
+                    id: target_id,
+                    display_id: target_id,
+                    label: "Wayland portal".to_string(),
+                    source: area,
+                    crop: area,
+                    // The portal already hands us physical pixels, so no rescale.
+                    scale_factor: 1.0,
+                };
+                crate::capture::platform::linux_wayland::stash_portal_stream(stream);
+                target
             } else if target_type == "region" {
-                crate::recording::CaptureKind::Region
+                let rect = region.ok_or_else(|| "region target requires a rect".to_string())?;
+                CaptureTarget::resolve_region(rect).map_err(|e| e.to_string())?
             } else {
-                crate::recording::CaptureKind::Display
-            };
-            let area = crate::recording::CaptureArea {
-                x: 0,
-                y: 0,
-                width: stream.width,
-                height: stream.height,
-            };
-            let target = CaptureTarget {
-                kind,
-                id: target_id,
-                display_id: target_id,
-                label: "Wayland portal".to_string(),
-                source: area,
-                crop: area,
-                // The portal already hands us physical pixels, so no rescale.
-                scale_factor: 1.0,
-            };
-            crate::capture::platform::linux_wayland::stash_portal_stream(stream);
-            target
-        } else if target_type == "region" {
+                CaptureTarget::resolve(&target_type, target_id).map_err(|e| e.to_string())?
+            }
+        };
+        #[cfg(not(target_os = "linux"))]
+        let target = if target_type == "region" {
             let rect = region.ok_or_else(|| "region target requires a rect".to_string())?;
             CaptureTarget::resolve_region(rect).map_err(|e| e.to_string())?
         } else {
             CaptureTarget::resolve(&target_type, target_id).map_err(|e| e.to_string())?
-        }
-    };
-    #[cfg(not(target_os = "linux"))]
-    let target = if target_type == "region" {
-        let rect = region.ok_or_else(|| "region target requires a rect".to_string())?;
-        CaptureTarget::resolve_region(rect).map_err(|e| e.to_string())?
-    } else {
-        CaptureTarget::resolve(&target_type, target_id).map_err(|e| e.to_string())?
-    };
-    let output_dir = get_active_output_dir(&state);
-    let warnings = state
-        .recording_manager
-        .start(target, output_dir, options.unwrap_or_default())
-        .inspect_err(|e| log::error!("start_recording failed: {e:#}"))
-        .map_err(|e| format!("{e:#}"))?;
-    Ok(RecordingStartResult { warnings })
+        };
+        let warnings = manager
+            .start(target, output_dir, options.unwrap_or_default())
+            .inspect_err(|e| log::error!("start_recording failed: {e:#}"))
+            .map_err(|e| format!("{e:#}"))?;
+        Ok(RecordingStartResult { warnings })
+    })
+    .await
+    .map_err(|e| format!("start_recording worker panicked: {e}"))?
 }
 
 #[tauri::command]
-pub fn stop_recording(state: State<'_, AppState>) -> Result<String, String> {
-    // `{:#}` formats the full anyhow chain (top message + every `.context()`
-    // below it), so the JS-side alert sees the real cause instead of just
-    // the outermost label. Without this, errors like "encoder thread
-    // panicked" hid the underlying FFmpeg-process exit code.
-    let artifacts = state
-        .recording_manager
-        .stop()
-        .inspect_err(|e| log::error!("stop_recording failed: {e:#}"))
-        .map_err(|e| format!("{e:#}"))?;
+pub async fn stop_recording(state: State<'_, AppState>) -> Result<String, String> {
+    // `stop()` joins the capture/cursor/encoder threads, finalizes the muxer,
+    // stops the audio/mic/camera sessions, and — when the camera was recorded
+    // through pauses — runs a full FFmpeg re-encode to cut the paused spans out
+    // (its own comment notes this can take 30+ seconds). `write_project` then
+    // zips the media to disk. All of it is blocking CPU/IO.
+    //
+    // Tauri runs *synchronous* commands directly on the main thread. On macOS
+    // the WebView renders on that same thread, so running this inline froze the
+    // entire window after every recording — clicks/drag stopped landing until
+    // the work finished. Windows' out-of-process WebView2 kept painting, which
+    // is why the hang was macOS-only. Mirror `get_displays`/`export_video`: make
+    // the command `async` and push the whole blocking body onto a worker so the
+    // UI thread stays free to paint the "Saving…" transition. See the matching
+    // note on `AppState::recording_manager` (it's an `Arc` for this reason).
+    let manager = state.recording_manager.clone();
     let dest = recasts_dir(&state);
-    // Human-readable, sortable, searchable name (local time of capture) —
-    // e.g. `Recast_2026-05-16_14-30-22.recast`.
-    let stamp = Local
-        .timestamp_millis_opt(artifacts.started_at_unix_ms as i64)
-        .single()
-        .unwrap_or_else(Local::now)
-        .format("%Y-%m-%d_%H-%M-%S");
-    let final_path = super::unique_path(&dest, &format!("Recast_{stamp}"), "recast");
-    // The recording pipeline is the authoritative source for these values
-    // (crop dimensions from `CaptureTarget`, FPS pinned by the pacer at 60).
-    // Spawning ffprobe here just to confirm what we already know was
-    // adding 100–300ms to every stop, right when the UI wants to transition.
-    let metadata = ProjectMetadata {
-        schema_version: 1,
-        created_at_unix_ms: artifacts.started_at_unix_ms,
-        capture_target: artifacts.capture_target.clone(),
-        stats: artifacts.stats.clone(),
-        video: ProjectVideoMetadata {
-            width: artifacts.capture_target.crop.width,
-            height: artifacts.capture_target.crop.height,
-            fps: crate::recording::RECORDING_FPS,
-            duration_ms: artifacts.stats.duration_ms,
-        },
-        media: Some(ProjectMediaMetadata {
-            has_system_audio: true,
-            has_microphone: artifacts.microphone_path.is_some(),
-            has_camera: artifacts.camera_path.is_some(),
-        }),
-    };
-    let default_render_state = RenderState {
-        trim_end: artifacts.stats.duration_ms as f64 / 1000.0,
-        camera_overlay: artifacts.camera_overlay.clone(),
-        ..RenderState::default()
-    };
-    let project_path = write_project(ProjectWriteRequest {
-        output_path: final_path.clone(),
-        metadata,
-        recording_path: artifacts.recording_path.clone(),
-        cursor_path: artifacts.cursor_path.clone(),
-        audio_path: artifacts.audio_path.clone(),
-        microphone_path: artifacts.microphone_path.clone(),
-        camera_path: artifacts.camera_path.clone(),
-        edits_json: serde_json::to_string_pretty(&default_render_state)
-            .unwrap_or_else(|_| "{}".into()),
-    })
-    .inspect_err(|e| log::error!("write_project failed: {e:#}"))
-    .map_err(|e| format!("{e:#}"))?;
 
-    // Clean up temporary session files.
-    let _ = fs::remove_file(&artifacts.recording_path);
-    let _ = fs::remove_file(&artifacts.cursor_path);
-    let _ = fs::remove_file(&artifacts.audio_path);
-    if let Some(ref mic_path) = artifacts.microphone_path {
-        let _ = fs::remove_file(mic_path);
-    }
-    if let Some(ref cam_path) = artifacts.camera_path {
-        let _ = fs::remove_file(cam_path);
-    }
+    let project_path = tauri::async_runtime::spawn_blocking(move || -> Result<PathBuf, String> {
+        // `{:#}` formats the full anyhow chain (top message + every `.context()`
+        // below it), so the JS-side alert sees the real cause instead of just
+        // the outermost label. Without this, errors like "encoder thread
+        // panicked" hid the underlying FFmpeg-process exit code.
+        let artifacts = manager
+            .stop()
+            .inspect_err(|e| log::error!("stop_recording failed: {e:#}"))
+            .map_err(|e| format!("{e:#}"))?;
+        // Human-readable, sortable, searchable name (local time of capture) —
+        // e.g. `Recast_2026-05-16_14-30-22.recast`.
+        let stamp = Local
+            .timestamp_millis_opt(artifacts.started_at_unix_ms as i64)
+            .single()
+            .unwrap_or_else(Local::now)
+            .format("%Y-%m-%d_%H-%M-%S");
+        let final_path = super::unique_path(&dest, &format!("Recast_{stamp}"), "recast");
+        // The recording pipeline is the authoritative source for these values
+        // (crop dimensions from `CaptureTarget`, FPS pinned by the pacer at 60).
+        // Spawning ffprobe here just to confirm what we already know was
+        // adding 100–300ms to every stop, right when the UI wants to transition.
+        let metadata = ProjectMetadata {
+            schema_version: 1,
+            created_at_unix_ms: artifacts.started_at_unix_ms,
+            capture_target: artifacts.capture_target.clone(),
+            stats: artifacts.stats.clone(),
+            video: ProjectVideoMetadata {
+                width: artifacts.capture_target.crop.width,
+                height: artifacts.capture_target.crop.height,
+                fps: crate::recording::RECORDING_FPS,
+                duration_ms: artifacts.stats.duration_ms,
+            },
+            media: Some(ProjectMediaMetadata {
+                has_system_audio: true,
+                has_microphone: artifacts.microphone_path.is_some(),
+                has_camera: artifacts.camera_path.is_some(),
+            }),
+        };
+        let default_render_state = RenderState {
+            trim_end: artifacts.stats.duration_ms as f64 / 1000.0,
+            camera_overlay: artifacts.camera_overlay.clone(),
+            ..RenderState::default()
+        };
+        let project_path = write_project(ProjectWriteRequest {
+            output_path: final_path.clone(),
+            metadata,
+            recording_path: artifacts.recording_path.clone(),
+            cursor_path: artifacts.cursor_path.clone(),
+            audio_path: artifacts.audio_path.clone(),
+            microphone_path: artifacts.microphone_path.clone(),
+            camera_path: artifacts.camera_path.clone(),
+            edits_json: serde_json::to_string_pretty(&default_render_state)
+                .unwrap_or_else(|_| "{}".into()),
+        })
+        .inspect_err(|e| log::error!("write_project failed: {e:#}"))
+        .map_err(|e| format!("{e:#}"))?;
+
+        // Clean up temporary session files.
+        let _ = fs::remove_file(&artifacts.recording_path);
+        let _ = fs::remove_file(&artifacts.cursor_path);
+        let _ = fs::remove_file(&artifacts.audio_path);
+        if let Some(ref mic_path) = artifacts.microphone_path {
+            let _ = fs::remove_file(mic_path);
+        }
+        if let Some(ref cam_path) = artifacts.camera_path {
+            let _ = fs::remove_file(cam_path);
+        }
+
+        Ok(project_path)
+    })
+    .await
+    .map_err(|e| format!("stop_recording worker panicked: {e}"))??;
 
     *state.last_file_path.lock() = Some(project_path.to_string_lossy().to_string());
     Ok(project_path.to_string_lossy().to_string())
@@ -193,14 +228,25 @@ pub fn update_camera_preview_state(
         .map_err(|e| e.to_string())
 }
 
+// `list_recasts`/`list_exports` are async + spawn_blocking: the scan does a
+// `read_dir` plus a `metadata()` stat per file, which adds up to hundreds of ms
+// on a library with many recordings — and on macOS/Linux a sync command runs on
+// the UI thread. Resolve the dir up front (cheap config read), then scan off the
+// main thread.
 #[tauri::command]
-pub fn list_recasts(state: State<'_, AppState>) -> Result<Vec<RecordingEntry>, String> {
-    list_files_by_ext(&recasts_dir(&state), &["recast"])
+pub async fn list_recasts(state: State<'_, AppState>) -> Result<Vec<RecordingEntry>, String> {
+    let dir = recasts_dir(&state);
+    tauri::async_runtime::spawn_blocking(move || list_files_by_ext(&dir, &["recast"]))
+        .await
+        .map_err(|e| format!("list_recasts join error: {e}"))?
 }
 
 #[tauri::command]
-pub fn list_exports(state: State<'_, AppState>) -> Result<Vec<RecordingEntry>, String> {
-    list_files_by_ext(&exports_dir(&state), &["mp4", "webm", "gif"])
+pub async fn list_exports(state: State<'_, AppState>) -> Result<Vec<RecordingEntry>, String> {
+    let dir = exports_dir(&state);
+    tauri::async_runtime::spawn_blocking(move || list_files_by_ext(&dir, &["mp4", "webm", "gif"]))
+        .await
+        .map_err(|e| format!("list_exports join error: {e}"))?
 }
 
 /// One pass over `dir`, collecting any file whose extension is in `exts`.
@@ -238,4 +284,34 @@ fn list_files_by_ext(dir: &PathBuf, exts: &[&str]) -> Result<Vec<RecordingEntry>
     }
     entries.sort_by(|a, b| b.created.cmp(&a.created));
     Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression guard for the macOS "app freezes after recording completes"
+    /// bug. `stop_recording` MUST stay `async` so its blocking body — joining
+    /// the capture/encoder threads, the camera-trim FFmpeg re-encode (30s+ on a
+    /// slow CPU), and zipping the `.recast` to disk — runs on a `spawn_blocking`
+    /// worker rather than Tauri's main thread. macOS renders the WebView on that
+    /// same main thread, so a *synchronous* `stop_recording` froze the entire
+    /// window until the work finished (Windows' out-of-process WebView2 kept
+    /// painting, which is why the hang was macOS-only).
+    ///
+    /// The closures below are type-checked but never executed (no real `State`
+    /// exists in a unit test). If either command is reverted to a plain `fn`,
+    /// its call yields a `Result<..>` instead of a `Future`, `drive` rejects
+    /// it, and the crate stops compiling here.
+    ///
+    /// `start_recording` is guarded too: it enumerates monitors/windows and
+    /// spawns the capture pipeline, so it must also stay off the UI thread.
+    #[test]
+    fn recording_commands_stay_async_off_the_ui_thread() {
+        fn drive<F: std::future::Future>(_: F) {}
+        let _assert_stop = |state: State<'_, AppState>| drive(stop_recording(state));
+        let _assert_start = |state: State<'_, AppState>| {
+            drive(start_recording(String::new(), 0, None, None, state))
+        };
+    }
 }

--- a/apps/desktop/src-tauri/src/commands/system.rs
+++ b/apps/desktop/src-tauri/src/commands/system.rs
@@ -248,6 +248,13 @@ pub async fn get_displays() -> Result<Vec<DisplayInfo>, String> {
                 height: monitor.height().unwrap_or_default(),
                 is_primary: monitor.is_primary().unwrap_or_default(),
                 thumbnail: capture_monitor_thumbnail(monitor),
+                // Round to the nearest whole Hz; 0 if xcap can't report it.
+                refresh_hz: monitor
+                    .frequency()
+                    .ok()
+                    .filter(|hz| hz.is_finite() && *hz >= 1.0)
+                    .map(|hz| hz.round() as u32)
+                    .unwrap_or(0),
             })
             .collect())
     })

--- a/apps/desktop/src-tauri/src/commands/system.rs
+++ b/apps/desktop/src-tauri/src/commands/system.rs
@@ -298,8 +298,21 @@ pub struct AudioDeviceInfo {
 }
 
 /// List available audio input (microphone) devices.
+///
+/// `async` + `spawn_blocking` for the same reason as `get_camera_devices`:
+/// enumeration blocks — Linux spawns `pactl list short sources` and waits on
+/// the PulseAudio daemon; macOS spawns FFmpeg on the first (uncached) call;
+/// Windows walks the WASAPI endpoint COM API. Tauri runs sync commands on the
+/// main thread, which on macOS/Linux also renders the WebView, so a slow audio
+/// subsystem would freeze the UI. Push it onto a worker instead.
 #[tauri::command]
-pub fn get_audio_devices() -> Result<Vec<AudioDeviceInfo>, String> {
+pub async fn get_audio_devices() -> Result<Vec<AudioDeviceInfo>, String> {
+    tauri::async_runtime::spawn_blocking(get_audio_devices_blocking)
+        .await
+        .map_err(|e| format!("get_audio_devices join error: {e}"))?
+}
+
+fn get_audio_devices_blocking() -> Result<Vec<AudioDeviceInfo>, String> {
     #[cfg(windows)]
     {
         get_audio_devices_windows()
@@ -975,8 +988,19 @@ mod tests {
     }
 }
 
+// `async` + `spawn_blocking`: the Linux path runs `gdbus ... .status()`, which
+// blocks on a D-Bus round-trip (and its timeout) to the file manager. Sync
+// commands run on the macOS/Linux UI thread, so that round-trip would briefly
+// freeze the window. The Windows/macOS branches only `spawn()` (non-blocking),
+// but routing all three through a worker keeps the command uniformly off-thread.
 #[tauri::command]
-pub fn open_file_location(path: String) -> Result<(), String> {
+pub async fn open_file_location(path: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || open_file_location_blocking(path))
+        .await
+        .map_err(|e| format!("open_file_location join error: {e}"))?
+}
+
+fn open_file_location_blocking(path: String) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
         Command::new("explorer")

--- a/apps/desktop/src-tauri/src/commands/types.rs
+++ b/apps/desktop/src-tauri/src/commands/types.rs
@@ -22,6 +22,11 @@ pub struct DisplayInfo {
     pub height: u32,
     pub is_primary: bool,
     pub thumbnail: Option<String>,
+    /// Monitor refresh rate in Hz (rounded), e.g. 60 / 120 / 144. The capture
+    /// pipeline can't deliver more unique frames per second than this, so the
+    /// recording UI uses it to gate the offered frame-rate options. 0 when the
+    /// platform couldn't report it (UI then falls back to 60).
+    pub refresh_hz: u32,
 }
 
 #[derive(Serialize, Clone)]

--- a/apps/desktop/src-tauri/src/commands/types.rs
+++ b/apps/desktop/src-tauri/src/commands/types.rs
@@ -248,6 +248,12 @@ pub struct ExportRequest {
     pub render_state: RenderState,
     #[serde(default)]
     pub gif_settings: Option<GifSettings>,
+    /// Output frame rate for MP4/WebM. `None` keeps the source recording's rate
+    /// (the quality-preserving default). Only values ≤ source are offered in the
+    /// UI, so the export never duplicates frames. GIF ignores this and uses
+    /// `gif_settings.fps`.
+    #[serde(default)]
+    pub fps: Option<f64>,
 }
 
 #[derive(Clone, Copy)]
@@ -262,7 +268,12 @@ pub struct ExportProfile {
 }
 
 pub struct AppState {
-    pub recording_manager: crate::recording::RecordingManager,
+    // `Arc` so `stop_recording` can hand an owned handle to a `spawn_blocking`
+    // worker. `stop()` joins the encoder/capture threads and (with a paused
+    // camera) runs a 30s+ FFmpeg re-encode; doing that on Tauri's main thread
+    // froze the macOS WebView until it finished. All other callers reach the
+    // manager through `Deref`, so the `Arc` is transparent to them.
+    pub recording_manager: Arc<crate::recording::RecordingManager>,
     pub last_file_path: parking_lot::Mutex<Option<String>>,
     pub config: parking_lot::Mutex<AppConfig>,
     /// Per-run cancellation tokens for active exports, keyed by export session id.

--- a/apps/desktop/src-tauri/src/encoder/mod.rs
+++ b/apps/desktop/src-tauri/src/encoder/mod.rs
@@ -82,6 +82,14 @@ pub struct EncoderConfig {
     pub output_path: PathBuf,
 }
 
+/// Number of duplicate frames to emit alongside one real frame to make up
+/// for pacer drops, bounded by `cap` so a large backlog drains over several
+/// iterations rather than blocking the encode loop in one burst. The residual
+/// (anything above `cap`) is flushed after the capture loop ends.
+fn dup_count(total_drops: u64, compensated: u64, cap: u64) -> u64 {
+    total_drops.saturating_sub(compensated).min(cap)
+}
+
 fn build_video_filter(crop: Option<CaptureArea>) -> Option<String> {
     crop.map(|area| {
         format!(
@@ -218,6 +226,26 @@ pub fn spawn_encoder_loop(
             let mut frames_since_alive_check: u32 = 0;
             const ALIVE_CHECK_EVERY: u32 = 30;
 
+            // Dropped-frame compensation. The capture pacer emits exactly
+            // `fps` frames per wall-clock second; when the queue saturates
+            // (encoder slower than capture), `RecordingPipeline::push` drops
+            // the overflow. Because we declare a fixed `-framerate` to FFmpeg
+            // and feed timestamp-less rawvideo, every dropped frame would
+            // otherwise SHORTEN the output below real time — the recording
+            // plays back sped-up and drifts out of sync with the cursor track
+            // and audio (which are wall-clock-timed). To keep
+            // `encoded == captured` (1 wall-clock second == 1 second of video
+            // PTS), we re-emit a duplicate of the most recent frame once per
+            // drop. A duplicate of an unchanged frame is ~free for every
+            // encoder (a skipped / near-zero-byte P-frame), so this can't
+            // meaningfully worsen the backpressure that caused the drop.
+            let mut compensated_drops: u64 = 0;
+            let mut last_frame: Option<std::sync::Arc<[u8]>> = None;
+            // Bound the dup burst per real frame so a large backlog drains
+            // over a few iterations instead of blocking the loop at once; any
+            // residual is flushed after the loop.
+            const MAX_DUPS_PER_ITER: u64 = 120;
+
             loop {
                 if let Some(frame) = pipeline.pop() {
                     // Detect FFmpeg early exit BEFORE writing — otherwise
@@ -238,21 +266,29 @@ pub fn spawn_encoder_loop(
                     }
                     frames_since_alive_check += 1;
 
-                    if let Err(e) = stdin.write_all(&frame.data) {
-                        // Broken pipe — FFmpeg died between our liveness
-                        // check and this write. The stderr pump is already
-                        // draining, so `wait()` can't hang; surface the real
-                        // reason from the captured tail.
-                        drop(stdin);
-                        let _ = child.wait();
-                        let tail = collect_stderr_tail(&mut stderr_pump, &stderr_tail);
-                        return Err(anyhow!(
-                            "ffmpeg encoder stdin write failed ({e}). \
-                             FFmpeg likely exited mid-recording. \
-                             Last stderr output:\n{tail}"
-                        ));
+                    // Emit the real frame, then one duplicate for each pacer
+                    // drop seen since our last write (capped per iteration).
+                    let drops = stats.dropped_frames.load(Ordering::Relaxed);
+                    let dups = dup_count(drops, compensated_drops, MAX_DUPS_PER_ITER);
+                    compensated_drops += dups;
+                    for _ in 0..(1 + dups) {
+                        if let Err(e) = stdin.write_all(&frame.data) {
+                            // Broken pipe — FFmpeg died between our liveness
+                            // check and this write. The stderr pump is already
+                            // draining, so `wait()` can't hang; surface the real
+                            // reason from the captured tail.
+                            drop(stdin);
+                            let _ = child.wait();
+                            let tail = collect_stderr_tail(&mut stderr_pump, &stderr_tail);
+                            return Err(anyhow!(
+                                "ffmpeg encoder stdin write failed ({e}). \
+                                 FFmpeg likely exited mid-recording. \
+                                 Last stderr output:\n{tail}"
+                            ));
+                        }
+                        stats.encoded_frames.fetch_add(1, Ordering::Relaxed);
                     }
-                    stats.encoded_frames.fetch_add(1, Ordering::Relaxed);
+                    last_frame = Some(frame.data.clone());
                     continue;
                 }
 
@@ -261,6 +297,23 @@ pub fn spawn_encoder_loop(
                 }
 
                 thread::sleep(Duration::from_millis(2));
+            }
+
+            // Final reconciliation: flush any drops not yet compensated (e.g.
+            // a backlog that exceeded the per-iteration cap right at the end)
+            // as duplicates of the last real frame, so total encoded frames
+            // equal total captured frames and the video length matches the
+            // wall-clock recording length to the frame.
+            if let Some(last) = last_frame {
+                let drops = stats.dropped_frames.load(Ordering::Relaxed);
+                let mut remaining = drops.saturating_sub(compensated_drops);
+                while remaining > 0 {
+                    if stdin.write_all(&last).is_err() {
+                        break;
+                    }
+                    stats.encoded_frames.fetch_add(1, Ordering::Relaxed);
+                    remaining -= 1;
+                }
             }
 
             drop(stdin);
@@ -280,8 +333,56 @@ pub fn spawn_encoder_loop(
 
 #[cfg(test)]
 mod tests {
-    use super::build_video_filter;
+    use super::{build_video_filter, dup_count};
     use crate::recording::CaptureArea;
+
+    /// Simulate the encoder's emit accounting over a whole recording and
+    /// assert the load-bearing invariant: total frames written to FFmpeg
+    /// (real + compensating duplicates, including the post-loop flush) equals
+    /// the number the pacer captured — so 1 wall-clock second always maps to
+    /// 1 second of video PTS regardless of how many frames were dropped.
+    fn total_emitted(captured: u64, drops: u64, cap: u64) -> u64 {
+        assert!(drops <= captured);
+        let real_frames = captured - drops; // frames that made it through the queue
+        let mut compensated = 0u64;
+        let mut emitted = 0u64;
+        for _ in 0..real_frames {
+            // Worst case for placement: all drops are already visible by the
+            // time each real frame is written.
+            let dups = dup_count(drops, compensated, cap);
+            compensated += dups;
+            emitted += 1 + dups;
+        }
+        // Post-loop flush of any residual the per-iteration cap left behind.
+        emitted += drops.saturating_sub(compensated);
+        emitted
+    }
+
+    #[test]
+    fn no_drops_emits_exactly_captured() {
+        assert_eq!(total_emitted(600, 0, 120), 600);
+    }
+
+    #[test]
+    fn drops_are_fully_compensated_to_match_captured() {
+        // Encoded must equal captured across a spread of drop counts and a
+        // small cap that forces multi-iteration draining + a final flush.
+        for &(captured, drops) in &[(600, 50), (600, 599), (100, 1), (3600, 1200)] {
+            assert_eq!(
+                total_emitted(captured, drops, 8),
+                captured,
+                "captured={captured} drops={drops}"
+            );
+        }
+    }
+
+    #[test]
+    fn dup_count_is_bounded_by_cap_and_never_over_compensates() {
+        assert_eq!(dup_count(100, 0, 30), 30); // capped
+        assert_eq!(dup_count(100, 90, 30), 10); // only the remainder
+        assert_eq!(dup_count(100, 100, 30), 0); // fully compensated
+        assert_eq!(dup_count(5, 9, 30), 0); // never negative
+    }
 
     #[test]
     fn no_crop_yields_no_filter() {

--- a/apps/desktop/src-tauri/src/encoder/mod.rs
+++ b/apps/desktop/src-tauri/src/encoder/mod.rs
@@ -72,6 +72,75 @@ fn collect_stderr_tail(
         .unwrap_or_default()
 }
 
+/// Capture-time quality tier for the live recorder.
+///
+/// `Balanced` is the historical default and emits byte-identical encoder args
+/// (fast preset + low-latency tune, no explicit rate control), so existing
+/// recordings are unchanged. `High`/`Pristine` trade real-time encode headroom
+/// for fidelity: the quality tune plus an explicit near-visually-lossless
+/// constant-quality target.
+///
+/// Every tier stays 8-bit 4:2:0 (`yuv420p` / `nv12`). The editor previews the
+/// raw `recording.mp4` in a WebView `<video>` element whose H.264 decoder only
+/// supports up to High profile (4:2:0) — a 4:4:4 master would capture sharper
+/// text but would not play back in the editor, so it's intentionally not an
+/// option here. (A future "export-only master" could revisit 4:4:4 with a
+/// transcode-for-preview step.)
+///
+/// Falling behind real time at a heavy tier degrades gracefully: the pacer
+/// drops frames and the encoder loop re-emits duplicates (see the drop
+/// compensation above), so the worst case is motion judder, never A/V desync.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum RecordingQuality {
+    #[default]
+    Balanced,
+    High,
+    Pristine,
+}
+
+impl RecordingQuality {
+    /// Parse the frontend's string tier; anything unrecognized (incl. `None`)
+    /// falls back to `Balanced` so an old/garbled payload can never break a
+    /// recording.
+    pub fn from_label(label: Option<&str>) -> Self {
+        match label {
+            Some("high") => Self::High,
+            Some("pristine") => Self::Pristine,
+            _ => Self::Balanced,
+        }
+    }
+}
+
+/// Build the codec + rate-control args (from `-c:v` onward) for a live
+/// recording, given the probed hardware encoder and the requested quality
+/// tier. `Balanced` reproduces the exact historical args for every encoder.
+fn recording_codec_args(encoder: &str, quality: RecordingQuality) -> Vec<String> {
+    let v = |args: &[&str]| args.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+    use RecordingQuality::*;
+    match (encoder, quality) {
+        // NVIDIA NVENC — `cq` is constant-quality (lower = better, 0..51).
+        ("h264_nvenc", Balanced) => v(&["-c:v", "h264_nvenc", "-preset", "p5", "-tune", "ll", "-pix_fmt", "yuv420p"]),
+        ("h264_nvenc", High) => v(&["-c:v", "h264_nvenc", "-preset", "p6", "-tune", "hq", "-rc", "vbr", "-cq", "21", "-b:v", "0", "-pix_fmt", "yuv420p"]),
+        ("h264_nvenc", Pristine) => v(&["-c:v", "h264_nvenc", "-preset", "p7", "-tune", "hq", "-rc", "vbr", "-cq", "16", "-b:v", "0", "-pix_fmt", "yuv420p"]),
+
+        // AMD AMF — `qp_i/qp_p` mirror the NVENC cq range.
+        ("h264_amf", Balanced) => v(&["-c:v", "h264_amf", "-quality", "speed", "-usage", "lowlatency", "-pix_fmt", "yuv420p"]),
+        ("h264_amf", High) => v(&["-c:v", "h264_amf", "-quality", "balanced", "-usage", "transcoding", "-rc", "cqp", "-qp_i", "21", "-qp_p", "21", "-pix_fmt", "yuv420p"]),
+        ("h264_amf", Pristine) => v(&["-c:v", "h264_amf", "-quality", "quality", "-usage", "transcoding", "-rc", "cqp", "-qp_i", "16", "-qp_p", "16", "-pix_fmt", "yuv420p"]),
+
+        // Intel Quick Sync — `global_quality` is its constant-quality knob.
+        ("h264_qsv", Balanced) => v(&["-c:v", "h264_qsv", "-preset", "veryfast", "-pix_fmt", "nv12"]),
+        ("h264_qsv", High) => v(&["-c:v", "h264_qsv", "-preset", "medium", "-global_quality", "21", "-pix_fmt", "nv12"]),
+        ("h264_qsv", Pristine) => v(&["-c:v", "h264_qsv", "-preset", "slow", "-global_quality", "16", "-pix_fmt", "nv12"]),
+
+        // libx264 software fallback. Balanced keeps zerolatency/ultrafast so
+        // weak CPUs don't drop; higher tiers drop zerolatency and lower CRF.
+        (_, Balanced) => v(&["-c:v", "libx264", "-preset", "ultrafast", "-tune", "zerolatency", "-pix_fmt", "yuv420p"]),
+        (_, High) => v(&["-c:v", "libx264", "-preset", "veryfast", "-crf", "20", "-pix_fmt", "yuv420p"]),
+        (_, Pristine) => v(&["-c:v", "libx264", "-preset", "faster", "-crf", "16", "-pix_fmt", "yuv420p"]),
+    }
+}
+
 /// Configuration for the live recording encoder.
 #[derive(Clone, Debug)]
 pub struct EncoderConfig {
@@ -80,6 +149,9 @@ pub struct EncoderConfig {
     pub fps: u32,
     pub crop: Option<CaptureArea>,
     pub output_path: PathBuf,
+    /// Capture-time quality tier. `Default` (`Balanced`) keeps the historical
+    /// fast/low-latency encoder args unchanged.
+    pub quality: RecordingQuality,
 }
 
 /// Number of duplicate frames to emit alongside one real frame to make up
@@ -132,59 +204,13 @@ pub fn spawn_encoder_loop(
                 args.extend(["-vf".to_string(), filter]);
             }
 
-            // Per-codec quality knobs. Hardware encoders get a low-latency
-            // preset matched to live capture; libx264 stays on `ultrafast`
-            // so weak CPUs (older laptops, no GPU at all) don't drop
-            // frames during recording — quality is recovered later by the
-            // export pipeline if the user re-encodes.
-            match encoder {
-                "h264_nvenc" => {
-                    args.extend([
-                        "-c:v".to_string(),
-                        "h264_nvenc".to_string(),
-                        "-preset".to_string(),
-                        "p5".to_string(),
-                        "-tune".to_string(),
-                        "ll".to_string(),
-                        "-pix_fmt".to_string(),
-                        "yuv420p".to_string(),
-                    ]);
-                }
-                "h264_amf" => {
-                    args.extend([
-                        "-c:v".to_string(),
-                        "h264_amf".to_string(),
-                        "-quality".to_string(),
-                        "speed".to_string(),
-                        "-usage".to_string(),
-                        "lowlatency".to_string(),
-                        "-pix_fmt".to_string(),
-                        "yuv420p".to_string(),
-                    ]);
-                }
-                "h264_qsv" => {
-                    args.extend([
-                        "-c:v".to_string(),
-                        "h264_qsv".to_string(),
-                        "-preset".to_string(),
-                        "veryfast".to_string(),
-                        "-pix_fmt".to_string(),
-                        "nv12".to_string(),
-                    ]);
-                }
-                _ => {
-                    args.extend([
-                        "-c:v".to_string(),
-                        "libx264".to_string(),
-                        "-preset".to_string(),
-                        "ultrafast".to_string(),
-                        "-tune".to_string(),
-                        "zerolatency".to_string(),
-                        "-pix_fmt".to_string(),
-                        "yuv420p".to_string(),
-                    ]);
-                }
-            }
+            // Per-codec quality knobs for the requested capture tier. Hardware
+            // encoders get a low-latency preset matched to live capture on the
+            // default (`Balanced`) tier; `High`/`Pristine` raise fidelity at the
+            // cost of real-time headroom. libx264 stays on `ultrafast` for the
+            // default tier so weak CPUs (older laptops, no GPU at all) don't
+            // drop frames during recording.
+            args.extend(recording_codec_args(encoder, config.quality));
 
             args.push(config.output_path.to_string_lossy().to_string());
 
@@ -333,8 +359,72 @@ pub fn spawn_encoder_loop(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_video_filter, dup_count};
+    use super::{build_video_filter, dup_count, recording_codec_args, RecordingQuality};
     use crate::recording::CaptureArea;
+
+    #[test]
+    fn recording_quality_parses_with_safe_default() {
+        assert_eq!(RecordingQuality::from_label(Some("high")), RecordingQuality::High);
+        assert_eq!(
+            RecordingQuality::from_label(Some("pristine")),
+            RecordingQuality::Pristine
+        );
+        // Unknown / missing / default → Balanced, never an error.
+        assert_eq!(RecordingQuality::from_label(Some("balanced")), RecordingQuality::Balanced);
+        assert_eq!(RecordingQuality::from_label(Some("garbage")), RecordingQuality::Balanced);
+        assert_eq!(RecordingQuality::from_label(None), RecordingQuality::Balanced);
+    }
+
+    #[test]
+    fn balanced_tier_reproduces_historical_args_exactly() {
+        // Regression guard: the default tier must be byte-identical to the
+        // pre-quality-tier encoder args so existing recordings don't change.
+        assert_eq!(
+            recording_codec_args("h264_nvenc", RecordingQuality::Balanced),
+            ["-c:v", "h264_nvenc", "-preset", "p5", "-tune", "ll", "-pix_fmt", "yuv420p"]
+        );
+        assert_eq!(
+            recording_codec_args("h264_amf", RecordingQuality::Balanced),
+            ["-c:v", "h264_amf", "-quality", "speed", "-usage", "lowlatency", "-pix_fmt", "yuv420p"]
+        );
+        assert_eq!(
+            recording_codec_args("h264_qsv", RecordingQuality::Balanced),
+            ["-c:v", "h264_qsv", "-preset", "veryfast", "-pix_fmt", "nv12"]
+        );
+        assert_eq!(
+            recording_codec_args("libx264", RecordingQuality::Balanced),
+            ["-c:v", "libx264", "-preset", "ultrafast", "-tune", "zerolatency", "-pix_fmt", "yuv420p"]
+        );
+        // Unknown encoder string falls back to the libx264 software path.
+        assert_eq!(
+            recording_codec_args("something_else", RecordingQuality::Balanced),
+            ["-c:v", "libx264", "-preset", "ultrafast", "-tune", "zerolatency", "-pix_fmt", "yuv420p"]
+        );
+    }
+
+    #[test]
+    fn higher_tiers_stay_420_and_add_quality_rate_control() {
+        for enc in ["h264_nvenc", "h264_amf", "h264_qsv", "libx264"] {
+            for q in [RecordingQuality::High, RecordingQuality::Pristine] {
+                let args = recording_codec_args(enc, q);
+                // Never emit a 4:4:4 pixel format — the editor preview can't
+                // decode it.
+                assert!(
+                    !args.iter().any(|a| a.contains("444")),
+                    "{enc}/{q:?} must stay 4:2:0, got {args:?}"
+                );
+                // Must carry an explicit quality target (cq / qp / global_quality
+                // / crf) so it's actually higher quality than Balanced.
+                assert!(
+                    args.iter().any(|a| matches!(
+                        a.as_str(),
+                        "-cq" | "-qp_i" | "-global_quality" | "-crf"
+                    )),
+                    "{enc}/{q:?} must set an explicit quality target, got {args:?}"
+                );
+            }
+        }
+    }
 
     /// Simulate the encoder's emit accounting over a whole recording and
     /// assert the load-bearing invariant: total frames written to FFmpeg

--- a/apps/desktop/src-tauri/src/encoder/mod.rs
+++ b/apps/desktop/src-tauri/src/encoder/mod.rs
@@ -1,8 +1,8 @@
 use std::io::{Read, Write};
 use std::path::PathBuf;
-use std::process::{Child, Command, Stdio};
+use std::process::{ChildStderr, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
@@ -10,29 +10,66 @@ use anyhow::{anyhow, Context, Result};
 
 use crate::recording::{pipeline::RecordingPipeline, CaptureArea};
 
-/// Best-effort drain of FFmpeg's stderr after the process has exited.
-/// Returns up to ~4KB of the tail so the encoder error message
-/// surfaces *why* FFmpeg died (codec error, disk full, etc.) instead
-/// of the cryptic "The pipe is being closed. (os error 232)" the OS
-/// reports when we write to a dead child's stdin.
-fn drain_child_stderr(child: &mut Child) -> String {
-    let Some(mut stderr) = child.stderr.take() else {
-        return String::new();
-    };
-    let mut buf = String::new();
-    let _ = stderr.read_to_string(&mut buf);
-    // Tail-only — the trailing lines are where the actual fatal
-    // message lives; FFmpeg's startup chatter is noise.
-    if buf.len() > 4096 {
-        let cut = buf.len() - 4096;
-        // Skip to the next newline so we don't start mid-UTF8-codepoint.
-        if let Some(nl) = buf[cut..].find('\n') {
-            buf.drain(..cut + nl + 1);
-        } else {
-            buf.drain(..cut);
+/// Maximum stderr tail retained for diagnostics. The fatal line is always at
+/// the end (codec error, disk full, etc.); FFmpeg's startup chatter is noise.
+const STDERR_TAIL_LIMIT: usize = 8192;
+
+/// Continuously read FFmpeg's stderr to EOF, keeping only the last
+/// `STDERR_TAIL_LIMIT` bytes in `sink`. Runs on its own thread for the whole
+/// life of the process so the stderr pipe is *always* drained.
+///
+/// This is load-bearing, not just for diagnostics: FFmpeg writes its banner
+/// and periodic `frame=… fps=…` progress to stderr. If nobody reads it, the
+/// ~64KB OS pipe buffer fills on a long recording, FFmpeg blocks on the stderr
+/// `write()`, stops reading stdin, and the encoder thread's `stdin.write_all`
+/// below deadlocks — the capture freezes mid-recording. macOS/Linux default to
+/// smaller pipe buffers than Windows, so they hit it sooner. Draining on a side
+/// thread also means the `child.wait()` calls on the error paths can never hang
+/// waiting for a stderr-blocked process to exit.
+fn pump_stderr_tail(stderr: ChildStderr, sink: Arc<Mutex<String>>) {
+    let mut reader = std::io::BufReader::new(stderr);
+    let mut chunk = [0u8; 4096];
+    loop {
+        match reader.read(&mut chunk) {
+            Ok(0) => break, // EOF — FFmpeg closed stderr (i.e. exited).
+            Ok(n) => {
+                if let Ok(mut tail) = sink.lock() {
+                    tail.push_str(&String::from_utf8_lossy(&chunk[..n]));
+                    if tail.len() > STDERR_TAIL_LIMIT {
+                        let mut cut = tail.len() - STDERR_TAIL_LIMIT;
+                        // Prefer a newline boundary so the tail starts on a
+                        // clean line; fall back to the raw offset.
+                        if let Some(nl) = tail[cut..].find('\n') {
+                            cut += nl + 1;
+                        }
+                        // `drain` panics on a non-char boundary (lossy decoding
+                        // can leave multi-byte chars straddling chunks), so back
+                        // off to the nearest boundary first.
+                        while cut < tail.len() && !tail.is_char_boundary(cut) {
+                            cut += 1;
+                        }
+                        tail.drain(..cut);
+                    }
+                }
+            }
+            Err(_) => break,
         }
     }
-    buf.trim().to_string()
+}
+
+/// Join the stderr pump (if it was spawned) and return the retained tail.
+/// The pump exits when FFmpeg closes stderr, so the process must already have
+/// exited — or be exiting — before this is called.
+fn collect_stderr_tail(
+    pump: &mut Option<thread::JoinHandle<()>>,
+    sink: &Arc<Mutex<String>>,
+) -> String {
+    if let Some(handle) = pump.take() {
+        let _ = handle.join();
+    }
+    sink.lock()
+        .map(|t| t.trim().to_string())
+        .unwrap_or_default()
 }
 
 /// Configuration for the live recording encoder.
@@ -158,6 +195,20 @@ pub fn spawn_encoder_loop(
                 .stdin
                 .take()
                 .context("ffmpeg encoder stdin was not available")?;
+
+            // Drain stderr continuously on a side thread — see `pump_stderr_tail`
+            // for why this is required (deadlock avoidance), not just nice-to-have.
+            let stderr_tail = Arc::new(Mutex::new(String::new()));
+            let mut stderr_pump = match child.stderr.take() {
+                Some(stderr) => {
+                    let sink = stderr_tail.clone();
+                    thread::Builder::new()
+                        .name("recast-encoder-stderr".into())
+                        .spawn(move || pump_stderr_tail(stderr, sink))
+                        .ok()
+                }
+                None => None,
+            };
             let stats = pipeline.stats();
 
             // Frame counter — check FFmpeg's liveness periodically (every
@@ -178,10 +229,10 @@ pub fn spawn_encoder_loop(
                         frames_since_alive_check = 0;
                         if let Ok(Some(status)) = child.try_wait() {
                             drop(stdin);
-                            let stderr_tail = drain_child_stderr(&mut child);
+                            let tail = collect_stderr_tail(&mut stderr_pump, &stderr_tail);
                             return Err(anyhow!(
                                 "ffmpeg encoder exited unexpectedly mid-recording \
-                                 (status: {status}). Last stderr output:\n{stderr_tail}"
+                                 (status: {status}). Last stderr output:\n{tail}"
                             ));
                         }
                     }
@@ -189,15 +240,16 @@ pub fn spawn_encoder_loop(
 
                     if let Err(e) = stdin.write_all(&frame.data) {
                         // Broken pipe — FFmpeg died between our liveness
-                        // check and this write. Surface the real reason
-                        // by draining stderr.
+                        // check and this write. The stderr pump is already
+                        // draining, so `wait()` can't hang; surface the real
+                        // reason from the captured tail.
                         drop(stdin);
                         let _ = child.wait();
-                        let stderr_tail = drain_child_stderr(&mut child);
+                        let tail = collect_stderr_tail(&mut stderr_pump, &stderr_tail);
                         return Err(anyhow!(
                             "ffmpeg encoder stdin write failed ({e}). \
                              FFmpeg likely exited mid-recording. \
-                             Last stderr output:\n{stderr_tail}"
+                             Last stderr output:\n{tail}"
                         ));
                     }
                     stats.encoded_frames.fetch_add(1, Ordering::Relaxed);
@@ -213,13 +265,12 @@ pub fn spawn_encoder_loop(
 
             drop(stdin);
 
-            let output = child.wait_with_output()?;
-            if !output.status.success() {
-                return Err(anyhow!(
-                    "ffmpeg encoder failed (status: {}): {}",
-                    output.status,
-                    String::from_utf8_lossy(&output.stderr)
-                ));
+            // stdout is `Stdio::null` and stderr is drained by the pump, so a
+            // bare `wait()` is sufficient and can't deadlock.
+            let status = child.wait()?;
+            let tail = collect_stderr_tail(&mut stderr_pump, &stderr_tail);
+            if !status.success() {
+                return Err(anyhow!("ffmpeg encoder failed (status: {status}): {tail}"));
             }
 
             Ok(())

--- a/apps/desktop/src-tauri/src/encoder/mod.rs
+++ b/apps/desktop/src-tauri/src/encoder/mod.rs
@@ -119,25 +119,136 @@ fn recording_codec_args(encoder: &str, quality: RecordingQuality) -> Vec<String>
     use RecordingQuality::*;
     match (encoder, quality) {
         // NVIDIA NVENC — `cq` is constant-quality (lower = better, 0..51).
-        ("h264_nvenc", Balanced) => v(&["-c:v", "h264_nvenc", "-preset", "p5", "-tune", "ll", "-pix_fmt", "yuv420p"]),
-        ("h264_nvenc", High) => v(&["-c:v", "h264_nvenc", "-preset", "p6", "-tune", "hq", "-rc", "vbr", "-cq", "21", "-b:v", "0", "-pix_fmt", "yuv420p"]),
-        ("h264_nvenc", Pristine) => v(&["-c:v", "h264_nvenc", "-preset", "p7", "-tune", "hq", "-rc", "vbr", "-cq", "16", "-b:v", "0", "-pix_fmt", "yuv420p"]),
+        ("h264_nvenc", Balanced) => v(&[
+            "-c:v",
+            "h264_nvenc",
+            "-preset",
+            "p5",
+            "-tune",
+            "ll",
+            "-pix_fmt",
+            "yuv420p",
+        ]),
+        ("h264_nvenc", High) => v(&[
+            "-c:v",
+            "h264_nvenc",
+            "-preset",
+            "p6",
+            "-tune",
+            "hq",
+            "-rc",
+            "vbr",
+            "-cq",
+            "21",
+            "-b:v",
+            "0",
+            "-pix_fmt",
+            "yuv420p",
+        ]),
+        ("h264_nvenc", Pristine) => v(&[
+            "-c:v",
+            "h264_nvenc",
+            "-preset",
+            "p7",
+            "-tune",
+            "hq",
+            "-rc",
+            "vbr",
+            "-cq",
+            "16",
+            "-b:v",
+            "0",
+            "-pix_fmt",
+            "yuv420p",
+        ]),
 
         // AMD AMF — `qp_i/qp_p` mirror the NVENC cq range.
-        ("h264_amf", Balanced) => v(&["-c:v", "h264_amf", "-quality", "speed", "-usage", "lowlatency", "-pix_fmt", "yuv420p"]),
-        ("h264_amf", High) => v(&["-c:v", "h264_amf", "-quality", "balanced", "-usage", "transcoding", "-rc", "cqp", "-qp_i", "21", "-qp_p", "21", "-pix_fmt", "yuv420p"]),
-        ("h264_amf", Pristine) => v(&["-c:v", "h264_amf", "-quality", "quality", "-usage", "transcoding", "-rc", "cqp", "-qp_i", "16", "-qp_p", "16", "-pix_fmt", "yuv420p"]),
+        ("h264_amf", Balanced) => v(&[
+            "-c:v",
+            "h264_amf",
+            "-quality",
+            "speed",
+            "-usage",
+            "lowlatency",
+            "-pix_fmt",
+            "yuv420p",
+        ]),
+        ("h264_amf", High) => v(&[
+            "-c:v",
+            "h264_amf",
+            "-quality",
+            "balanced",
+            "-usage",
+            "transcoding",
+            "-rc",
+            "cqp",
+            "-qp_i",
+            "21",
+            "-qp_p",
+            "21",
+            "-pix_fmt",
+            "yuv420p",
+        ]),
+        ("h264_amf", Pristine) => v(&[
+            "-c:v",
+            "h264_amf",
+            "-quality",
+            "quality",
+            "-usage",
+            "transcoding",
+            "-rc",
+            "cqp",
+            "-qp_i",
+            "16",
+            "-qp_p",
+            "16",
+            "-pix_fmt",
+            "yuv420p",
+        ]),
 
         // Intel Quick Sync — `global_quality` is its constant-quality knob.
-        ("h264_qsv", Balanced) => v(&["-c:v", "h264_qsv", "-preset", "veryfast", "-pix_fmt", "nv12"]),
-        ("h264_qsv", High) => v(&["-c:v", "h264_qsv", "-preset", "medium", "-global_quality", "21", "-pix_fmt", "nv12"]),
-        ("h264_qsv", Pristine) => v(&["-c:v", "h264_qsv", "-preset", "slow", "-global_quality", "16", "-pix_fmt", "nv12"]),
+        ("h264_qsv", Balanced) => v(&[
+            "-c:v", "h264_qsv", "-preset", "veryfast", "-pix_fmt", "nv12",
+        ]),
+        ("h264_qsv", High) => v(&[
+            "-c:v",
+            "h264_qsv",
+            "-preset",
+            "medium",
+            "-global_quality",
+            "21",
+            "-pix_fmt",
+            "nv12",
+        ]),
+        ("h264_qsv", Pristine) => v(&[
+            "-c:v",
+            "h264_qsv",
+            "-preset",
+            "slow",
+            "-global_quality",
+            "16",
+            "-pix_fmt",
+            "nv12",
+        ]),
 
         // libx264 software fallback. Balanced keeps zerolatency/ultrafast so
         // weak CPUs don't drop; higher tiers drop zerolatency and lower CRF.
-        (_, Balanced) => v(&["-c:v", "libx264", "-preset", "ultrafast", "-tune", "zerolatency", "-pix_fmt", "yuv420p"]),
-        (_, High) => v(&["-c:v", "libx264", "-preset", "veryfast", "-crf", "20", "-pix_fmt", "yuv420p"]),
-        (_, Pristine) => v(&["-c:v", "libx264", "-preset", "faster", "-crf", "16", "-pix_fmt", "yuv420p"]),
+        (_, Balanced) => v(&[
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
+            "-tune",
+            "zerolatency",
+            "-pix_fmt",
+            "yuv420p",
+        ]),
+        (_, High) => v(&[
+            "-c:v", "libx264", "-preset", "veryfast", "-crf", "20", "-pix_fmt", "yuv420p",
+        ]),
+        (_, Pristine) => v(&[
+            "-c:v", "libx264", "-preset", "faster", "-crf", "16", "-pix_fmt", "yuv420p",
+        ]),
     }
 }
 
@@ -364,15 +475,27 @@ mod tests {
 
     #[test]
     fn recording_quality_parses_with_safe_default() {
-        assert_eq!(RecordingQuality::from_label(Some("high")), RecordingQuality::High);
+        assert_eq!(
+            RecordingQuality::from_label(Some("high")),
+            RecordingQuality::High
+        );
         assert_eq!(
             RecordingQuality::from_label(Some("pristine")),
             RecordingQuality::Pristine
         );
         // Unknown / missing / default → Balanced, never an error.
-        assert_eq!(RecordingQuality::from_label(Some("balanced")), RecordingQuality::Balanced);
-        assert_eq!(RecordingQuality::from_label(Some("garbage")), RecordingQuality::Balanced);
-        assert_eq!(RecordingQuality::from_label(None), RecordingQuality::Balanced);
+        assert_eq!(
+            RecordingQuality::from_label(Some("balanced")),
+            RecordingQuality::Balanced
+        );
+        assert_eq!(
+            RecordingQuality::from_label(Some("garbage")),
+            RecordingQuality::Balanced
+        );
+        assert_eq!(
+            RecordingQuality::from_label(None),
+            RecordingQuality::Balanced
+        );
     }
 
     #[test]
@@ -381,11 +504,29 @@ mod tests {
         // pre-quality-tier encoder args so existing recordings don't change.
         assert_eq!(
             recording_codec_args("h264_nvenc", RecordingQuality::Balanced),
-            ["-c:v", "h264_nvenc", "-preset", "p5", "-tune", "ll", "-pix_fmt", "yuv420p"]
+            [
+                "-c:v",
+                "h264_nvenc",
+                "-preset",
+                "p5",
+                "-tune",
+                "ll",
+                "-pix_fmt",
+                "yuv420p"
+            ]
         );
         assert_eq!(
             recording_codec_args("h264_amf", RecordingQuality::Balanced),
-            ["-c:v", "h264_amf", "-quality", "speed", "-usage", "lowlatency", "-pix_fmt", "yuv420p"]
+            [
+                "-c:v",
+                "h264_amf",
+                "-quality",
+                "speed",
+                "-usage",
+                "lowlatency",
+                "-pix_fmt",
+                "yuv420p"
+            ]
         );
         assert_eq!(
             recording_codec_args("h264_qsv", RecordingQuality::Balanced),
@@ -393,12 +534,30 @@ mod tests {
         );
         assert_eq!(
             recording_codec_args("libx264", RecordingQuality::Balanced),
-            ["-c:v", "libx264", "-preset", "ultrafast", "-tune", "zerolatency", "-pix_fmt", "yuv420p"]
+            [
+                "-c:v",
+                "libx264",
+                "-preset",
+                "ultrafast",
+                "-tune",
+                "zerolatency",
+                "-pix_fmt",
+                "yuv420p"
+            ]
         );
         // Unknown encoder string falls back to the libx264 software path.
         assert_eq!(
             recording_codec_args("something_else", RecordingQuality::Balanced),
-            ["-c:v", "libx264", "-preset", "ultrafast", "-tune", "zerolatency", "-pix_fmt", "yuv420p"]
+            [
+                "-c:v",
+                "libx264",
+                "-preset",
+                "ultrafast",
+                "-tune",
+                "zerolatency",
+                "-pix_fmt",
+                "yuv420p"
+            ]
         );
     }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -214,7 +214,7 @@ pub fn run() {
             let pending_open_file = parse_open_arg(&cold_open_file);
 
             app.manage(AppState {
-                recording_manager: RecordingManager::default(),
+                recording_manager: std::sync::Arc::new(RecordingManager::default()),
                 last_file_path: Mutex::new(None),
                 config: Mutex::new(config),
                 export_cancel: Mutex::new(HashMap::new()),

--- a/apps/desktop/src-tauri/src/project/reader.rs
+++ b/apps/desktop/src-tauri/src/project/reader.rs
@@ -88,6 +88,48 @@ fn extract_entry(archive: &mut ZipArchive<File>, name: &str, path: &Path) -> Res
     Ok(path.to_path_buf())
 }
 
+#[cfg(test)]
+mod backcompat_tests {
+    use super::*;
+
+    /// Load every real `.recast` in `$RECAST_BACKCOMPAT_DIR` through the current
+    /// `open_project` and assert it parses. This is the concrete backward-
+    /// compatibility check: pre-change recasts must still deserialize against
+    /// the present `ProjectMetadata`/`RecordingStats` structs. Skips silently
+    /// when the env var is unset so normal `cargo test` is unaffected.
+    #[test]
+    fn opens_existing_recasts_from_dir() {
+        let Some(dir) = std::env::var_os("RECAST_BACKCOMPAT_DIR") else {
+            eprintln!("RECAST_BACKCOMPAT_DIR unset — skipping backcompat check");
+            return;
+        };
+        let dir = PathBuf::from(dir);
+        let mut checked = 0usize;
+        for entry in fs::read_dir(&dir).expect("read dir") {
+            let path = entry.expect("dir entry").path();
+            if path.extension().and_then(|e| e.to_str()) != Some("recast") {
+                continue;
+            }
+            let result = open_project(&path)
+                .unwrap_or_else(|e| panic!("FAILED to open {}: {e:#}", path.display()));
+            // Sanity-check the fields the recording-fps changes touch.
+            assert!(result.metadata.video.fps >= 1, "{}", path.display());
+            assert!(result.metadata.stats.nominal_fps >= 1, "{}", path.display());
+            eprintln!(
+                "OK  {}  video.fps={} stats.nominalFps={} {}x{}",
+                path.file_name().unwrap().to_string_lossy(),
+                result.metadata.video.fps,
+                result.metadata.stats.nominal_fps,
+                result.metadata.video.width,
+                result.metadata.video.height,
+            );
+            checked += 1;
+        }
+        assert!(checked > 0, "no .recast files found in {}", dir.display());
+        eprintln!("Parsed {checked} existing recast(s) with the current schema.");
+    }
+}
+
 /// Try to extract an optional entry from the archive. Returns None if the entry doesn't exist.
 fn try_extract_entry(archive: &mut ZipArchive<File>, name: &str, path: &Path) -> Option<PathBuf> {
     let mut entry = archive.by_name(name).ok()?;

--- a/apps/desktop/src-tauri/src/recording/mod.rs
+++ b/apps/desktop/src-tauri/src/recording/mod.rs
@@ -430,6 +430,17 @@ pub struct RecordingOptions {
     /// Camera device ID / DirectShow device name (None = first available).
     #[serde(default)]
     pub camera_device_id: Option<String>,
+    /// Capture frame rate. `None` (or out of the supported 24..=240 range)
+    /// falls back to [`RECORDING_FPS`]. The pacer and encoder both run at this
+    /// rate; values above the monitor's refresh just duplicate frames, so the
+    /// UI gates the offered options by the detected display refresh.
+    #[serde(default)]
+    pub fps: Option<u32>,
+    /// Capture quality tier — `"balanced"` (default), `"high"`, or
+    /// `"pristine"`. Unknown values fall back to balanced. See
+    /// [`crate::encoder::RecordingQuality`].
+    #[serde(default)]
+    pub quality: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -457,7 +468,20 @@ impl Default for RecordingOptions {
             microphone_device_id: None,
             camera: false,
             camera_device_id: None,
+            fps: None,
+            quality: None,
         }
+    }
+}
+
+/// Clamp a requested capture frame rate to a sane range, falling back to the
+/// default when unset or out of range. The lower bound matches the lowest
+/// cinematic rate; the upper bound covers high-refresh panels (240 Hz) while
+/// rejecting absurd values that would blow the queue budget.
+fn resolve_recording_fps(requested: Option<u32>) -> u32 {
+    match requested {
+        Some(fps) if (24..=240).contains(&fps) => fps,
+        _ => RECORDING_FPS,
     }
 }
 
@@ -507,6 +531,8 @@ struct RecordingSession {
     clock: RecordingClock,
     started_at_unix_ms: u64,
     camera_overlay: CameraOverlayTracker,
+    /// Capture rate this session was started at (pacer + encoder + metadata).
+    recording_fps: u32,
 }
 
 impl RecordingManager {
@@ -607,6 +633,16 @@ impl RecordingManager {
         }
 
         std::fs::create_dir_all(&output_dir)?;
+        // Resolve the capture rate + quality tier up front. Both the pacer and
+        // the encoder must agree on `recording_fps` (the encoder declares it as
+        // `-framerate`, the pacer emits exactly that many frames/sec), and the
+        // chosen rate is persisted into the project metadata at stop().
+        let recording_fps = resolve_recording_fps(options.fps);
+        let recording_quality =
+            crate::encoder::RecordingQuality::from_label(options.quality.as_deref());
+        log::info!(
+            "recording config: {recording_fps} fps, quality={recording_quality:?}"
+        );
         let started_at_unix_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -650,7 +686,7 @@ impl RecordingManager {
             pause_flag.clone(),
             pipeline.clone(),
             started_at,
-            RECORDING_FPS,
+            recording_fps,
             first_frame_offset_us.clone(),
         )?;
 
@@ -658,9 +694,10 @@ impl RecordingManager {
             EncoderConfig {
                 width: target.source.width,
                 height: target.source.height,
-                fps: RECORDING_FPS,
+                fps: recording_fps,
                 crop: target.crop_relative_to_source(),
                 output_path: recording_path.clone(),
+                quality: recording_quality,
             },
             stop_flag.clone(),
             pipeline.clone(),
@@ -779,6 +816,7 @@ impl RecordingManager {
                 last_at_secs: Some(0.0),
                 overlay: camera_overlay,
             },
+            recording_fps,
         });
         Ok(warnings)
     }
@@ -875,6 +913,7 @@ impl RecordingManager {
         let stats = build_stats(
             &session.pipeline,
             session.clock.effective_elapsed().as_millis() as u64,
+            session.recording_fps,
         );
 
         // Persist the user's latest overlay settings (mirror, shape, corner
@@ -1031,7 +1070,7 @@ fn trim_video_pause_intervals(path: &Path, intervals: &[(u64, u64)]) -> Result<(
     Ok(())
 }
 
-fn build_stats(pipeline: &RecordingPipeline, duration_ms: u64) -> RecordingStats {
+fn build_stats(pipeline: &RecordingPipeline, duration_ms: u64, nominal_fps: u32) -> RecordingStats {
     let PipelineSnapshot {
         captured_frames,
         dropped_frames,
@@ -1043,7 +1082,7 @@ fn build_stats(pipeline: &RecordingPipeline, duration_ms: u64) -> RecordingStats
         encoded_frames,
         dropped_frames,
         duration_ms,
-        nominal_fps: 60,
+        nominal_fps,
     }
 }
 

--- a/apps/desktop/src-tauri/src/recording/mod.rs
+++ b/apps/desktop/src-tauri/src/recording/mod.rs
@@ -654,7 +654,7 @@ impl RecordingManager {
             first_frame_offset_us.clone(),
         )?;
 
-        let encoder_handle = spawn_encoder_loop(
+        let encoder_handle = match spawn_encoder_loop(
             EncoderConfig {
                 width: target.source.width,
                 height: target.source.height,
@@ -664,7 +664,17 @@ impl RecordingManager {
             },
             stop_flag.clone(),
             pipeline.clone(),
-        )?;
+        ) {
+            Ok(handle) => handle,
+            Err(e) => {
+                // Capture thread is already live; signal + join it so a failed
+                // start doesn't leave an orphaned capture loop (and its FFmpeg
+                // child) running forever.
+                stop_flag.store(true, Ordering::Release);
+                let _ = capture_handle.join();
+                return Err(e);
+            }
+        };
 
         // Cursor coordinates need to be remapped from virtual-desktop space
         // (where `GetCursorPos` returns them) to the recorded frame's
@@ -673,7 +683,7 @@ impl RecordingManager {
         // virtual-desktop (`crop.x`, `crop.y`). Without this remap, every
         // sample lives outside the [0..frame] range whenever the user
         // records a secondary monitor or a region.
-        let cursor_handle = spawn_cursor_capture(
+        let cursor_handle = match spawn_cursor_capture(
             stop_flag.clone(),
             clock.clone(),
             CursorCaptureFrame {
@@ -686,7 +696,17 @@ impl RecordingManager {
                 // line up. 1.0 on Windows/Linux (already physical) → unchanged.
                 scale: target.scale_factor,
             },
-        )?;
+        ) {
+            Ok(handle) => handle,
+            Err(e) => {
+                // Capture + encoder are already live; tear both down so a failed
+                // start doesn't orphan them.
+                stop_flag.store(true, Ordering::Release);
+                let _ = capture_handle.join();
+                let _ = encoder_handle.join();
+                return Err(e);
+            }
+        };
 
         // Start system audio capture. If it fails, log and continue.
         let audio_session = match AudioCaptureSession::start(AudioCaptureConfig {

--- a/apps/desktop/src-tauri/src/recording/mod.rs
+++ b/apps/desktop/src-tauri/src/recording/mod.rs
@@ -640,9 +640,7 @@ impl RecordingManager {
         let recording_fps = resolve_recording_fps(options.fps);
         let recording_quality =
             crate::encoder::RecordingQuality::from_label(options.quality.as_deref());
-        log::info!(
-            "recording config: {recording_fps} fps, quality={recording_quality:?}"
-        );
+        log::info!("recording config: {recording_fps} fps, quality={recording_quality:?}");
         let started_at_unix_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()

--- a/apps/desktop/src-tauri/src/recording/pipeline.rs
+++ b/apps/desktop/src-tauri/src/recording/pipeline.rs
@@ -146,7 +146,18 @@ pub fn spawn_capture_loop(
         .name("recast-capture".into())
         .spawn(move || {
             let mut source = create_capture_source(&target)?;
-            let frame_period = Duration::from_micros(1_000_000_u64 / target_fps.max(1) as u64);
+            let fps = target_fps.max(1) as u64;
+            // Exact per-tick schedule: tick `k` (counting from the pacer's
+            // current anchor) fires at `base + k/fps` seconds, computed in
+            // integer nanoseconds so the 1/fps rounding never accumulates.
+            // The previous `Duration::from_micros(1_000_000/fps)` truncated
+            // (60 fps → 16666 µs instead of 16666.67), making the pacer run
+            // ~0.004 % fast — negligible per second, but ~0.14 s of video-vs-
+            // wall-clock drift per hour of recording, enough to desync the
+            // cursor/audio on a long capture.
+            let tick_at = |base: Instant, k: u64| -> Instant {
+                base + Duration::from_nanos(k.saturating_mul(1_000_000_000) / fps)
+            };
 
             // Wait for the very first frame so the encoder isn't fed an
             // empty pipeline at t=0. DXGI returns the current desktop
@@ -174,7 +185,12 @@ pub fn spawn_capture_loop(
                 height: source.height(),
                 data: last_frame.clone(),
             });
-            let mut next_tick = Instant::now() + frame_period;
+            // Anchor the exact schedule at the warmup frame. `emitted` counts
+            // frames pushed since `pacer_base`; tick `emitted+1` is the next
+            // deadline. Both reset on resume so a paused span is excluded
+            // without being "caught up" as lag.
+            let mut pacer_base = Instant::now();
+            let mut emitted: u64 = 0;
             let mut was_paused = false;
 
             while !stop_flag.load(Ordering::Acquire) {
@@ -187,9 +203,11 @@ pub fn spawn_capture_loop(
                     continue;
                 }
                 if was_paused {
-                    // Resuming: rebase the pacer so the paused span isn't
-                    // treated as lag and "caught up" with a burst of frames.
-                    next_tick = Instant::now() + frame_period;
+                    // Resuming: restart the exact schedule from now so the
+                    // paused span isn't treated as lag and "caught up" with a
+                    // burst of frames.
+                    pacer_base = Instant::now();
+                    emitted = 0;
                     was_paused = false;
                 }
 
@@ -212,6 +230,7 @@ pub fn spawn_capture_loop(
                 }
 
                 let now = Instant::now();
+                let next_tick = tick_at(pacer_base, emitted + 1);
                 if now >= next_tick {
                     pipeline.push(VideoFrame {
                         timestamp_us: clock.elapsed().as_micros() as u64,
@@ -219,7 +238,7 @@ pub fn spawn_capture_loop(
                         height: source.height(),
                         data: last_frame.clone(),
                     });
-                    next_tick += frame_period;
+                    emitted += 1;
                     // If a system stall pushed us more than one period
                     // behind, keep emitting one frame per iteration (no
                     // sleep) until we catch up — the loop body is cheap

--- a/apps/desktop/src-tauri/src/render/graph.rs
+++ b/apps/desktop/src-tauri/src/render/graph.rs
@@ -276,6 +276,13 @@ pub fn compute_canvas_geometry(
 pub struct SourceVideoMetadata {
     pub width: u32,
     pub height: u32,
+    /// Source frame rate. The generated background source (`color=`) MUST be
+    /// pinned to this — otherwise FFmpeg defaults the generator to 25 fps and,
+    /// because the background is the BASE of the composite `overlay`, the whole
+    /// export inherits 25 fps. A 60 fps recording then gets frame-dropped to 25,
+    /// which judders every motion (most visibly under a zoom). See
+    /// `build_color_background_filter`.
+    pub fps: f64,
 }
 
 #[derive(Debug, Clone)]
@@ -482,6 +489,7 @@ impl RenderGraph {
                         canvas.comp_x,
                         canvas.comp_y,
                         shadow_input_index,
+                        source.fps,
                     )
                 }
             }
@@ -496,6 +504,7 @@ impl RenderGraph {
                 canvas.comp_x,
                 canvas.comp_y,
                 shadow_input_index,
+                source.fps,
             ),
             None => {
                 if prelude_segments.is_empty() {
@@ -545,6 +554,7 @@ fn build_color_background_filter(
     shadow_overlay_x: u32,
     shadow_overlay_y: u32,
     shadow_input_index: Option<usize>,
+    fps: f64,
 ) -> Option<String> {
     let color = match background.background_type.as_str() {
         "color" => normalize_color(&background.value),
@@ -552,9 +562,19 @@ fn build_color_background_filter(
         _ => "#111111".into(),
     };
 
+    // Pin the generator to the source frame rate. Without `:r=` FFmpeg defaults
+    // `color=` to 25 fps; since this is the BASE of the composite `overlay`, the
+    // entire export would inherit 25 fps and frame-drop a 60 fps recording into
+    // a juddery mess (very visible under a zoom). Fall back to 60 for a bogus
+    // metadata value rather than emitting an invalid rate.
+    let rate = if fps.is_finite() && fps >= 1.0 {
+        fps
+    } else {
+        60.0
+    };
     let mut segments = prelude_segments;
     segments.push(format!(
-        "color=c={color}:s={canvas_width}x{canvas_height}[bg0]"
+        "color=c={color}:s={canvas_width}x{canvas_height}:r={rate}[bg0]"
     ));
     let bg_label = compose_shadow_stage(
         &mut segments,
@@ -1054,6 +1074,7 @@ mod tests {
                 SourceVideoMetadata {
                     width: 1920,
                     height: 1080,
+                    fps: 60.0,
                 },
                 Path::new("."),
                 1,
@@ -1072,6 +1093,7 @@ mod tests {
                 SourceVideoMetadata {
                     width: 1920,
                     height: 1080,
+                    fps: 60.0,
                 },
                 Path::new("."),
                 1,
@@ -1195,6 +1217,42 @@ mod tests {
         assert!(fc.contains("gte(t,6.0000)"), "third region missing: {fc}");
     }
 
+    /// The generated `color=` background MUST carry an explicit `:r=<fps>`.
+    /// Without it FFmpeg defaults the generator to 25 fps, and since it's the
+    /// base of the composite overlay the whole export drops to 25 fps —
+    /// frame-dropping a 60 fps recording into juddery motion (the export-only
+    /// "shake", very visible under a zoom).
+    #[test]
+    fn color_background_pins_source_framerate() {
+        let state = RenderState {
+            background_type: "color".into(),
+            background_value: "#111111".into(),
+            zoom_regions: vec![region(1.0, 4.0, 1.6)],
+            ..RenderState::default()
+        };
+        let plan = RenderGraph::from_state(&state)
+            .build_export_plan_with(
+                SourceVideoMetadata {
+                    width: 1920,
+                    height: 1080,
+                    fps: 60.0,
+                },
+                Path::new("."),
+                1,
+                None,
+                None,
+                None,
+                None,
+                test_canvas(),
+            )
+            .expect("plan");
+        let fc = plan.filter_complex.expect("filter_complex");
+        assert!(
+            fc.contains("color=") && fc.contains(":r=60"),
+            "color background must pin the source fps (got: {fc})"
+        );
+    }
+
     /// A hidden region is a non-destructive mute: it must contribute NOTHING to
     /// the export filter (no scale/crop prelude when it's the only region).
     #[test]
@@ -1293,6 +1351,7 @@ mod tests {
             SourceVideoMetadata {
                 width: 1920,
                 height: 1080,
+                fps: 60.0,
             },
             0.0,
         )];
@@ -1327,6 +1386,7 @@ mod tests {
                 SourceVideoMetadata {
                     width: 1920,
                     height: 1080,
+                    fps: 60.0,
                 },
                 Path::new("."),
                 1,

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -14,6 +14,14 @@
 	--font-mono: "Geist Mono Variable", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
 		Consolas, monospace;
 
+	/* Light-mode surface contrast (desktop-only override of @recast/design):
+	   lift the content area toward white so the gray sidebar/backdrop reads as a
+	   distinct frame, and darken the hairline border so cards — translucent-white
+	   on the now-bright content — keep a crisp outline instead of washing out.
+	   Dark-mode values are restored in `.dark` below so this stays light-only. */
+	--background: oklch(0.985 0 0);
+	--border: oklch(0.91 0 0);
+
 	--sidebar: oklch(93.403% 0.00011 271.152);
 	--sidebar-foreground: oklch(0.145 0 0);
 	--sidebar-primary: oklch(0.205 0 0);
@@ -25,6 +33,11 @@
 }
 
 .dark {
+	/* Restore @recast/design's dark surfaces — the `:root` block above is
+	   light-mode tuning and must not leak into dark mode. */
+	--background: oklch(20.352% 0.00157 197.844);
+	--border: oklch(23.929% 0.00003 271.152);
+
 	--sidebar: oklch(0.24 0 0);
 	--sidebar-foreground: oklch(0.985 0 0);
 	--sidebar-primary: oklch(0.488 0.243 264.376);
@@ -121,7 +134,7 @@
 	html {
 		scroll-behavior: smooth;
 		scrollbar-width: thin;
-		scrollbar-gutter: stable;
+		scrollbar-gutter: auto;
 		@apply selection:bg-primary/15 selection:text-primary;
 	}
 
@@ -268,4 +281,19 @@ input[type="number"]:has(class) {
 ::view-transition-group(recast-sidebar),
 ::view-transition-group(recast-titlebar) {
 	animation-duration: 0.01ms;
+}
+
+/*
+ * OS-native layout: a real, full-width window titlebar sits at the very top,
+ * outside the sidebar/content shell. The shadcn sidebar container is
+ * viewport-fixed (`fixed inset-y-0 h-svh`), so shift it down below the titlebar
+ * instead of letting it span the whole viewport. Keep `--os-titlebar-h` in sync
+ * with the header's `h-10` and the provider's `top-10`.
+ */
+.os-native-shell {
+	--os-titlebar-h: 2.5rem;
+}
+.os-native-shell [data-slot="sidebar-container"] {
+	top: var(--os-titlebar-h);
+	height: calc(100svh - var(--os-titlebar-h));
 }

--- a/apps/desktop/src/components/editor/ExportDialog.svelte
+++ b/apps/desktop/src/components/editor/ExportDialog.svelte
@@ -83,6 +83,32 @@
   function setSpeed(v: ExportSpeed) {
     store.exportSpeed = v;
   }
+  function setFps(v: number | null) {
+    store.exportFps = v;
+  }
+
+  // Frame-rate options derived from the SOURCE recording. We only ever offer
+  // the source rate (default, preserves the original) plus standard lower rates
+  // — never higher, since duplicating frames adds size without smoothness. If
+  // the user's stored choice exceeds the current source (e.g. a different clip),
+  // it falls back to Original at export via the Rust-side clamp.
+  const sourceFps = $derived(Math.max(1, Math.round(store.metadata?.fps ?? 60)));
+  const fpsOptions = $derived([
+    { value: null as number | null, label: "Original", desc: `${sourceFps} fps` },
+    ...[60, 30, 24]
+      .filter((f) => f < sourceFps)
+      .map((f) => ({
+        value: f as number | null,
+        label: `${f} fps`,
+        desc: f === 24 ? "Cinematic" : "Smaller file",
+      })),
+  ]);
+  // Only worth showing when there's an actual choice (source > 24). Uses the
+  // store directly rather than `isGif` (declared further down) to avoid a
+  // use-before-declaration.
+  const showFps = $derived(
+    store.exportFormat !== "gif" && fpsOptions.length > 1,
+  );
 
   function formatTime(seconds: number) {
     if (!Number.isFinite(seconds) || seconds <= 0) return "0:00.00";
@@ -555,6 +581,60 @@
           {/each}
         </div>
       </section>
+
+      <!-- Frame rate: output fps for MP4/WebM. Defaults to Original (the source
+           rate) so exports keep the recording's smoothness; lower rates shrink
+           the file. Hidden for GIF (its own fps control) and when the source is
+           already ≤24 fps (no meaningful choice). -->
+      {#if showFps}
+        <section
+          in:fly={{ y: 8, duration: 240, delay: 185, easing: cubicOut }}
+          class="flex flex-col gap-2.5 px-5 pt-4"
+        >
+          {@render sectionLabel("Frame rate", "Original keeps the source rate.")}
+          <div
+            class={cn(
+              "grid gap-1.5",
+              fpsOptions.length === 2 ? "grid-cols-2" : "grid-cols-3",
+            )}
+          >
+            {#each fpsOptions as f, i (f.value ?? "original")}
+              {@const selected = store.exportFps === f.value}
+              <span
+                class="flex"
+                in:scale={{ start: 0.92, duration: 220, delay: 215 + i * 35, easing: cubicOut }}
+              >
+                <button
+                  type="button"
+                  onclick={() => setFps(f.value)}
+                  aria-pressed={selected}
+                  title={f.desc}
+                  class={cn(
+                    "group flex w-full flex-col items-center gap-0.5 rounded-xl border px-2 py-2 text-center transition-all duration-200",
+                    selected
+                      ? "border-primary/40 bg-primary/8 ring-1 ring-primary/25"
+                      : "border-border/40 bg-card/40 hover:-translate-y-0.5 hover:border-border/70 hover:bg-card/70 hover:shadow-craft-sm",
+                  )}
+                >
+                  <span
+                    class={cn(
+                      "text-[12.5px] font-semibold tracking-tight",
+                      selected ? "text-primary" : "text-foreground",
+                    )}
+                  >
+                    {f.label}
+                  </span>
+                  <span
+                    class="truncate text-[10px] leading-tight text-muted-foreground"
+                  >
+                    {f.desc}
+                  </span>
+                </button>
+              </span>
+            {/each}
+          </div>
+        </section>
+      {/if}
 
       <!-- Speed: encoder effort. Hidden for GIF, which uses a palette 2-pass
            and ignores these codec preset knobs entirely. -->

--- a/apps/desktop/src/components/editor/ExportDialog.svelte
+++ b/apps/desktop/src/components/editor/ExportDialog.svelte
@@ -37,9 +37,9 @@
     desc: string;
     icon: typeof Video;
   }[] = [
-    { value: "mp4", label: "MP4", desc: "H.264 · universal", icon: Video },
-    { value: "webm", label: "WebM", desc: "VP9 · web-optimized", icon: Film },
-    { value: "gif", label: "GIF", desc: "Animated · palette", icon: ImageIcon },
+    { value: "mp4", label: "MP4", desc: "Universal", icon: Video },
+    { value: "webm", label: "WebM", desc: "Web · VP9", icon: Film },
+    { value: "gif", label: "GIF", desc: "Animated", icon: ImageIcon },
   ];
 
   const qualities: { value: ExportQuality; label: string; desc: string }[] = [
@@ -138,9 +138,11 @@
     ditherModes.find((d) => d.value === store.gifSettings.dither),
   );
 
-  // Track viewport so the GIF extras render as a side panel on wide screens
-  // and fall back to an inline accordion on narrow ones. The wrapper flow
-  // dialog auto-morphs to whatever width/height this body declares.
+  // The body lays its option sections out in two columns on roomy viewports
+  // (wider, not taller) and collapses to a single stacked column when there
+  // isn't space. The flow-dialog wrapper observes the width/height this body
+  // reports and morphs its chrome to match — so we just declare the target
+  // width here; the growth is the wrapper's morph.
   let viewportWidth = $state(
     typeof window !== "undefined" ? window.innerWidth : 1280,
   );
@@ -151,18 +153,8 @@
     return () => window.removeEventListener("resize", onResize);
   });
   const isCompact = $derived(viewportWidth < 720);
-  const showSidePanel = $derived(isGif && !isCompact);
-  const showInlinePanel = $derived(isGif && isCompact);
-
-  // Explicit body width. The flow dialog observes this via ResizeObserver
-  // and morphs its chrome to match — so we don't animate the side panel's
-  // own width here; growth is the morph.
   const bodyWidth = $derived(
-    isCompact
-      ? Math.min(440, viewportWidth - 32)
-      : showSidePanel
-        ? 760
-        : 440,
+    isCompact ? Math.min(460, viewportWidth - 32) : 680,
   );
 
   function setLoop(value: "infinite" | "once" | number) {
@@ -414,6 +406,208 @@
   </div>
 {/snippet}
 
+{#snippet formatSection()}
+  <section
+    in:fly={{ y: 8, duration: 240, delay: 110, easing: cubicOut }}
+    class="flex flex-col gap-2.5"
+  >
+    {@render sectionLabel("Format", "How the file is encoded.")}
+    <div class="grid grid-cols-3 gap-1.5">
+      {#each formats as fmt, i (fmt.value)}
+        {@const selected = store.exportFormat === fmt.value}
+        {@const Icon = fmt.icon}
+        <span
+          class="flex"
+          in:scale={{ start: 0.92, duration: 220, delay: 140 + i * 35, easing: cubicOut }}
+        >
+          <button
+            type="button"
+            onclick={() => setFormat(fmt.value)}
+            aria-pressed={selected}
+            class={cn(
+              "group relative flex w-full flex-col items-start gap-1 rounded-xl border px-3 py-2.5 text-left transition-all duration-200",
+              selected
+                ? "border-primary/40 bg-primary/8 ring-1 ring-primary/25"
+                : "border-border/40 bg-card/40 hover:-translate-y-0.5 hover:border-border/70 hover:bg-card/70 hover:shadow-craft-sm",
+            )}
+          >
+            <span
+              class={cn(
+                "flex items-center gap-1.5 text-[12.5px] font-semibold tracking-tight",
+                selected ? "text-primary" : "text-foreground",
+              )}
+            >
+              <Icon class="size-3.5" />
+              {fmt.label}
+            </span>
+            <span class="text-[10.5px] leading-tight text-muted-foreground">
+              {fmt.desc}
+            </span>
+            {#if selected}
+              <span
+                class="absolute right-2 top-2"
+                in:scale={{ start: 0.5, duration: 180, easing: cubicOut }}
+              >
+                <Check class="size-3 text-primary" />
+              </span>
+            {/if}
+          </button>
+        </span>
+      {/each}
+    </div>
+  </section>
+{/snippet}
+
+{#snippet qualitySection()}
+  <section
+    in:fly={{ y: 8, duration: 240, delay: 170, easing: cubicOut }}
+    class="flex flex-col gap-2.5"
+  >
+    {@render sectionLabel("Quality", "Resolution preset for the export.")}
+    <div class="grid grid-cols-2 gap-1.5">
+      {#each qualities as q, i (q.value)}
+        {@const selected = store.exportQuality === q.value}
+        <span
+          class="flex"
+          in:scale={{ start: 0.92, duration: 220, delay: 200 + i * 35, easing: cubicOut }}
+        >
+          <button
+            type="button"
+            onclick={() => setQuality(q.value)}
+            aria-pressed={selected}
+            class={cn(
+              "group flex w-full items-center justify-between gap-2 rounded-xl border px-3 py-2.5 text-left transition-all duration-200",
+              selected
+                ? "border-primary/40 bg-primary/8 ring-1 ring-primary/25"
+                : "border-border/40 bg-card/40 hover:-translate-y-0.5 hover:border-border/70 hover:bg-card/70 hover:shadow-craft-sm",
+            )}
+          >
+            <div class="flex min-w-0 flex-col gap-0.5">
+              <span
+                class={cn(
+                  "text-[12.5px] font-semibold tracking-tight",
+                  selected ? "text-primary" : "text-foreground",
+                )}
+              >
+                {q.label}
+              </span>
+              <span
+                class="truncate text-[10.5px] leading-tight text-muted-foreground"
+              >
+                {q.desc}
+              </span>
+            </div>
+            {#if selected}
+              <Check class="size-3 shrink-0 text-primary" />
+            {/if}
+          </button>
+        </span>
+      {/each}
+    </div>
+  </section>
+{/snippet}
+
+{#snippet fpsSection()}
+  <!-- Frame rate: output fps for MP4/WebM. Defaults to Original (the source
+       rate) so exports keep the recording's smoothness; lower rates shrink
+       the file. Hidden for GIF (its own fps control) and when the source is
+       already ≤24 fps (no meaningful choice). -->
+  <section
+    in:fly={{ y: 8, duration: 240, delay: 185, easing: cubicOut }}
+    class="flex flex-col gap-2.5"
+  >
+    {@render sectionLabel("Frame rate", "Original keeps the source rate.")}
+    <div
+      class={cn(
+        "grid gap-1.5",
+        fpsOptions.length === 2 ? "grid-cols-2" : "grid-cols-3",
+      )}
+    >
+      {#each fpsOptions as f, i (f.value ?? "original")}
+        {@const selected = store.exportFps === f.value}
+        <span
+          class="flex"
+          in:scale={{ start: 0.92, duration: 220, delay: 215 + i * 35, easing: cubicOut }}
+        >
+          <button
+            type="button"
+            onclick={() => setFps(f.value)}
+            aria-pressed={selected}
+            title={f.desc}
+            class={cn(
+              "group flex w-full flex-col items-center gap-0.5 rounded-xl border px-2 py-2 text-center transition-all duration-200",
+              selected
+                ? "border-primary/40 bg-primary/8 ring-1 ring-primary/25"
+                : "border-border/40 bg-card/40 hover:-translate-y-0.5 hover:border-border/70 hover:bg-card/70 hover:shadow-craft-sm",
+            )}
+          >
+            <span
+              class={cn(
+                "text-[12.5px] font-semibold tracking-tight",
+                selected ? "text-primary" : "text-foreground",
+              )}
+            >
+              {f.label}
+            </span>
+            <span
+              class="truncate text-[10px] leading-tight text-muted-foreground"
+            >
+              {f.desc}
+            </span>
+          </button>
+        </span>
+      {/each}
+    </div>
+  </section>
+{/snippet}
+
+{#snippet speedSection()}
+  <!-- Speed: encoder effort. Hidden for GIF, which uses a palette 2-pass
+       and ignores these codec preset knobs entirely. -->
+  <section
+    in:fly={{ y: 8, duration: 240, delay: 200, easing: cubicOut }}
+    class="flex flex-col gap-2.5"
+  >
+    {@render sectionLabel("Speed", "Encoder effort — same resolution.")}
+    <div class="grid grid-cols-3 gap-1.5">
+      {#each speeds as s, i (s.value)}
+        {@const selected = store.exportSpeed === s.value}
+        <span
+          class="flex"
+          in:scale={{ start: 0.92, duration: 220, delay: 230 + i * 35, easing: cubicOut }}
+        >
+          <button
+            type="button"
+            onclick={() => setSpeed(s.value)}
+            aria-pressed={selected}
+            title={s.desc}
+            class={cn(
+              "group flex w-full flex-col items-center gap-0.5 rounded-xl border px-2 py-2 text-center transition-all duration-200",
+              selected
+                ? "border-primary/40 bg-primary/8 ring-1 ring-primary/25"
+                : "border-border/40 bg-card/40 hover:-translate-y-0.5 hover:border-border/70 hover:bg-card/70 hover:shadow-craft-sm",
+            )}
+          >
+            <span
+              class={cn(
+                "text-[12.5px] font-semibold tracking-tight",
+                selected ? "text-primary" : "text-foreground",
+              )}
+            >
+              {s.label}
+            </span>
+            <span
+              class="truncate text-[10px] leading-tight text-muted-foreground"
+            >
+              {s.desc}
+            </span>
+          </button>
+        </span>
+      {/each}
+    </div>
+  </section>
+{/snippet}
+
 <div class="flex flex-col" style="width: {bodyWidth}px;">
   <!-- Header -->
   <header
@@ -438,280 +632,89 @@
     </div>
   </header>
 
-  <div class="flex min-h-0">
-    <div
-      class="flex min-w-0 flex-col"
-      style={isCompact
-        ? "flex: 1 1 0; min-width: 0;"
-        : "width: 440px; flex: 0 0 440px;"}
-    >
-      <!-- Stat strip -->
-      <section
-        in:fly={{ y: 8, duration: 240, delay: 70, easing: cubicOut }}
-        class="flex items-stretch divide-x divide-border/40 border-b border-border/40 bg-muted/15 px-5 py-2.5"
+  <!-- Stat strip — full width across the top, above the option columns. -->
+  <section
+    in:fly={{ y: 8, duration: 240, delay: 70, easing: cubicOut }}
+    class="flex items-stretch divide-x divide-border/40 border-b border-border/40 bg-muted/15 px-5 py-2.5"
+  >
+    <div class="flex flex-1 flex-col gap-0.5 pr-4">
+      <span
+        class="text-[10px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
       >
-        <div class="flex flex-1 flex-col gap-0.5 pr-4">
-          <span
-            class="text-[10px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
-          >
-            Clip
-          </span>
-          <span class="font-mono text-[12px] tabular-nums text-foreground">
-            {formatTime(clipDuration)}
-          </span>
-        </div>
-        <div class="flex flex-1 flex-col gap-0.5 pl-4">
-          <span
-            class="text-[10px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
-          >
-            Range
-          </span>
-          <span class="font-mono text-[12px] tabular-nums text-foreground">
-            {formatTime(store.trimStart)} – {formatTime(clipEnd)}
-          </span>
-        </div>
-      </section>
-      {#if hasTrim}
-        <p
-          class="border-b border-border/40 bg-muted/10 px-5 py-1.5 text-[10.5px] text-muted-foreground"
-          in:fade={{ duration: 200, delay: 200 }}
-        >
-          Source length
-          <span class="ml-1 font-mono tabular-nums text-foreground">
-            {formatTime(sourceDuration)}
-          </span>
-        </p>
-      {/if}
-
-      <!-- Format -->
-      <section
-        in:fly={{ y: 8, duration: 240, delay: 110, easing: cubicOut }}
-        class="flex flex-col gap-2.5 px-5 pt-4"
-      >
-        {@render sectionLabel("Format", "How the file is encoded.")}
-        <div class="grid grid-cols-3 gap-1.5">
-          {#each formats as fmt, i (fmt.value)}
-            {@const selected = store.exportFormat === fmt.value}
-            {@const Icon = fmt.icon}
-            <span
-              class="flex"
-              in:scale={{ start: 0.92, duration: 220, delay: 140 + i * 35, easing: cubicOut }}
-            >
-              <button
-                type="button"
-                onclick={() => setFormat(fmt.value)}
-                aria-pressed={selected}
-                class={cn(
-                  "group relative flex w-full flex-col items-start gap-1 rounded-xl border px-3 py-2.5 text-left transition-all duration-200",
-                  selected
-                    ? "border-primary/40 bg-primary/8 ring-1 ring-primary/25"
-                    : "border-border/40 bg-card/40 hover:-translate-y-0.5 hover:border-border/70 hover:bg-card/70 hover:shadow-craft-sm",
-                )}
-              >
-                <span
-                  class={cn(
-                    "flex items-center gap-1.5 text-[12.5px] font-semibold tracking-tight",
-                    selected ? "text-primary" : "text-foreground",
-                  )}
-                >
-                  <Icon class="size-3.5" />
-                  {fmt.label}
-                </span>
-                <span class="text-[10.5px] leading-tight text-muted-foreground">
-                  {fmt.desc}
-                </span>
-                {#if selected}
-                  <span
-                    class="absolute right-2 top-2"
-                    in:scale={{ start: 0.5, duration: 180, easing: cubicOut }}
-                  >
-                    <Check class="size-3 text-primary" />
-                  </span>
-                {/if}
-              </button>
-            </span>
-          {/each}
-        </div>
-      </section>
-
-      <!-- Quality -->
-      <section
-        in:fly={{ y: 8, duration: 240, delay: 170, easing: cubicOut }}
-        class="flex flex-col gap-2.5 px-5 pt-4"
-      >
-        {@render sectionLabel("Quality", "Resolution preset for the export.")}
-        <div class="grid grid-cols-2 gap-1.5">
-          {#each qualities as q, i (q.value)}
-            {@const selected = store.exportQuality === q.value}
-            <span
-              class="flex"
-              in:scale={{ start: 0.92, duration: 220, delay: 200 + i * 35, easing: cubicOut }}
-            >
-              <button
-                type="button"
-                onclick={() => setQuality(q.value)}
-                aria-pressed={selected}
-                class={cn(
-                  "group flex w-full items-center justify-between gap-2 rounded-xl border px-3 py-2.5 text-left transition-all duration-200",
-                  selected
-                    ? "border-primary/40 bg-primary/8 ring-1 ring-primary/25"
-                    : "border-border/40 bg-card/40 hover:-translate-y-0.5 hover:border-border/70 hover:bg-card/70 hover:shadow-craft-sm",
-                )}
-              >
-                <div class="flex min-w-0 flex-col gap-0.5">
-                  <span
-                    class={cn(
-                      "text-[12.5px] font-semibold tracking-tight",
-                      selected ? "text-primary" : "text-foreground",
-                    )}
-                  >
-                    {q.label}
-                  </span>
-                  <span
-                    class="truncate text-[10.5px] leading-tight text-muted-foreground"
-                  >
-                    {q.desc}
-                  </span>
-                </div>
-                {#if selected}
-                  <Check class="size-3 shrink-0 text-primary" />
-                {/if}
-              </button>
-            </span>
-          {/each}
-        </div>
-      </section>
-
-      <!-- Frame rate: output fps for MP4/WebM. Defaults to Original (the source
-           rate) so exports keep the recording's smoothness; lower rates shrink
-           the file. Hidden for GIF (its own fps control) and when the source is
-           already ≤24 fps (no meaningful choice). -->
-      {#if showFps}
-        <section
-          in:fly={{ y: 8, duration: 240, delay: 185, easing: cubicOut }}
-          class="flex flex-col gap-2.5 px-5 pt-4"
-        >
-          {@render sectionLabel("Frame rate", "Original keeps the source rate.")}
-          <div
-            class={cn(
-              "grid gap-1.5",
-              fpsOptions.length === 2 ? "grid-cols-2" : "grid-cols-3",
-            )}
-          >
-            {#each fpsOptions as f, i (f.value ?? "original")}
-              {@const selected = store.exportFps === f.value}
-              <span
-                class="flex"
-                in:scale={{ start: 0.92, duration: 220, delay: 215 + i * 35, easing: cubicOut }}
-              >
-                <button
-                  type="button"
-                  onclick={() => setFps(f.value)}
-                  aria-pressed={selected}
-                  title={f.desc}
-                  class={cn(
-                    "group flex w-full flex-col items-center gap-0.5 rounded-xl border px-2 py-2 text-center transition-all duration-200",
-                    selected
-                      ? "border-primary/40 bg-primary/8 ring-1 ring-primary/25"
-                      : "border-border/40 bg-card/40 hover:-translate-y-0.5 hover:border-border/70 hover:bg-card/70 hover:shadow-craft-sm",
-                  )}
-                >
-                  <span
-                    class={cn(
-                      "text-[12.5px] font-semibold tracking-tight",
-                      selected ? "text-primary" : "text-foreground",
-                    )}
-                  >
-                    {f.label}
-                  </span>
-                  <span
-                    class="truncate text-[10px] leading-tight text-muted-foreground"
-                  >
-                    {f.desc}
-                  </span>
-                </button>
-              </span>
-            {/each}
-          </div>
-        </section>
-      {/if}
-
-      <!-- Speed: encoder effort. Hidden for GIF, which uses a palette 2-pass
-           and ignores these codec preset knobs entirely. -->
-      {#if !isGif}
-        <section
-          in:fly={{ y: 8, duration: 240, delay: 200, easing: cubicOut }}
-          class="flex flex-col gap-2.5 px-5 pt-4"
-        >
-          {@render sectionLabel("Speed", "Encoder effort — same resolution.")}
-          <div class="grid grid-cols-3 gap-1.5">
-            {#each speeds as s, i (s.value)}
-              {@const selected = store.exportSpeed === s.value}
-              <span
-                class="flex"
-                in:scale={{ start: 0.92, duration: 220, delay: 230 + i * 35, easing: cubicOut }}
-              >
-                <button
-                  type="button"
-                  onclick={() => setSpeed(s.value)}
-                  aria-pressed={selected}
-                  title={s.desc}
-                  class={cn(
-                    "group flex w-full flex-col items-center gap-0.5 rounded-xl border px-2 py-2 text-center transition-all duration-200",
-                    selected
-                      ? "border-primary/40 bg-primary/8 ring-1 ring-primary/25"
-                      : "border-border/40 bg-card/40 hover:-translate-y-0.5 hover:border-border/70 hover:bg-card/70 hover:shadow-craft-sm",
-                  )}
-                >
-                  <span
-                    class={cn(
-                      "text-[12.5px] font-semibold tracking-tight",
-                      selected ? "text-primary" : "text-foreground",
-                    )}
-                  >
-                    {s.label}
-                  </span>
-                  <span
-                    class="truncate text-[10px] leading-tight text-muted-foreground"
-                  >
-                    {s.desc}
-                  </span>
-                </button>
-              </span>
-            {/each}
-          </div>
-        </section>
-      {/if}
-
-      <!-- Compact fallback: GIF settings inline below Quality. -->
-      {#if showInlinePanel}
-        <section
-          in:fade={{ duration: 220, delay: 100 }}
-          class="overflow-hidden"
-        >
-          <div
-            class="mx-5 mt-4 rounded-xl border border-border/50 bg-card/60 shadow-(--shadow-craft-inset) backdrop-blur"
-          >
-            {@render gifSettingsBody()}
-          </div>
-        </section>
-      {/if}
-
-      <div class="px-5 pb-5 pt-4"></div>
+        Clip
+      </span>
+      <span class="font-mono text-[12px] tabular-nums text-foreground">
+        {formatTime(clipDuration)}
+      </span>
     </div>
-
-    <!-- Side panel: wide screens only. No width animation here — the wrapper
-         flow dialog's morph handles it as the body's measured width grows. -->
-    {#if showSidePanel}
-      <aside
-        in:fade={{ duration: 220, delay: 160 }}
-        style="width: 320px;"
-        class="flex h-full flex-col border-l border-border/40 bg-muted/10"
+    <div class="flex flex-1 flex-col gap-0.5 pl-4">
+      <span
+        class="text-[10px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
       >
-        {@render gifSettingsBody()}
-      </aside>
-    {/if}
-  </div>
+        Range
+      </span>
+      <span class="font-mono text-[12px] tabular-nums text-foreground">
+        {formatTime(store.trimStart)} – {formatTime(clipEnd)}
+      </span>
+    </div>
+  </section>
+  {#if hasTrim}
+    <p
+      class="border-b border-border/40 bg-muted/10 px-5 py-1.5 text-[10.5px] text-muted-foreground"
+      in:fade={{ duration: 200, delay: 200 }}
+    >
+      Source length
+      <span class="ml-1 font-mono tabular-nums text-foreground">
+        {formatTime(sourceDuration)}
+      </span>
+    </p>
+  {/if}
+
+  <!-- GIF settings, wrapped so it reads as one panel in either layout. -->
+  {#snippet gifSettingsCard()}
+    <div
+      class="rounded-xl border border-border/50 bg-card/50 shadow-(--shadow-craft-inset) backdrop-blur"
+    >
+      {@render gifSettingsBody()}
+    </div>
+  {/snippet}
+
+  {#if isCompact}
+    <!-- Narrow viewports: a single stacked column. -->
+    <div class="flex flex-col gap-4 px-5 py-4">
+      {@render formatSection()}
+      {@render qualitySection()}
+      {#if showFps}{@render fpsSection()}{/if}
+      {#if !isGif}{@render speedSection()}{/if}
+      {#if isGif}
+        <section in:fade={{ duration: 220, delay: 100 }}>
+          {@render gifSettingsCard()}
+        </section>
+      {/if}
+    </div>
+  {:else}
+    <!-- Roomy viewports: two columns so the dialog grows wider, not taller.
+         Left = what & resolution (Format, Quality); right = motion & effort
+         (Frame rate, Speed) — or the GIF panel, which replaces the codec
+         knobs GIF doesn't use. items-start keeps each section top-aligned so
+         the shorter column doesn't stretch its cards. -->
+    <div class="grid grid-cols-2 items-start gap-x-6 gap-y-5 px-5 py-5">
+      <div class="flex min-w-0 flex-col gap-5">
+        {@render formatSection()}
+        {@render qualitySection()}
+      </div>
+      <div class="flex min-w-0 flex-col gap-5">
+        {#if isGif}
+          <section in:fade={{ duration: 220, delay: 160 }}>
+            {@render gifSettingsCard()}
+          </section>
+        {:else}
+          {#if showFps}{@render fpsSection()}{/if}
+          {@render speedSection()}
+        {/if}
+      </div>
+    </div>
+  {/if}
 
   <!-- Footer -->
   <footer

--- a/apps/desktop/src/components/editor/properity-panel/PropertiesPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/PropertiesPanel.svelte
@@ -75,7 +75,7 @@
 </script>
 
 <aside
-  class="@container/panel flex h-full min-h-0 flex-col bg-sidebar text-[12px]"
+  class="@container/panel flex h-full min-h-0 flex-col bg-background text-[12px]"
 >
   <Tabs.Root
     value={store.activePanel}

--- a/apps/desktop/src/components/layout/app-sidebar.svelte
+++ b/apps/desktop/src/components/layout/app-sidebar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import SearchCommandMenu from "$components/layout/SearchCommandMenu.svelte";
+  import WindowControls from "$components/layout/window-controls.svelte";
   import Logo from "$components/logo.svelte";
   import { launchRecordingPanel } from "$lib/ipc";
   import {
@@ -21,8 +22,13 @@
 
   let {
     ref = $bindable(null),
+    variant = "inset",
+    showMacLights = false,
     ...restProps
-  }: ComponentProps<typeof Sidebar.Root> = $props();
+  }: ComponentProps<typeof Sidebar.Root> & {
+    /** Render macOS traffic lights at the top-left (set by the app layout). */
+    showMacLights?: boolean;
+  } = $props();
 
   // Read the parent <Sidebar.Provider> state so transitions can fire on
   // open/collapse rather than being purely CSS-driven.
@@ -51,10 +57,23 @@
   });
 </script>
 
-<Sidebar.Root bind:ref variant="floating" collapsible="icon" {...restProps}>
+<Sidebar.Root bind:ref {variant} collapsible="icon" {...restProps}>
   <Sidebar.Rail class="data-[state=collapsed]:hidden" />
 
   <Sidebar.Header class="gap-3 py-3">
+    {#if showMacLights}
+      <!-- macOS traffic lights sit at the window's top-left, inside the
+           sidebar. Draggable around the buttons so the window still moves. -->
+      <div
+        class={cn(
+          "flex h-3 items-center",
+          open ? "px-1.5" : "justify-center",
+        )}
+        data-tauri-drag-region
+      >
+        <WindowControls kind="mac" />
+      </div>
+    {/if}
     <Sidebar.MenuItem class="relative">
       <a
         href="/"

--- a/apps/desktop/src/components/layout/app-sidebar.svelte
+++ b/apps/desktop/src/components/layout/app-sidebar.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { page } from "$app/state";
   import SearchCommandMenu from "$components/layout/SearchCommandMenu.svelte";
-  import WindowControls from "$components/layout/window-controls.svelte";
   import Logo from "$components/logo.svelte";
   import { launchRecordingPanel } from "$lib/ipc";
   import {
@@ -23,12 +22,8 @@
   let {
     ref = $bindable(null),
     variant = "inset",
-    showMacLights = false,
     ...restProps
-  }: ComponentProps<typeof Sidebar.Root> & {
-    /** Render macOS traffic lights at the top-left (set by the app layout). */
-    showMacLights?: boolean;
-  } = $props();
+  }: ComponentProps<typeof Sidebar.Root> = $props();
 
   // Read the parent <Sidebar.Provider> state so transitions can fire on
   // open/collapse rather than being purely CSS-driven.
@@ -61,19 +56,6 @@
   <Sidebar.Rail class="data-[state=collapsed]:hidden" />
 
   <Sidebar.Header class="gap-3 py-3">
-    {#if showMacLights}
-      <!-- macOS traffic lights sit at the window's top-left, inside the
-           sidebar. Draggable around the buttons so the window still moves. -->
-      <div
-        class={cn(
-          "flex h-3 items-center",
-          open ? "px-1.5" : "justify-center",
-        )}
-        data-tauri-drag-region
-      >
-        <WindowControls kind="mac" />
-      </div>
-    {/if}
     <Sidebar.MenuItem class="relative">
       <a
         href="/"

--- a/apps/desktop/src/components/layout/window-controls.svelte
+++ b/apps/desktop/src/components/layout/window-controls.svelte
@@ -1,0 +1,166 @@
+<script module lang="ts">
+  // Windows/Linux control button — same look as the editor titlebar.
+  const winBtn =
+    "group inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-card hover:text-foreground";
+</script>
+
+<script lang="ts">
+  import { isTauriApp } from "$lib/runtime/tauri";
+  import { Minus, Plus, Square, X } from "@lucide/svelte";
+  import { cn } from "@recast/ui/utils";
+  import { onMount } from "svelte";
+
+  // `mac` → faux macOS traffic lights (rendered top-left, in the sidebar).
+  // `win` → minimize / maximize / close stack (rendered top-right, in the
+  // content header). The OS decision is made by the caller via `platform()`
+  // so this component just draws + wires the chosen variant.
+  let { kind, class: className }: { kind: "mac" | "win"; class?: string } =
+    $props();
+
+  let isTauri = $state(false);
+  let isMaximized = $state(false);
+
+  onMount(() => {
+    let unlisten: (() => void) | undefined;
+    void (async () => {
+      isTauri = await isTauriApp();
+      if (!isTauri) return;
+      const { getCurrentWindow } = await import("@tauri-apps/api/window");
+      const win = getCurrentWindow();
+      isMaximized = await win.isMaximized();
+      // Keep the maximize/restore glyph in sync with OS-driven resizes
+      // (snap, double-click titlebar, etc.).
+      unlisten = await win.onResized(async () => {
+        isMaximized = await win.isMaximized();
+      });
+    })();
+    return () => unlisten?.();
+  });
+
+  async function currentWindow() {
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    return getCurrentWindow();
+  }
+  async function minimize(e: MouseEvent) {
+    e.stopPropagation();
+    (await currentWindow()).minimize();
+  }
+  async function toggleMaximize(e: MouseEvent) {
+    e.stopPropagation();
+    const win = await currentWindow();
+    if (await win.isMaximized()) await win.unmaximize();
+    else await win.maximize();
+  }
+  async function close(e: MouseEvent) {
+    e.stopPropagation();
+    (await currentWindow()).close();
+  }
+</script>
+
+{#if isTauri}
+  {#if kind === "mac"}
+    <!--
+      Faux macOS traffic lights. Real system buttons would need the native
+      title bar (a Rust window-config change we deliberately skipped), so these
+      mirror the system look: standard close/minimise/zoom colours with glyphs
+      that fade in on hover of the cluster. Window-chrome mimicry is the one
+      place we use literal OS colours instead of theme tokens — by design.
+    -->
+    <div
+      class={cn("group/lights flex items-center gap-2", className)}
+      onmousedown={(e) => e.stopPropagation()}
+      role="presentation"
+    >
+      <button
+        type="button"
+        onclick={close}
+        aria-label="Close"
+        title="Close"
+        class="flex size-3 items-center justify-center rounded-full bg-[#ff5f57] ring-1 ring-inset ring-black/15"
+      >
+        <X
+          size={8}
+          strokeWidth={2.5}
+          class="text-black/55 opacity-0 transition-opacity group-hover/lights:opacity-100"
+        />
+      </button>
+      <button
+        type="button"
+        onclick={minimize}
+        aria-label="Minimize"
+        title="Minimize"
+        class="flex size-3 items-center justify-center rounded-full bg-[#febc2e] ring-1 ring-inset ring-black/15"
+      >
+        <Minus
+          size={8}
+          strokeWidth={2.5}
+          class="text-black/55 opacity-0 transition-opacity group-hover/lights:opacity-100"
+        />
+      </button>
+      <button
+        type="button"
+        onclick={toggleMaximize}
+        aria-label={isMaximized ? "Restore" : "Zoom"}
+        title={isMaximized ? "Restore" : "Zoom"}
+        class="flex size-3 items-center justify-center rounded-full bg-[#28c840] ring-1 ring-inset ring-black/15"
+      >
+        <Plus
+          size={8}
+          strokeWidth={2.5}
+          class="text-black/55 opacity-0 transition-opacity group-hover/lights:opacity-100"
+        />
+      </button>
+    </div>
+  {:else}
+    <div
+      class={cn(
+        "flex items-center gap-0.5 rounded-lg bg-muted/40 p-0.5 ring-1 ring-inset ring-border/40",
+        className
+      )}
+      onmousedown={(e) => e.stopPropagation()}
+      role="presentation"
+    >
+      <button
+        type="button"
+        onclick={minimize}
+        aria-label="Minimize"
+        title="Minimize"
+        class={winBtn}
+      >
+        <Minus size={14} />
+      </button>
+      <button
+        type="button"
+        onclick={toggleMaximize}
+        aria-label={isMaximized ? "Restore" : "Maximize"}
+        title={isMaximized ? "Restore" : "Maximize"}
+        class={winBtn}
+      >
+        {#if isMaximized}
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 13 13"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1"
+          >
+            <rect x="3" y="0.5" width="9" height="9" rx="1.5" />
+            <rect x="0.5" y="3" width="9" height="9" rx="1.5" />
+          </svg>
+        {:else}
+          <Square size={14} />
+        {/if}
+      </button>
+      <button
+        type="button"
+        onclick={close}
+        aria-label="Close"
+        title="Close"
+        class={cn(winBtn, "hover:bg-destructive/15 hover:text-destructive")}
+      >
+        <X size={16} />
+      </button>
+    </div>
+  {/if}
+{/if}

--- a/apps/desktop/src/components/logo.svelte
+++ b/apps/desktop/src/components/logo.svelte
@@ -1,21 +1,32 @@
 <script lang="ts">
-  // Logo component configuration
-  import { onMount } from "svelte";
-  import { safeStorage } from "@recast/ui/persisted-state";
-  type Theme = "light" | "dark" | "system";
-
-  let currentTheme = $state<Theme>("system");
-  onMount(() => {
-    // Read-only — mode-watcher owns this key.
-    currentTheme = safeStorage.get<Theme>("mode-watcher-mode", currentTheme);
-  });
+  // Logo mark. Colours follow the *resolved* theme via mode-watcher's `mode`
+  // rune (light/dark, "system" already resolved to the active OS theme), so it
+  // updates reactively when the user toggles the theme — the previous version
+  // read `mode-watcher-mode` from storage once on mount and never resolved
+  // "system", so it stuck on one variant in both modes.
+  import { mode } from "@recast/ui/theme";
+  import type { SVGAttributes } from "svelte/elements";
 
   let {
-    color = currentTheme === "light" ? "white" : "black",
-    fill = currentTheme === "light" ? "black" : "white",
+    color: colorProp,
+    fill: fillProp,
     size = "512",
     ...rest
+  }: SVGAttributes<SVGSVGElement> & {
+    /** Bars colour. Defaults to the theme-appropriate contrast colour. */
+    color?: string;
+    /** Disc background. Defaults to the theme-appropriate contrast colour. */
+    fill?: string;
+    size?: string | number;
   } = $props();
+
+  // `mode.current` is undefined until mode-watcher hydrates; treat that as light.
+  const isDark = $derived(mode.current === "dark");
+
+  // Light mode → black disc with white bars (reads on a light sidebar);
+  // dark mode → the inverse. Explicit props still win.
+  const fill = $derived(fillProp ?? (isDark ? "white" : "black"));
+  const color = $derived(colorProp ?? (isDark ? "black" : "white"));
 </script>
 
 <svg

--- a/apps/desktop/src/components/recast/PlayerDialog.svelte
+++ b/apps/desktop/src/components/recast/PlayerDialog.svelte
@@ -77,7 +77,14 @@
          showing). media-chrome's controller starts in `user-inactive`, so once
          the clip is playing and the pointer hasn't moved yet the whole bar is
          hidden — reads as "the player has no controls". -->
-    <RecastPlayer {src} title={entry.filename} autoplay autohide={-1} />
+    <!-- preload="auto" (not the player's "metadata" default): exports are
+         written moov-at-end, and over the Tauri asset protocol a metadata-only
+         preload has to range-fetch the tail to find the moov atom before it can
+         decode — which stalls the <video> in NETWORK_LOADING (black frame +
+         "media loading" forever) in release builds. "auto" streams the local
+         file sequentially from byte 0, exactly like the editor preview, which
+         loads the same moov-at-end recordings without issue. -->
+    <RecastPlayer {src} title={entry.filename} preload="auto" autoplay autohide={-1} />
 
     <footer
       class="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-3 text-xs text-muted-foreground"

--- a/apps/desktop/src/constants/changelog.ts
+++ b/apps/desktop/src/constants/changelog.ts
@@ -37,6 +37,17 @@ export const KIND_META: Record<
 // RELEASES:START — auto-generated, do not edit by hand
 export const RELEASES: readonly ChangelogRelease[] = [
 	{
+		version: '0.2.5',
+		date: '2026-06-09',
+		changes: [
+			{ kind: 'fixed', summary: 'Exported videos no longer open to a black screen stuck on "media loading" in the in-app player on release builds — the player now streams the file from the start instead of waiting on a tail fetch that never completed, so exports play back immediately.' },
+			{ kind: 'fixed', summary: 'macOS and Linux: the app no longer freezes after a recording finishes. Saving a recording — flushing the encoder, finalizing the file, and the camera pause-trim re-encode — ran on the UI thread and locked the whole window until it completed. It now runs off the main thread. (Windows was unaffected because it renders the UI in a separate process.)' },
+			{ kind: 'fixed', summary: 'macOS and Linux: starting a recording, listing recordings/exports, picking a microphone, and "reveal in file manager" no longer briefly freeze the window — these all moved off the UI thread for the same reason.' },
+			{ kind: 'fixed', summary: 'Long recordings could freeze mid-capture: the encoder\'s FFmpeg progress output filled an OS pipe buffer that was never drained, stalling the encoder and the recording. Its output is now drained continuously.' },
+			{ kind: 'fixed', summary: 'A recording that fails to start partway through no longer leaves orphaned capture/encoder processes running in the background.' },
+		],
+	},
+	{
 		version: '0.2.4',
 		date: '2026-06-07',
 		highlights: [

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -469,10 +469,12 @@ export function exportVideo(
 	exportId: string,
 	gifSettings?: ExportGifSettings,
 	speed: ExportSpeed = "balanced",
+	/** Output frame rate for MP4/WebM. `null`/omitted keeps the source rate. */
+	fps?: number | null,
 ): Promise<string> {
-	analytics.capture("export_started", { format, quality, speed });
+	analytics.capture("export_started", { format, quality, speed, fps: fps ?? "source" });
 	return invoke<string>("export_video", {
-		request: { exportId, inputPath, format, quality, speed, renderState, gifSettings },
+		request: { exportId, inputPath, format, quality, speed, renderState, gifSettings, fps: fps ?? null },
 	});
 }
 

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -34,6 +34,8 @@ export interface DisplayInfo {
 	height: number;
 	isPrimary: boolean;
 	thumbnail: string | null;
+	/** Monitor refresh rate in Hz (rounded); 0 if the OS couldn't report it. */
+	refreshHz: number;
 }
 
 export interface WindowInfo {
@@ -217,6 +219,10 @@ export interface RecordingOptions {
 	microphoneDeviceId?: string | null;
 	camera?: boolean;
 	cameraDeviceId?: string | null;
+	/** Capture frame rate. Omitted/out-of-range (24–240) → backend default 60. */
+	fps?: number | null;
+	/** Capture quality tier: "balanced" (default), "high", or "pristine". */
+	quality?: "balanced" | "high" | "pristine" | null;
 }
 
 export interface AudioDeviceInfo {
@@ -268,8 +274,13 @@ export function startRecording(
 	options?: RecordingOptions,
 	region?: RegionRect | null,
 ): Promise<RecordingStartResult> {
-	// No-op unless the user opted into product analytics. No PII — source kind only.
-	analytics.capture("recording_started", { source_kind: targetType });
+	// No-op unless the user opted into product analytics. No PII — source kind,
+	// capture rate, and quality tier only.
+	analytics.capture("recording_started", {
+		source_kind: targetType,
+		fps: options?.fps ?? "default",
+		quality: options?.quality ?? "balanced",
+	});
 	return invoke<RecordingStartResult>("start_recording", {
 		targetType,
 		targetId,

--- a/apps/desktop/src/lib/profiles.ts
+++ b/apps/desktop/src/lib/profiles.ts
@@ -53,6 +53,42 @@ interface RecordingProfileV1 {
 export const PROFILES_STORAGE_KEY = "recast-recording-profiles";
 export const PROFILES_ENABLED_STORAGE_KEY = "recast-profiles-enabled";
 
+// ---------- Global capture quality + frame rate ----------
+//
+// Capture rate and quality are capture-WIDE preferences (like the global
+// countdown), not per-device-combo settings, so they live outside the
+// profile records — this keeps them clear of the profile capability
+// fingerprint (`capSig`) and combination cap. Persisted globally and applied
+// to every recording regardless of which profile is active.
+
+export const RECORDING_QUALITY_STORAGE_KEY = "recast-recording-quality";
+export const RECORDING_FPS_STORAGE_KEY = "recast-recording-fps";
+
+/** Capture quality tier — mirrors the Rust `RecordingQuality` enum. */
+export type RecordingQuality = "balanced" | "high" | "pristine";
+
+/** Read the persisted capture quality tier. Defaults to "balanced" (the
+ *  historical behavior); any unrecognized value falls back to it too. */
+export function loadRecordingQuality(): RecordingQuality {
+	const v = safeStorage.get<string>(RECORDING_QUALITY_STORAGE_KEY, "balanced");
+	return v === "high" || v === "pristine" ? v : "balanced";
+}
+
+export function persistRecordingQuality(q: RecordingQuality): void {
+	safeStorage.set(RECORDING_QUALITY_STORAGE_KEY, q);
+}
+
+/** Read the persisted capture frame rate. `null` = "Auto" (backend default
+ *  60). Out-of-range values are coerced back to `null`. */
+export function loadRecordingFps(): number | null {
+	const v = safeStorage.get<number | null>(RECORDING_FPS_STORAGE_KEY, null);
+	return typeof v === "number" && v >= 24 && v <= 240 ? Math.round(v) : null;
+}
+
+export function persistRecordingFps(fps: number | null): void {
+	safeStorage.set(RECORDING_FPS_STORAGE_KEY, fps);
+}
+
 /** Sentinel slot for "use system default at recording time" — distinct from
  *  any specific device id, and distinct from "off". */
 const DEFAULT_SLOT = "default";

--- a/apps/desktop/src/lib/service-worker.ts
+++ b/apps/desktop/src/lib/service-worker.ts
@@ -15,7 +15,7 @@ const isTauri =
     (self.location.protocol.includes('tauri') ||
     self.location.hostname.includes('tauri.localhost'));
 // Create a unique cache name for this deployment
-const CACHE = `orbit.nexonauts.cache-${version}`;
+const CACHE = `recast.nexonauts.cache-${version}`;
 
 const ASSETS = [
     ...build, // the app itself

--- a/apps/desktop/src/lib/stores/editor-store.svelte.ts
+++ b/apps/desktop/src/lib/stores/editor-store.svelte.ts
@@ -873,6 +873,11 @@ export function createEditorStore() {
 	let exportFormat = $state<ExportFormat>('mp4');
 	let exportQuality = $state<ExportQuality>('hd');
 	let exportSpeed = $state<ExportSpeed>('balanced');
+	// Output frame rate for MP4/WebM. `null` = keep the source recording's rate
+	// (the quality-preserving default). A number requests a clean downsample to
+	// that rate (only ever offered ≤ source, so we never duplicate frames). GIF
+	// has its own fps control in `gifSettings`.
+	let exportFps = $state<number | null>(null);
 	let gifSettings = $state<GifSettings>({ ...DEFAULT_GIF_SETTINGS });
 	let exportProgress = $state<number | null>(null);
 	let isExporting = $state(false);
@@ -1463,6 +1468,7 @@ export function createEditorStore() {
 		};
 		exportQuality = 'hd';
 		exportSpeed = 'balanced';
+		exportFps = null;
 		undoStack = [];
 		redoStack = [];
 	}
@@ -1891,6 +1897,9 @@ export function createEditorStore() {
 
 		get exportSpeed() { return exportSpeed; },
 		set exportSpeed(v: ExportSpeed) { exportSpeed = v; },
+
+		get exportFps() { return exportFps; },
+		set exportFps(v: number | null) { exportFps = v; },
 
 		get gifSettings() { return gifSettings; },
 		set gifSettings(v: GifSettings) { gifSettings = v; },

--- a/apps/desktop/src/lib/stores/layout-mode.svelte.ts
+++ b/apps/desktop/src/lib/stores/layout-mode.svelte.ts
@@ -1,0 +1,34 @@
+import { PersistedState } from "@recast/ui/persisted-state";
+
+export type LayoutMode = "os-native" | "recast";
+
+/** Option metadata for the Settings → General segmented control. */
+export const LAYOUT_MODES: {
+  value: LayoutMode;
+  label: string;
+  hint: string;
+}[] = [
+  {
+    value: "os-native",
+    label: "OS native",
+    hint: "Window controls follow your operating system — traffic lights on the left on macOS, min / max / close on the right on Windows & Linux.",
+  },
+  {
+    value: "recast",
+    label: "Recast",
+    hint: "Recast's own unified titlebar, identical on every OS.",
+  },
+];
+
+/**
+ * App-shell chrome preference. Pure UI state (no Rust round-trip), exposed as a
+ * single shared `PersistedState` so the Settings toggle and the `(app)` shell
+ * read and react to the same reactive value within the window. Persists in
+ * localStorage and broadcasts across windows that share the origin.
+ *
+ * Default `os-native` keeps the shipped chrome; `recast` is the opt-in classic.
+ */
+export const layoutMode = new PersistedState<LayoutMode>(
+  "recast-layout-mode",
+  "os-native",
+);

--- a/apps/desktop/src/routes/(app)/+layout.svelte
+++ b/apps/desktop/src/routes/(app)/+layout.svelte
@@ -3,10 +3,14 @@
   import CornerNotifications from "$components/corner-notifications.svelte";
   import AppSidebar from "$components/layout/app-sidebar.svelte";
   import CustomTitlebar from "$components/layout/custom-titlebar.svelte";
+  import WindowControls from "$components/layout/window-controls.svelte";
   import WhatsNewDialog from "$components/whats-new-dialog.svelte";
   import { config } from "$constants/app";
+  import { layoutMode } from "$lib/stores/layout-mode.svelte";
+  import { shortcutsDialog } from "$lib/shortcuts/registry.svelte";
   import { updater } from "$lib/stores/updater.svelte";
   import { whatsNew } from "$lib/stores/whats-new.svelte";
+  import { Keyboard } from "@lucide/svelte";
   import * as Sidebar from "@recast/ui/sidebar";
   import { onMount } from "svelte";
   import { cubicOut } from "svelte/easing";
@@ -14,11 +18,30 @@
 
   let { children } = $props();
   let routeKey = $derived(page.url.pathname);
+  let section = $derived(
+    routeKey === "/" ? "Home" : routeKey.replace(/^\//, "").split("/")[0]
+  );
 
-  // On boot: surface the "What's new" corner card once per release (skip if
-  // the user already landed on the changelog page), and kick off the
-  // background update check. Both render as non-blocking bottom-right cards.
+  // Detected synchronously from the webview UA (same test the shortcuts
+  // registry uses) so there's no chrome flash on first paint; false under SSR.
+  const isMac =
+    typeof navigator !== "undefined" &&
+    /mac|iphone|ipad/i.test(navigator.platform || navigator.userAgent || "");
+
+  // Layout chrome preference (Settings → General). `os-native` adapts the
+  // window controls per-OS (macOS traffic lights top-left, min/max/close
+  // top-right elsewhere) with the inset/flush sidebar; `recast` keeps the
+  // classic unified titlebar identical on every OS.
+  let osNative = $derived(layoutMode.current === "os-native");
+  let sidebarVariant: "sidebar" | "floating" | "inset" = $derived(
+    osNative ? (isMac ? "inset" : "sidebar") : "floating"
+  );
+  let showMacLights = $derived(osNative && isMac);
+
   onMount(() => {
+    // Surface "What's new" once per release (skip if we landed on the changelog
+    // already) and kick off the background update check — both non-blocking
+    // bottom-right cards.
     if (page.url.pathname.startsWith("/whats-new")) {
       whatsNew.markSeen();
     } else {
@@ -28,47 +51,105 @@
   });
 </script>
 
-<Sidebar.Provider class="h-full min-h-full fixed inset-0">
-  <AppSidebar />
-  <Sidebar.Inset class="@container/layout">
-    <CustomTitlebar class="items-center gap-1 px-3">
-      <div
-        class="flex h-full items-center gap-2 font-sans"
-        data-tauri-drag-region
+<Sidebar.Provider class="fixed inset-0 h-full min-h-full">
+  <AppSidebar variant={sidebarVariant} {showMacLights} />
+  <Sidebar.Inset
+    class={["@container/layout", osNative && "overflow-hidden"]}
+  >
+    {#if osNative}
+      <!--
+        OS-native chrome. Left: sidebar trigger + breadcrumb, doubling as the
+        drag region. Right: keyboard-shortcuts button, then (Windows/Linux only)
+        the window controls — on macOS they live in the sidebar (top-left).
+      -->
+      <header
+        data-recast-titlebar
+        class="flex h-10 shrink-0 select-none items-center gap-1 border-b border-border/60 px-3"
       >
         <div
-          in:fade={{ duration: 180, delay: 100, easing: cubicOut }}
-          out:fade={{ duration: 140, easing: cubicOut }}
+          class="flex h-full flex-1 items-center gap-2 font-sans"
+          data-tauri-drag-region
         >
           <Sidebar.Trigger
             class="size-7 rounded-md text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"
             title="Pin / unpin sidebar (⌘B)"
           />
+          <span
+            class="pointer-events-none select-none text-[13px] font-semibold tracking-tight text-foreground/80"
+            data-tauri-drag-region
+          >
+            {config.appName}
+          </span>
+          <span
+            class="pointer-events-none select-none text-[11px] font-medium text-muted-foreground/60"
+            data-tauri-drag-region
+          >
+            ·
+          </span>
+          <span
+            class="pointer-events-none select-none truncate text-[11px] font-medium capitalize text-muted-foreground/80"
+            data-tauri-drag-region
+          >
+            {section}
+          </span>
+          <div class="h-full flex-1" data-tauri-drag-region></div>
         </div>
-        <span
-          class="pointer-events-none select-none text-[13px] font-semibold tracking-tight text-foreground/80"
+
+        <button
+          type="button"
+          onclick={() => shortcutsDialog.show()}
+          onmousedown={(e) => e.stopPropagation()}
+          aria-label="Keyboard shortcuts"
+          title="Keyboard shortcuts (Ctrl + /)"
+          class="group inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-card hover:text-foreground"
+        >
+          <Keyboard size={15} />
+        </button>
+
+        {#if !isMac}
+          <WindowControls kind="win" class="shrink-0" />
+        {/if}
+      </header>
+    {:else}
+      <!-- Recast classic: one unified titlebar, identical on every OS. -->
+      <CustomTitlebar class="items-center gap-1 px-3">
+        <div
+          class="flex h-full items-center gap-2 font-sans"
           data-tauri-drag-region
         >
-          {config.appName}
-        </span>
-        <span
-          class="pointer-events-none select-none text-[11px] font-medium text-muted-foreground/60"
-          data-tauri-drag-region
-        >
-          ·
-        </span>
-        <span
-          class="pointer-events-none select-none truncate capitalize text-[11px] font-medium text-muted-foreground/80"
-          data-tauri-drag-region
-        >
-          {routeKey === "/"
-            ? "Home"
-            : routeKey.replace(/^\//, "").split("/")[0]}
-        </span>
-      </div>
-      <div class="h-full flex-1" data-tauri-drag-region></div>
-    </CustomTitlebar>
-    <main class="flex-1 overflow-hidden no-scrollbar">
+          <div
+            in:fade={{ duration: 180, delay: 100, easing: cubicOut }}
+            out:fade={{ duration: 140, easing: cubicOut }}
+          >
+            <Sidebar.Trigger
+              class="size-7 rounded-md text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"
+              title="Pin / unpin sidebar (⌘B)"
+            />
+          </div>
+          <span
+            class="pointer-events-none select-none text-[13px] font-semibold tracking-tight text-foreground/80"
+            data-tauri-drag-region
+          >
+            {config.appName}
+          </span>
+          <span
+            class="pointer-events-none select-none text-[11px] font-medium text-muted-foreground/60"
+            data-tauri-drag-region
+          >
+            ·
+          </span>
+          <span
+            class="pointer-events-none select-none truncate text-[11px] font-medium capitalize text-muted-foreground/80"
+            data-tauri-drag-region
+          >
+            {section}
+          </span>
+        </div>
+        <div class="h-full flex-1" data-tauri-drag-region></div>
+      </CustomTitlebar>
+    {/if}
+
+    <main class="no-scrollbar flex-1 overflow-hidden">
       <div class="h-full">
         {@render children()}
       </div>

--- a/apps/desktop/src/routes/(app)/+layout.svelte
+++ b/apps/desktop/src/routes/(app)/+layout.svelte
@@ -6,8 +6,8 @@
   import WindowControls from "$components/layout/window-controls.svelte";
   import WhatsNewDialog from "$components/whats-new-dialog.svelte";
   import { config } from "$constants/app";
-  import { layoutMode } from "$lib/stores/layout-mode.svelte";
   import { shortcutsDialog } from "$lib/shortcuts/registry.svelte";
+  import { layoutMode } from "$lib/stores/layout-mode.svelte";
   import { updater } from "$lib/stores/updater.svelte";
   import { whatsNew } from "$lib/stores/whats-new.svelte";
   import { Keyboard } from "@lucide/svelte";
@@ -28,15 +28,12 @@
     typeof navigator !== "undefined" &&
     /mac|iphone|ipad/i.test(navigator.platform || navigator.userAgent || "");
 
-  // Layout chrome preference (Settings → General). `os-native` adapts the
-  // window controls per-OS (macOS traffic lights top-left, min/max/close
-  // top-right elsewhere) with the inset/flush sidebar; `recast` keeps the
-  // classic unified titlebar identical on every OS.
+  // The sidebar is always the inset (rounded panel) layout. Only the titlebar
+  // differs: `os-native` lifts a real, full-width window titlebar to the very
+  // top — outside the sidebar/content shell — with OS-placed controls (macOS
+  // traffic lights top-left, min/max/close top-right on Windows/Linux). `recast`
+  // keeps the unified titlebar embedded in the content header, same on every OS.
   let osNative = $derived(layoutMode.current === "os-native");
-  let sidebarVariant: "sidebar" | "floating" | "inset" = $derived(
-    osNative ? (isMac ? "inset" : "sidebar") : "floating"
-  );
-  let showMacLights = $derived(osNative && isMac);
 
   onMount(() => {
     // Surface "What's new" once per release (skip if we landed on the changelog
@@ -51,67 +48,12 @@
   });
 </script>
 
-<Sidebar.Provider class="fixed inset-0 h-full min-h-full">
-  <AppSidebar variant={sidebarVariant} {showMacLights} />
-  <Sidebar.Inset
-    class={["@container/layout", osNative && "overflow-hidden"]}
-  >
-    {#if osNative}
-      <!--
-        OS-native chrome. Left: sidebar trigger + breadcrumb, doubling as the
-        drag region. Right: keyboard-shortcuts button, then (Windows/Linux only)
-        the window controls — on macOS they live in the sidebar (top-left).
-      -->
-      <header
-        data-recast-titlebar
-        class="flex h-10 shrink-0 select-none items-center gap-1 border-b border-border/60 px-3"
-      >
-        <div
-          class="flex h-full flex-1 items-center gap-2 font-sans"
-          data-tauri-drag-region
-        >
-          <Sidebar.Trigger
-            class="size-7 rounded-md text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"
-            title="Pin / unpin sidebar (⌘B)"
-          />
-          <span
-            class="pointer-events-none select-none text-[13px] font-semibold tracking-tight text-foreground/80"
-            data-tauri-drag-region
-          >
-            {config.appName}
-          </span>
-          <span
-            class="pointer-events-none select-none text-[11px] font-medium text-muted-foreground/60"
-            data-tauri-drag-region
-          >
-            ·
-          </span>
-          <span
-            class="pointer-events-none select-none truncate text-[11px] font-medium capitalize text-muted-foreground/80"
-            data-tauri-drag-region
-          >
-            {section}
-          </span>
-          <div class="h-full flex-1" data-tauri-drag-region></div>
-        </div>
-
-        <button
-          type="button"
-          onclick={() => shortcutsDialog.show()}
-          onmousedown={(e) => e.stopPropagation()}
-          aria-label="Keyboard shortcuts"
-          title="Keyboard shortcuts (Ctrl + /)"
-          class="group inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-card hover:text-foreground"
-        >
-          <Keyboard size={15} />
-        </button>
-
-        {#if !isMac}
-          <WindowControls kind="win" class="shrink-0" />
-        {/if}
-      </header>
-    {:else}
-      <!-- Recast classic: one unified titlebar, identical on every OS. -->
+<!-- Sidebar + content. Identical in both modes; in `recast` it also carries the
+     embedded unified titlebar at the top of the content area. -->
+{#snippet shell()}
+  <AppSidebar variant="inset" />
+  <Sidebar.Inset class="@container/layout overflow-hidden md:peer-data-[variant=inset]:ml-0">
+    {#if !osNative}
       <CustomTitlebar class="items-center gap-1 px-3">
         <div
           class="flex h-full items-center gap-2 font-sans"
@@ -155,7 +97,78 @@
       </div>
     </main>
   </Sidebar.Inset>
-</Sidebar.Provider>
+{/snippet}
+
+{#if osNative}
+  <!--
+    True window titlebar: full-width, topmost. It lives *inside* the provider so
+    the sidebar trigger gets its context, but is `fixed top-0` so it still
+    renders as a real window titlebar above the shell (a fixed ancestor doesn't
+    trap a fixed child). macOS traffic lights on the left; min/max/close on the
+    right for Windows/Linux. The whole bar is a drag region; the buttons opt
+    out. The `.os-native-shell` rule in app.css offsets the viewport-fixed
+    sidebar down by the titlebar height.
+  -->
+  <Sidebar.Provider
+    class="os-native-shell fixed inset-x-0 bottom-0 top-10 min-h-0"
+  >
+    <header
+      data-recast-titlebar
+      class="bg-sidebar fixed inset-x-0 top-0 z-50 flex h-10 select-none items-center gap-1 px-3"
+    >
+    {#if isMac}
+      <WindowControls kind="mac" />
+    {/if}
+    <div
+      class="flex h-full items-center gap-2 font-sans"
+      data-tauri-drag-region
+    >
+      <Sidebar.Trigger
+        class="size-7 rounded-md text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"
+        title="Pin / unpin sidebar (⌘B)"
+      />
+      <span
+        class="pointer-events-none select-none text-[13px] font-semibold tracking-tight text-foreground/80"
+        data-tauri-drag-region
+      >
+        {config.appName}
+      </span>
+      <span
+        class="pointer-events-none select-none text-[11px] font-medium text-muted-foreground/60"
+        data-tauri-drag-region
+      >
+        ·
+      </span>
+      <span
+        class="pointer-events-none select-none truncate text-[11px] font-medium capitalize text-muted-foreground/80"
+        data-tauri-drag-region
+      >
+        {section}
+      </span>
+    </div>
+    <div class="h-full flex-1" data-tauri-drag-region></div>
+    <button
+      type="button"
+      onclick={() => shortcutsDialog.show()}
+      onmousedown={(e) => e.stopPropagation()}
+      aria-label="Keyboard shortcuts"
+      title="Keyboard shortcuts (Ctrl + /)"
+      class="group inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-card hover:text-foreground"
+    >
+      <Keyboard size={15} />
+    </button>
+    {#if !isMac}
+      <WindowControls kind="win" class="shrink-0" />
+    {/if}
+    </header>
+
+    {@render shell()}
+  </Sidebar.Provider>
+{:else}
+  <Sidebar.Provider class="fixed inset-0 h-full min-h-full">
+    {@render shell()}
+  </Sidebar.Provider>
+{/if}
 
 <WhatsNewDialog />
 <CornerNotifications />

--- a/apps/desktop/src/routes/(app)/settings/+page.svelte
+++ b/apps/desktop/src/routes/(app)/settings/+page.svelte
@@ -21,6 +21,7 @@
     Monitor,
     Moon,
     Navigation,
+    PanelsTopLeft,
     Server,
     Settings as SettingsIcon,
     Shield,
@@ -46,6 +47,11 @@
     experimentalStore,
     type ExperimentalFlag,
   } from "$lib/stores/experimental.svelte";
+  import {
+    LAYOUT_MODES,
+    layoutMode,
+    type LayoutMode,
+  } from "$lib/stores/layout-mode.svelte";
   import { profilesStore } from "$lib/stores/profiles.svelte";
   import {
     recordingCountdown,
@@ -180,6 +186,11 @@
       }
     }
   }
+
+  const layoutModeIcons: Record<LayoutMode, typeof Monitor> = {
+    "os-native": Monitor,
+    recast: PanelsTopLeft,
+  };
 
   const themes: { value: Theme; label: string; icon: typeof Sun }[] = [
     { value: "light", label: "Light", icon: Sun },
@@ -646,6 +657,60 @@
                         >
                           <Icon class="size-3.5" />
                           <span>{t.label}</span>
+                        </button>
+                      {/each}
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <!-- Layout -->
+              <section id="settings-layout" class="flex flex-col gap-3">
+                <div class="px-1">
+                  <h2
+                    class="text-[11px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
+                  >
+                    Layout
+                  </h2>
+                  <p class="mt-0.5 text-[11px] text-muted-foreground/80">
+                    How the window titlebar and controls are arranged.
+                  </p>
+                </div>
+                <div
+                  class="rounded-xl border border-border/60 bg-card/70 shadow-(--shadow-craft-inset) backdrop-blur"
+                >
+                  <div class="flex items-center justify-between gap-3 px-4 py-3">
+                    <div class="min-w-0">
+                      <div class="text-[12px] font-semibold text-foreground">
+                        Window chrome
+                      </div>
+                      <div class="text-[11px] text-muted-foreground">
+                        {LAYOUT_MODES.find((m) => m.value === layoutMode.current)
+                          ?.hint}
+                      </div>
+                    </div>
+                    <div
+                      class="flex items-center gap-1 rounded-xl bg-muted/30 p-1 ring-1 ring-inset ring-border/40"
+                      role="radiogroup"
+                      aria-label="Window chrome layout"
+                    >
+                      {#each LAYOUT_MODES as m (m.value)}
+                        {@const Icon = layoutModeIcons[m.value]}
+                        {@const active = layoutMode.current === m.value}
+                        <button
+                          type="button"
+                          role="radio"
+                          aria-checked={active}
+                          onclick={() => (layoutMode.current = m.value)}
+                          class={cn(
+                            "flex h-7 cursor-pointer items-center gap-1.5 rounded-lg px-2.5 text-[11px] font-semibold transition-all duration-200",
+                            active
+                              ? "bg-card text-foreground shadow-(--shadow-craft-inset) ring-1 ring-inset ring-border/40"
+                              : "text-muted-foreground hover:text-foreground",
+                          )}
+                        >
+                          <Icon class="size-3.5" />
+                          <span>{m.label}</span>
                         </button>
                       {/each}
                     </div>

--- a/apps/desktop/src/routes/(app)/settings/+page.svelte
+++ b/apps/desktop/src/routes/(app)/settings/+page.svelte
@@ -6,7 +6,20 @@
   import DiagnosticsPanel from "$components/settings/DiagnosticsPanel.svelte";
   import GoogleDriveConnection from "$components/settings/GoogleDriveConnection.svelte";
   import { config } from "$constants/app";
-  import { getOutputDir, setOutputDir } from "$lib/ipc";
+  import {
+    getDisplays,
+    getLastSource,
+    getOutputDir,
+    setOutputDir,
+  } from "$lib/ipc";
+  import { listen } from "@tauri-apps/api/event";
+  import {
+    loadRecordingFps,
+    loadRecordingQuality,
+    persistRecordingFps,
+    persistRecordingQuality,
+    type RecordingQuality,
+  } from "$lib/profiles";
   import {
     ArrowUpRight,
     Cloud,
@@ -73,6 +86,15 @@
   let editorWindow = $state<EditorBehavior>("navigate");
   let countdown = $state<CountdownSeconds>(3);
   let closeToTray = $state(true);
+  // Capture quality + frame rate (global recording preferences, read by the
+  // recording panel at start time via shared localStorage). `recordingFps`
+  // null = unset → backend default 60.
+  let recordingQuality = $state<RecordingQuality>("balanced");
+  let recordingFps = $state<number>(60);
+  // Highest refresh rate among attached displays — the capture pipeline can't
+  // produce more unique frames/sec than this, so we only offer fps options up
+  // to it. Defaults to 60 until displays are probed.
+  let maxRefreshHz = $state(60);
   // Land on Recording — the daily-use panel (output directory, profiles,
   // editor behavior) — rather than the leftmost General tab, matching how
   // people actually reach for these settings.
@@ -89,7 +111,93 @@
       editorWindow,
     );
     countdown = recordingCountdown.value;
+    recordingQuality = loadRecordingQuality();
+    recordingFps = loadRecordingFps() ?? 60;
+    // Gate the fps options by the refresh of the display that will actually be
+    // recorded (the last-selected source), not just the global max — so the
+    // options reflect the user's real target. Re-sync whenever they change the
+    // source in the picker window.
+    void syncMaxRefresh();
+    const unlistenSource = listen("source-selected", () => void syncMaxRefresh());
+    return () => {
+      unlistenSource.then((fn) => fn());
+    };
   });
+
+  /** Resolve the relevant display refresh: the selected monitor's rate when a
+   *  monitor is the active source, else the highest attached display (windows
+   *  /regions don't pin a single display). Best effort — falls back to 60. */
+  async function syncMaxRefresh() {
+    try {
+      const [displays, last] = await Promise.all([
+        getDisplays(),
+        getLastSource(),
+      ]);
+      const globalMax = displays.reduce(
+        (m, d) => Math.max(m, d.refreshHz || 0),
+        0,
+      );
+      let selected = 0;
+      if (last?.kind === "monitor") {
+        selected = displays.find((d) => d.id === last.id)?.refreshHz ?? 0;
+      }
+      const resolved = selected || globalMax;
+      maxRefreshHz = resolved >= 1 ? resolved : 60;
+    } catch {
+      maxRefreshHz = 60;
+    }
+  }
+
+  function updateRecordingQuality(value: RecordingQuality) {
+    recordingQuality = value;
+    persistRecordingQuality(value);
+  }
+
+  function updateRecordingFps(value: number) {
+    recordingFps = value;
+    // Persist 60 as null (the "unset/default" sentinel) so a fresh install and
+    // an explicit 60 choice behave identically downstream.
+    persistRecordingFps(value === 60 ? null : value);
+  }
+
+  // Frame-rate options gated by detected display refresh. 60 is always
+  // available; 120/144/240 appear only when a monitor can actually present
+  // them (a small tolerance covers 119.88/143.86-style reported rates).
+  const fpsOptions = $derived(
+    [60, 120, 144, 240].filter(
+      (rate) => rate === 60 || maxRefreshHz >= rate - 2,
+    ),
+  );
+
+  // What capture will actually use on the selected display: the user's desired
+  // rate capped to the highest option this display supports. The stored
+  // preference itself is never mutated, so switching back to a high-refresh
+  // display restores the higher rate.
+  const effectiveFps = $derived(
+    Math.min(recordingFps, fpsOptions[fpsOptions.length - 1] ?? 60),
+  );
+
+  const recordingQualityOptions: {
+    value: RecordingQuality;
+    label: string;
+    desc: string;
+  }[] = [
+    {
+      value: "balanced",
+      label: "Balanced",
+      desc: "Fast, low CPU/GPU load. Great default.",
+    },
+    {
+      value: "high",
+      label: "High",
+      desc: "Sharper detail. Slightly more load.",
+    },
+    {
+      value: "pristine",
+      label: "Pristine",
+      desc: "Near-lossless. Needs a strong GPU.",
+    },
+  ];
 
   function toggleProfilesEnabled() {
     const next = !profilesStore.enabled;
@@ -381,6 +489,132 @@
                           )}
                         >
                           {o.label}
+                        </button>
+                      {/each}
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <!-- Capture quality. Global recording preference read by the
+                   recording panel via shared localStorage. Higher tiers raise
+                   fidelity at the cost of real-time encode headroom; if the GPU
+                   can't keep up the result is motion judder, never desync (the
+                   pacer/encoder compensate dropped frames). -->
+              <section id="settings-capture-quality" class="flex flex-col gap-3">
+                <div class="px-1">
+                  <h2
+                    class="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
+                  >
+                    <Sparkles class="size-3 text-primary" />
+                    Capture quality
+                  </h2>
+                  <p class="mt-0.5 text-[11px] text-muted-foreground/80">
+                    How crisp the recorded master is. The editor re-encodes on
+                    export, but detail lost here can't be recovered later.
+                  </p>
+                </div>
+                <div
+                  class="rounded-xl border border-border/60 bg-card/70 shadow-(--shadow-craft-inset) backdrop-blur"
+                >
+                  <div class="flex items-center justify-between gap-3 px-4 py-3">
+                    <div class="min-w-0">
+                      <div class="text-[12px] font-semibold text-foreground">
+                        Recording quality
+                      </div>
+                      <div class="text-[11px] text-muted-foreground">
+                        {recordingQualityOptions.find(
+                          (o) => o.value === recordingQuality,
+                        )?.desc}
+                      </div>
+                    </div>
+                    <div
+                      class="flex items-center gap-1 rounded-xl bg-muted/30 p-1 ring-1 ring-inset ring-border/40"
+                      role="radiogroup"
+                      aria-label="Recording quality"
+                    >
+                      {#each recordingQualityOptions as o (o.value)}
+                        {@const active = recordingQuality === o.value}
+                        <button
+                          type="button"
+                          role="radio"
+                          aria-checked={active}
+                          onclick={() => updateRecordingQuality(o.value)}
+                          class={cn(
+                            "flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-[11px] font-semibold transition-all duration-200",
+                            active
+                              ? "bg-card text-foreground shadow-(--shadow-craft-inset) ring-1 ring-inset ring-border/40"
+                              : "text-muted-foreground hover:text-foreground",
+                          )}
+                        >
+                          {o.label}
+                        </button>
+                      {/each}
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <!-- Capture frame rate. Options are gated by detected display
+                   refresh — capturing above the monitor's refresh only
+                   duplicates frames, so we don't offer rates no display can
+                   present. 60 is always available. -->
+              <section id="settings-capture-fps" class="flex flex-col gap-3">
+                <div class="px-1">
+                  <h2
+                    class="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
+                  >
+                    <Video class="size-3 text-primary" />
+                    Frame rate
+                  </h2>
+                  <p class="mt-0.5 text-[11px] text-muted-foreground/80">
+                    {#if fpsOptions.length > 1}
+                      Higher frame rates capture smoother motion. Your display
+                      supports up to {maxRefreshHz} Hz.
+                    {:else}
+                      Smoother motion needs a higher-refresh display — yours runs
+                      at {maxRefreshHz} Hz, so 60 fps is the max useful rate.
+                    {/if}
+                  </p>
+                </div>
+                <div
+                  class="rounded-xl border border-border/60 bg-card/70 shadow-(--shadow-craft-inset) backdrop-blur"
+                >
+                  <div class="flex items-center justify-between gap-3 px-4 py-3">
+                    <div class="min-w-0">
+                      <div class="text-[12px] font-semibold text-foreground">
+                        Recording frame rate
+                      </div>
+                      <div class="text-[11px] text-muted-foreground">
+                        {#if recordingFps > effectiveFps}
+                          Set to {recordingFps} fps, but this display runs at {maxRefreshHz}
+                          Hz — capture uses {effectiveFps} fps here.
+                        {:else}
+                          {recordingFps} fps — bigger files & more encode load at
+                          higher rates.
+                        {/if}
+                      </div>
+                    </div>
+                    <div
+                      class="flex items-center gap-1 rounded-xl bg-muted/30 p-1 ring-1 ring-inset ring-border/40"
+                      role="radiogroup"
+                      aria-label="Recording frame rate"
+                    >
+                      {#each fpsOptions as rate (rate)}
+                        {@const active = effectiveFps === rate}
+                        <button
+                          type="button"
+                          role="radio"
+                          aria-checked={active}
+                          onclick={() => updateRecordingFps(rate)}
+                          class={cn(
+                            "flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-[11px] font-semibold tabular-nums transition-all duration-200",
+                            active
+                              ? "bg-card text-foreground shadow-(--shadow-craft-inset) ring-1 ring-inset ring-border/40"
+                              : "text-muted-foreground hover:text-foreground",
+                          )}
+                        >
+                          {rate}
                         </button>
                       {/each}
                     </div>

--- a/apps/desktop/src/routes/editor/[file]/+page.svelte
+++ b/apps/desktop/src/routes/editor/[file]/+page.svelte
@@ -1450,12 +1450,80 @@
   />
 {/snippet}
 
+{#snippet exportSpecStrip()}
+  {@const fmt = store.exportFormat}
+  {@const isGifFmt = fmt === "gif"}
+  {@const srcFps = Math.max(1, Math.round(store.metadata?.fps ?? 60))}
+  {@const qualityLabel = isGifFmt
+    ? store.gifSettings.quality === "low"
+      ? "Lite"
+      : store.gifSettings.quality === "high"
+        ? "Vivid"
+        : "Standard"
+    : store.exportQuality === "small"
+      ? "720p"
+      : store.exportQuality === "hd"
+        ? "1080p"
+        : store.exportQuality === "4k"
+          ? "2160p"
+          : "Source"}
+  {@const fpsLabel = isGifFmt
+    ? store.gifSettings.fps
+      ? `${store.gifSettings.fps} fps`
+      : "Auto"
+    : store.exportFps
+      ? `${store.exportFps} fps`
+      : `${srcFps} fps`}
+  <!-- Spec recap — carries the committed export settings forward from the
+       options step so every later phase (encoding, done, cancelled, failed)
+       stays anchored to "what you're exporting". Mirrors the options stat
+       strip styling for visual continuity. -->
+  <section
+    class="flex items-stretch divide-x divide-border/40 border-b border-border/40 bg-muted/15 px-5 py-2.5"
+  >
+    <div class="flex min-w-0 flex-1 flex-col gap-0.5 pr-4">
+      <span
+        class="text-[10px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
+        >Format</span
+      >
+      <span class="truncate text-[12px] font-medium tabular-nums text-foreground">
+        {fmt.toUpperCase()}
+      </span>
+    </div>
+    <div class="flex min-w-0 flex-1 flex-col gap-0.5 px-4">
+      <span
+        class="text-[10px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
+        >{isGifFmt ? "Colors" : "Quality"}</span
+      >
+      <span class="truncate text-[12px] font-medium tabular-nums text-foreground">
+        {qualityLabel}
+      </span>
+    </div>
+    <div class="flex min-w-0 flex-1 flex-col gap-0.5 px-4">
+      <span
+        class="text-[10px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
+        >Frame rate</span
+      >
+      <span class="truncate text-[12px] font-medium tabular-nums text-foreground">
+        {fpsLabel}
+      </span>
+    </div>
+    <div class="flex min-w-0 flex-1 flex-col gap-0.5 pl-4">
+      <span
+        class="text-[10px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
+        >Duration</span
+      >
+      <span class="truncate font-mono text-[12px] tabular-nums text-foreground">
+        {formatTime(getExportDuration())}
+      </span>
+    </div>
+  </section>
+{/snippet}
+
 {#snippet progress()}
   {@const isPreparing =
     prepSending !== "done" && !exportHasProgress && !exportFinalizing}
   {@const eta = exportEtaMs()}
-  {@const exportDuration = getExportDuration()}
-  {@const exportRange = getExportRangeLabel()}
   {@const ringPct = isPreparing
     ? 0
     : exportFinalizing
@@ -1463,8 +1531,10 @@
       : Math.min(100, Math.max(0, displayPct))}
   {@const RING_R = 52}
 
-  <div class="flex flex-col" style="width: 420px;">
-    <!-- Header: title + live metadata -->
+  <div class="flex flex-col" style="width: 540px;">
+    <!-- Header: phase title + reassuring status line. The encode spec moves to
+         the shared spec strip below so it reads as a continuation of the
+         options step. -->
     <header
       class="flex items-start gap-3 border-b border-border/40 px-5 py-4"
     >
@@ -1488,15 +1558,27 @@
             Encoding video
           {/if}
         </h3>
-        <p class="mt-0.5 truncate text-[11px] text-muted-foreground">
-          {store.exportFormat.toUpperCase()} · {store.exportQuality.toUpperCase()}
-          · {formatTime(exportDuration)} clip · {exportRange}
+        <p class="mt-0.5 text-[11px] text-muted-foreground">
+          {#if exportCancelling}
+            Stopping and cleaning up the partial file…
+          {:else if exportFinalizing}
+            Writing the finished file to disk…
+          {:else if isPreparing}
+            Getting frames and effects ready…
+          {:else}
+            This can take a moment — you can keep working.
+          {/if}
         </p>
       </div>
     </header>
 
-    <!-- Circular progress ring + stages -->
-    <div class="flex flex-col items-center gap-3 px-5 pt-5 pb-3">
+    {@render exportSpecStrip()}
+
+    <!-- Circular progress ring + stages, centred so the wider spec strip and
+         footer frame it consistently with the other phases. -->
+    <div
+      class="mx-auto flex w-full max-w-xs flex-col items-center gap-3 px-5 pt-5 pb-3"
+    >
       <div class="relative size-32" aria-live="polite">
         <svg
           viewBox="0 0 120 120"
@@ -1680,11 +1762,11 @@
 {/snippet}
 
 {#snippet success()}
-  <div class="flex flex-col" style="width: 500px;">
-    <!-- Header: success badge + title + file path as the secondary line.
-         Format/quality is implicit from the export the user just kicked off
-         and drops here in favor of the path the user actually needs to see. -->
-    <header class="flex items-start gap-3 px-5 py-4">
+  <div class="flex flex-col" style="width: 540px;">
+    <!-- Header: success badge + title + file path as the secondary line. The
+         encode spec is recapped in the shared strip below; the path is the
+         thing the user actually needs here, so it stays in the subtitle. -->
+    <header class="flex items-start gap-3 border-b border-border/40 px-5 py-4">
       <div
         class="flex size-10 shrink-0 items-center justify-center rounded-xl border border-success/30 bg-success/10 text-success shadow-(--shadow-craft-inset)"
       >
@@ -1707,6 +1789,8 @@
         {/if}
       </div>
     </header>
+
+    {@render exportSpecStrip()}
 
     {#if successUpload}
       <!-- Drive row: single horizontal row with leading status icon, label,
@@ -1911,7 +1995,7 @@
 {/snippet}
 
 {#snippet cancelled()}
-  <div class="flex flex-col" style="width: 420px;">
+  <div class="flex flex-col" style="width: 540px;">
     <header
       class="flex items-start gap-3 border-b border-border/40 px-5 py-4"
     >
@@ -1928,10 +2012,14 @@
           Export cancelled
         </h3>
         <p class="mt-0.5 text-[11px] text-muted-foreground">
-          No file was written.
+          Stopped before finishing — no file was written. Your settings are
+          kept, so you can pick up right where you left off.
         </p>
       </div>
     </header>
+
+    {@render exportSpecStrip()}
+
     <footer
       class="flex items-center justify-end gap-1.5 border-t border-border/40 bg-muted/30 px-3 py-2.5"
     >
@@ -1952,7 +2040,7 @@
 {/snippet}
 
 {#snippet errorPanel()}
-  <div class="flex flex-col" style="width: 500px;">
+  <div class="flex flex-col" style="width: 540px;">
     <header
       class="flex items-start gap-3 border-b border-border/40 px-5 py-4"
     >
@@ -1969,13 +2057,24 @@
           Export failed
         </h3>
         <p class="mt-0.5 text-[11px] text-muted-foreground">
-          Something went wrong while encoding.
+          Something went wrong while encoding. Your settings are kept — try
+          again, or adjust them first.
         </p>
       </div>
     </header>
+
+    {@render exportSpecStrip()}
+
+    <!-- Failure detail — the raw FFmpeg/pipeline message, scrollable so a long
+         stack never blows out the dialog height. -->
     <div
       class="max-h-40 overflow-y-auto border-b border-border/40 px-5 py-3"
     >
+      <p
+        class="mb-1.5 text-[10px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
+      >
+        Details
+      </p>
       {#if exportResult?.kind === "error"}
         <pre
           class="whitespace-pre-wrap wrap-break-word font-mono text-[10px] leading-snug text-destructive">{exportResult.message}</pre>

--- a/apps/desktop/src/routes/editor/[file]/+page.svelte
+++ b/apps/desktop/src/routes/editor/[file]/+page.svelte
@@ -40,12 +40,14 @@
   import {
     ArrowLeft,
     CheckCircle2,
+    Circle,
     ExternalLink,
     FlaskConical,
     FolderOpen,
     Cloud,
     HardDriveUpload,
     Link2,
+    LoaderCircle,
     RefreshCw,
     Share2,
     TriangleAlert,
@@ -792,6 +794,9 @@
         exportId,
         store.exportFormat === "gif" ? store.gifSettings : undefined,
         store.exportSpeed,
+        // GIF carries its own fps in gifSettings; MP4/WebM use the picker
+        // (null = keep source rate).
+        store.exportFormat === "gif" ? undefined : store.exportFps,
       );
       // Safety net: if the export-state success event was missed, fall back to
       // the Promise result. Don't overwrite if the listener already set it.
@@ -1638,16 +1643,16 @@
                         >shipping…</span
                       >
                     {:else if s.state === "running"}
-                      <span
-                        class="flex size-2.5 shrink-0 items-center justify-center"
-                      >
-                        <span
-                          class="size-1.5 animate-pulse rounded-full bg-primary"
-                        ></span>
-                      </span>
+                      <LoaderCircle
+                        size={11}
+                        class="shrink-0 animate-spin text-primary"
+                      />
                       <span class="text-foreground">{s.label}</span>
                     {:else}
-                      <span class="size-2.5 shrink-0"></span>
+                      <Circle
+                        size={11}
+                        class="shrink-0 text-muted-foreground/40"
+                      />
                       <span class="text-muted-foreground/60">{s.label}</span>
                     {/if}
                   </li>

--- a/apps/desktop/src/routes/panel/+page.svelte
+++ b/apps/desktop/src/routes/panel/+page.svelte
@@ -25,6 +25,8 @@
     type RecordingOptions,
   } from "$lib/ipc";
   import {
+    loadRecordingFps,
+    loadRecordingQuality,
     resolveCamera,
     resolveMic,
     type RecordingProfile,
@@ -81,6 +83,9 @@
     type: "monitor" | "window" | "region";
     id: number;
     label: string;
+    /** Monitor refresh rate in Hz (monitors only); caps the useful capture
+     *  fps so we never record above what the display can present. */
+    refreshHz?: number;
     region?: {
       x: number;
       y: number;
@@ -385,6 +390,20 @@
                   }
                 : undefined,
           };
+          // Restored a monitor — look up its current refresh rate (best
+          // effort, off the start path) so record-time fps clamping knows the
+          // display's ceiling without an extra probe at capture time.
+          if (selectedSource?.type === "monitor") {
+            const restoredId = selectedSource.id;
+            getDisplays()
+              .then((displays) => {
+                const hz = displays.find((d) => d.id === restoredId)?.refreshHz;
+                if (hz && selectedSource && selectedSource.id === restoredId) {
+                  selectedSource = { ...selectedSource, refreshHz: hz };
+                }
+              })
+              .catch(() => {});
+          }
           return;
         }
         return getDisplays().then((displays) => {
@@ -394,6 +413,7 @@
               type: "monitor",
               id: d.id,
               label: d.isPrimary ? "Primary Display" : `Display ${d.id}`,
+              refreshHz: d.refreshHz || undefined,
             };
           }
         });
@@ -830,6 +850,16 @@
     }
   }
 
+  /** Cap a desired capture fps to the selected monitor's refresh rate. `null`
+   *  (Auto) and non-monitor / unknown-refresh sources pass through unchanged —
+   *  the backend still clamps to its 24–240 range. */
+  function clampFpsToDisplay(desired: number | null): number | null {
+    if (desired == null) return null;
+    const cap =
+      selectedSource?.type === "monitor" ? selectedSource.refreshHz : undefined;
+    return cap && cap >= 1 ? Math.min(desired, cap) : desired;
+  }
+
   async function startActualRecording() {
     if (!selectedSource) {
       isStarting = false;
@@ -843,6 +873,15 @@
       // Rust feeds this directly to FFmpeg dshow as a DirectShow friendly
       // name — pass the label, not the browser deviceId hash.
       cameraDeviceId: cameraOn ? selectedCameraName : null,
+      // Global capture preferences set in Settings → Recording, read fresh at
+      // start time (localStorage is shared across the app's webviews). The
+      // backend clamps/validates both, so a stale or missing value is safe.
+      // The desired fps is additionally capped to the selected monitor's
+      // refresh — capturing above it only duplicates frames, so e.g. a 144 fps
+      // preference records at 60 on a 60 Hz display while still recording 144
+      // on a 144 Hz one. The user's preference itself is left untouched.
+      fps: clampFpsToDisplay(loadRecordingFps()),
+      quality: loadRecordingQuality(),
     };
     try {
       const result = await startRecording(

--- a/apps/desktop/src/routes/select/+page.svelte
+++ b/apps/desktop/src/routes/select/+page.svelte
@@ -24,6 +24,8 @@
     appName?: string;
     thumbnail: string | null;
     resolution?: string;
+    /** Monitor refresh rate in Hz (monitors only); caps the useful capture fps. */
+    refreshHz?: number;
     region?: {
       x: number;
       y: number;
@@ -136,6 +138,7 @@
           label: d.isPrimary ? "Primary Display" : `Display ${i + 1}`,
           thumbnail: d.thumbnail,
           resolution: `${d.width} × ${d.height}`,
+          refreshHz: d.refreshHz || undefined,
         }),
       );
       windows.forEach((w) => {
@@ -443,7 +446,9 @@
                 <div
                   class="mt-0.5 text-[10px] font-mono tabular-nums text-muted-foreground"
                 >
-                  {source.resolution}
+                  {source.resolution}{#if source.refreshHz}
+                    <span class="text-primary/80"> · {source.refreshHz} Hz</span>
+                  {/if}
                 </div>
               {/if}
             </div>

--- a/apps/web/src/content/blog/bringing-recast-to-macos-and-linux.md
+++ b/apps/web/src/content/blog/bringing-recast-to-macos-and-linux.md
@@ -1,0 +1,110 @@
+---
+title: "Bringing Recast to macOS and Linux"
+description: "What it actually takes to make one screen recorder feel native on three operating systems — the abstractions that made it tractable, the war story that nearly hid behind a platform quirk, and where we are now."
+slug: bringing-recast-to-macos-and-linux
+date: 2026-06-08
+author: Kanak
+tags: [engineering, cross-platform, desktop, tauri, rust]
+published: false
+---
+
+Recast started life as a Windows app. Not by ideology — by gravity. You build
+where you sit, and the fastest path to "record your screen, polish it, share
+it" ran through DXGI and WASAPI. But a recorder that only works on one OS isn't
+a recorder; it's a demo. So we set out to make Recast feel genuinely native on
+macOS and Linux too — not a port, not a lowest-common-denominator wrapper, but
+the same Record → Polish → Share loop on whatever you happen to be sitting in
+front of.
+
+Here's what that actually took, and — because we'd rather be honest than
+breathless — exactly where each platform stands today.
+
+## The two abstractions that made it tractable
+
+Cross-platform native code has a reputation for being a swamp. Ours wasn't,
+and the reason comes down to two decisions we'd made early without fully
+appreciating how much they'd pay off.
+
+**One: a per-capability platform module.** Screen capture, audio, camera,
+cursor — each is a folder of small files (`windows.rs`, `macos.rs`,
+`linux_wayland.rs`, `linux_x11.rs`) behind a single trait and a `#[cfg]`
+dispatch. Adding macOS screen capture didn't mean touching the Windows path;
+it meant writing one new file that satisfied the same contract. Every gap was
+*additive and isolated*. No grand refactor, no flag-day rewrite.
+
+**Two: FFmpeg as the great equalizer.** Underneath the OS-specific capture
+front-ends, every platform hands raw frames and PCM to the same FFmpeg-based
+encode/format layer. DXGI on Windows, AVFoundation on macOS, PipeWire and
+XGetImage on Linux — four very different ways to get pixels — all funnel into
+one encoding pipeline. The hard, OS-specific part shrinks to "get me frames";
+everything downstream is shared.
+
+With that shape, the macOS and Linux build-out went faster than the planning
+doc feared. Screen capture, system audio, microphone, camera, cursor tracking,
+device pickers — all implemented on all three, all green in CI on every push.
+
+## The war story: a freeze that only existed on a Mac
+
+The most instructive bug of the whole effort never reproduced on Windows.
+
+A macOS tester reported that the app froze right after a recording finished —
+the window went dead, clicks stopped landing. On Windows: flawless. We had two
+tempting suspects (a UI scroll-lock quirk, an FFmpeg subprocess) and both were
+red herrings.
+
+The real cause was a single missing keyword. The "stop recording" command was
+a *synchronous* function, and inside it the app did real work: flushing the
+encoder, finalizing the file, sometimes a multi-second video re-encode. On
+Windows that's invisible, because Windows renders the web UI in a *separate
+process* — it keeps painting no matter what the backend is doing. macOS (and
+Linux) render the UI on the *same* main thread the command runs on. Block that
+thread and the entire window beach-balls until the work finishes.
+
+The fix was to move the heavy work onto a background worker so the UI thread
+stays free. But the lesson was bigger than one command: we swept the whole
+recording surface for the same anti-pattern and found several more — device
+enumeration, file listing, "reveal in folder" — each a latent freeze that
+Windows had been quietly hiding for us. We also found and closed a subtler one:
+on a long recording, FFmpeg's own progress chatter could fill an OS pipe buffer
+nobody was draining, stalling the encode mid-capture. None of these were "macOS
+bugs." They were *our* bugs that only macOS and Linux were honest enough to
+show us.
+
+That's the recurring theme of going cross-platform: other operating systems
+don't just run your code, they *audit* it.
+
+## Where each platform stands
+
+We'd rather tell you the truth than a roadmap.
+
+- **Windows** is done. It's the reference platform, it's in users' hands, and
+  everything is verified.
+- **macOS** is in active testing — that freeze above came from a real macOS
+  build, which is exactly the point. The capture paths are all there. The
+  honest remaining gaps are hardware verification of the permissions flow and
+  Retina/multi-monitor behavior, the system-audio default (macOS has no
+  built-in loopback the way Windows does — the native path exists but we're
+  finishing its bring-up), and the Apple notarization grind that turns "an app
+  you have to right-click past Gatekeeper" into "an app that just opens."
+- **Linux** is code-complete and waiting on its first real hardware pass.
+  Wayland (via the desktop portal and PipeWire) and X11 are both written and
+  audit-fixed, but nothing earns a checkmark from us until it has actually run
+  on a real GNOME, KDE, and X11 session.
+
+If you want the one-liner: Windows ships today, macOS is a focused
+verification-and-notarization cycle from a public preview, and Linux is one
+hardware bring-up behind that.
+
+## Why we're sharing the messy middle
+
+Most "now on macOS and Linux!" posts are written the day everything is
+perfect. We're writing this one a little earlier, on purpose. Recast is
+founder-built and we'd rather show you the actual engineering — the
+abstractions, the war stories, the honest gaps — than a polished press
+release. The code is there. The remaining distance is a person in front of a
+Mac and a Linux box, doing the unglamorous work of proving each path on real
+hardware.
+
+If you're on macOS or Linux and want to help us get there faster, that's
+exactly the kind of early signal that moves a checkmark from 🟢 to ✅. We'll
+have preview builds to share soon.


### PR DESCRIPTION

Export
- Add an output frame-rate picker for MP4/WebM (Original + lower standard
  rates ≤ source; never upsampling, so we never duplicate frames). Threaded
  through editor store, ipc, and ExportRequest as `fps` (None = source rate);
  GIF keeps its own fps in gifSettings.
- Fix export judder: FFmpeg defaults generated `color=` backgrounds and
  `-loop 1` image inputs to 25 fps, and since the background is the base of
  the composite overlay the whole export inherited 25 fps — frame-dropping a
  60 fps recording into visible shake (worst under zoom). Pin the generator,
  looped inputs, and cursor overlay to the target rate. Adds a regression
  test asserting `color=` carries an explicit `:r=`.

Recording stability
- Fix macOS "window freezes after recording" hang: Tauri runs sync commands
  on the main thread, which on macOS/Linux also renders the WebView. Make
  start_recording, stop_recording, list_recasts, list_exports,
  get_audio_devices, and open_file_location async + spawn_blocking so their
  blocking work (thread joins, camera-trim re-encode, dir scans, device
  enumeration, D-Bus calls) stays off the UI thread. recording_manager is now
  an Arc so stop can hand an owned handle to the worker. Adds a compile-time
  guard test that the recording commands stay async.
- Fix mid-recording capture freeze: drain FFmpeg's stderr continuously on a
  side thread (pump_stderr_tail) instead of only after exit. The ~64KB pipe
  buffer would otherwise fill on long recordings, block FFmpeg, and deadlock
  the encoder's stdin write.
- Tear down already-live capture/encoder threads when a later stage of
  recording start fails, so a failed start can't orphan a capture loop and its
  FFmpeg child.

UI
- Export progress: replace the ad-hoc dot markers with consistent 11px icons —
  a spinning LoaderCircle for the running stage and an outline Circle for
  pending ones — aligned with the done checkmark.