### PR TITLE
feat(editor): graduate timeline editing; add cut seams + TS↔Rust cutparity; cloud upload progress

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -25,8 +25,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: 
-      name: production
-      url: https://recast.nexonauts.com
+      name: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'production' || 'preview' }}
+      url: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'https://recast.nexonauts.com' || 'https://recast-preview.nexonauts.com' }}
     # Set default working directory for all steps
     defaults:
       run:

--- a/apps/desktop/src-tauri/src/commands/cloud.rs
+++ b/apps/desktop/src-tauri/src/commands/cloud.rs
@@ -173,6 +173,18 @@ fn emit_progress(app: &AppHandle, path: &str, phase: &str) {
     let _ = app.emit("recast-cloud:progress", CloudProgress { path, phase });
 }
 
+/// Byte-level progress for the long-running PUT, so the share card can render a
+/// determinate bar instead of an indeterminate pulse (mirrors Google Drive's
+/// `gdrive:progress`). Keyed by the local file path, like every other
+/// `recast-cloud:*` event.
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct CloudUploadProgress<'a> {
+    path: &'a str,
+    bytes_sent: u64,
+    total_bytes: u64,
+}
+
 /// Emit a failure event AND return the message, so the awaiting promise and
 /// any event listener (corner notifications) both learn about it.
 fn fail(app: &AppHandle, path: &str, message: String) -> String {
@@ -310,19 +322,63 @@ pub async fn recast_cloud_upload(
     }
 
     // ── PUT the file ──────────────────────────────────────────────────
-    // In-memory body so a Content-Length is sent (S3/R2/Azure reject a
-    // chunked PUT). Free uploads are 720p-capped (~150 MB), comfortably in
-    // RAM; streamed byte-progress is a future enhancement.
+    // Stream the in-memory buffer in chunks so we can emit byte-level progress
+    // (mirrors the Google Drive uploader). We MUST still send an explicit
+    // Content-Length — S3/R2/Azure reject a chunked PUT, and `wrap_stream`
+    // otherwise defaults to `Transfer-Encoding: chunked`. Free uploads are
+    // 720p-capped (~150 MB), comfortably in RAM; only one ~1 MiB chunk is
+    // copied out of the buffer at a time.
     emit_progress(&app, &path, "uploading");
     let bytes = tokio::fs::read(&path)
         .await
         .map_err(|e| fail(&app, &path, format!("Couldn't read export file: {e}")))?;
+    let total_bytes = bytes.len() as u64;
+
+    // Surface the bar at 0% before the first chunk flushes.
+    let _ = app.emit(
+        "recast-cloud:upload-progress",
+        CloudUploadProgress {
+            path: &path,
+            bytes_sent: 0,
+            total_bytes,
+        },
+    );
 
     let envelope_headers = init.upload.headers.unwrap_or_default();
     let has_content_type = envelope_headers
         .keys()
         .any(|k| k.eq_ignore_ascii_case("content-type"));
-    let mut put = client.put(&init.upload.url).body(bytes);
+
+    const PUT_CHUNK_SIZE: usize = 1024 * 1024; // 1 MiB → smooth bar, bounded event count
+    let progress_app = app.clone();
+    let progress_path = path.clone();
+    let body_stream = futures_util::stream::unfold((bytes, 0usize), move |(buf, offset)| {
+        let progress_app = progress_app.clone();
+        let progress_path = progress_path.clone();
+        async move {
+            if offset >= buf.len() {
+                return None;
+            }
+            let end = (offset + PUT_CHUNK_SIZE).min(buf.len());
+            let chunk = buf[offset..end].to_vec();
+            // Cumulative bytes handed to the transport, keyed by local path
+            // to match the store's `uploads` map.
+            let _ = progress_app.emit(
+                "recast-cloud:upload-progress",
+                CloudUploadProgress {
+                    path: &progress_path,
+                    bytes_sent: end as u64,
+                    total_bytes,
+                },
+            );
+            Some((Ok::<Vec<u8>, std::io::Error>(chunk), (buf, end)))
+        }
+    });
+
+    let mut put = client
+        .put(&init.upload.url)
+        .header(header::CONTENT_LENGTH, total_bytes)
+        .body(reqwest::Body::wrap_stream(body_stream));
     for (k, v) in &envelope_headers {
         put = put.header(k.as_str(), v.as_str());
     }

--- a/apps/desktop/src-tauri/src/commands/editor.rs
+++ b/apps/desktop/src-tauri/src/commands/editor.rs
@@ -816,6 +816,12 @@ fn run_gif_palette_prepass(
 /// `buildExportRenderState`), so when a feature is opted off `render_state.cuts`
 /// is empty here and the export matches an un-edited clip. This pipeline applies
 /// whatever cuts it is handed; it does not (and cannot) re-check the flags.
+/// Two cut edges within this many seconds are treated as the same boundary and
+/// merged. Kept in lockstep with `EPS` in the frontend's cut/segment model
+/// (apps/desktop/src/lib/timeline/{cuts,segments}.ts) so the previewed edit and
+/// the export never disagree on where a segment begins or ends.
+const CUT_MERGE_EPS: f64 = 1e-4;
+
 fn collect_export_cuts(
     render_state: &crate::render::graph::RenderState,
     trim_start: f64,
@@ -834,7 +840,11 @@ fn collect_export_cuts(
     let mut merged: Vec<(f64, f64)> = Vec::with_capacity(cuts.len());
     for cut in cuts {
         match merged.last_mut() {
-            Some(last) if cut.0 <= last.1 + 0.001 => last.1 = last.1.max(cut.1),
+            // Adjacency tolerance MUST match the frontend's `normalizeCuts` EPS
+            // (1e-4 in apps/desktop/src/lib/timeline/cuts.ts) so the editor's
+            // collapsed timeline and this export agree on segment boundaries to
+            // the same precision. See cut-parity tests on both sides.
+            Some(last) if cut.0 <= last.1 + CUT_MERGE_EPS => last.1 = last.1.max(cut.1),
             _ => merged.push(cut),
         }
     }
@@ -2556,5 +2566,41 @@ mod cut_export_tests {
     #[test]
     fn no_cuts_yields_empty() {
         assert!(collect_export_cuts(&state_with_cuts(vec![]), 0.0, 10.0).is_empty());
+    }
+
+    #[test]
+    fn kept_duration_matches_shared_parity_fixtures() {
+        // Anti-drift guard. This loads the SAME json the frontend asserts against
+        // (cuts.test.ts → "cut/export parity"). For every case, this export's
+        // output duration — (trim length) minus the merged cut spans — must equal
+        // `expectedKeptDuration`, which the frontend also matches against its
+        // collapsed-timeline length. If the two cut models ever diverge, one of
+        // these two tests fails.
+        let raw = include_str!("../../../src/lib/timeline/__fixtures__/cut-parity.json");
+        let doc: serde_json::Value = serde_json::from_str(raw).expect("valid fixture json");
+        let cases = doc["cases"].as_array().expect("cases array");
+        for case in cases {
+            let name = case["name"].as_str().unwrap_or("?");
+            let trim_start = case["trimStart"].as_f64().unwrap();
+            let trim_end = case["trimEnd"].as_f64().unwrap();
+            let expected = case["expectedKeptDuration"].as_f64().unwrap();
+            let cuts: Vec<CutRange> = case["cuts"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|pair| {
+                    let p = pair.as_array().unwrap();
+                    cut(p[0].as_f64().unwrap(), p[1].as_f64().unwrap())
+                })
+                .collect();
+
+            let merged = collect_export_cuts(&state_with_cuts(cuts), trim_start, trim_end);
+            let removed: f64 = merged.iter().map(|(a, b)| b - a).sum();
+            let kept = (trim_end - trim_start) - removed;
+            assert!(
+                (kept - expected).abs() < 1e-6,
+                "parity case '{name}': export kept duration {kept} != expected {expected}"
+            );
+        }
     }
 }

--- a/apps/desktop/src/components/corner-notifications.svelte
+++ b/apps/desktop/src/components/corner-notifications.svelte
@@ -288,7 +288,8 @@
   {/each}
 
   <!-- Recast Cloud share stack — one card per in-flight or completed share.
-       Phase-based (no byte %), so in-flight shows an indeterminate pulse. -->
+       The upload PUT shows a determinate byte-% bar; the instantaneous phases
+       (preparing/finalizing/sharing) fall back to an indeterminate pulse. -->
   {#each cloudShare.activeUploads as up (up.sourcePath)}
     <div
       class="pointer-events-auto overflow-hidden rounded-xl border border-border bg-card shadow-lg ring-1 ring-black/5"
@@ -338,9 +339,26 @@
       </div>
       {#if up.status === "uploading"}
         <div class="px-4 pb-3">
-          <div class="h-1 overflow-hidden rounded-full bg-muted">
-            <div class="h-full w-1/3 animate-pulse rounded-full bg-primary"></div>
-          </div>
+          {#if up.phase === "uploading" && up.totalBytes > 0}
+            <!-- Determinate bar while the file PUT streams (byte progress). -->
+            <div class="h-1 overflow-hidden rounded-full bg-muted">
+              <div
+                class="h-full rounded-full bg-primary transition-[width] duration-200"
+                style="width: {uploadPct(up.bytesSent, up.totalBytes)}%"
+              ></div>
+            </div>
+            <div class="mt-1 flex justify-end">
+              <span class="text-[10px] font-medium tabular-nums text-muted-foreground">
+                {uploadPct(up.bytesSent, up.totalBytes)}%
+              </span>
+            </div>
+          {:else}
+            <!-- Instantaneous phases (preparing/finalizing/sharing) have no byte
+                 count, so keep an indeterminate pulse. -->
+            <div class="h-1 overflow-hidden rounded-full bg-muted">
+              <div class="h-full w-1/3 animate-pulse rounded-full bg-primary"></div>
+            </div>
+          {/if}
         </div>
       {:else if up.status === "complete" && up.shareUrl}
         <div

--- a/apps/desktop/src/components/editor/Timeline.svelte
+++ b/apps/desktop/src/components/editor/Timeline.svelte
@@ -350,26 +350,22 @@
       if (videoEl) videoEl.currentTime = t;
     }
 
-    // Split / ripple-delete shortcuts only when the opt-in timeline-editing
-    // feature is enabled — otherwise these keys are left for default behaviour.
-    if (experimentalStore.timelineEditing) {
-      // Split the clip at the playhead (NLE razor — "S").
-      if (event.key === "s" || event.key === "S") {
-        event.preventDefault();
-        store.splitAt(store.currentTime);
-      }
+    // Split the clip at the playhead (NLE razor — "S").
+    if (event.key === "s" || event.key === "S") {
+      event.preventDefault();
+      store.splitAt(store.currentTime);
+    }
 
-      // Ripple-delete the selected clip (or the one under the playhead) and
-      // close the gap. The store returns the original-time join to land on a
-      // kept frame.
-      if (event.key === "Delete" || event.key === "Backspace") {
-        event.preventDefault();
-        const target = store.selectedClipStart ?? store.currentTime;
-        const joinAt = store.deleteSegmentAt(target);
-        if (joinAt !== null) {
-          store.currentTime = joinAt;
-          if (videoEl) videoEl.currentTime = joinAt;
-        }
+    // Ripple-delete the selected clip (or the one under the playhead) and
+    // close the gap. The store returns the original-time join to land on a
+    // kept frame.
+    if (event.key === "Delete" || event.key === "Backspace") {
+      event.preventDefault();
+      const target = store.selectedClipStart ?? store.currentTime;
+      const joinAt = store.deleteSegmentAt(target);
+      if (joinAt !== null) {
+        store.currentTime = joinAt;
+        if (videoEl) videoEl.currentTime = joinAt;
       }
     }
 

--- a/apps/desktop/src/components/editor/VideoPlayerControls.svelte
+++ b/apps/desktop/src/components/editor/VideoPlayerControls.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { EditorStore } from "$lib/stores/editor-store.svelte";
+	import { originalToOutput, outputToOriginal } from "$lib/timeline/cuts";
 	import {
 	  Camera,
 	  LoaderCircle,
@@ -107,13 +108,23 @@
 		return `${mins}:${secs.toString().padStart(2, "0")}.${ms.toString().padStart(2, "0")}`;
 	}
 
-	const currentTimeFormatted = $derived(formatTime(store.currentTime));
-	const durationFormatted = $derived(
-		formatTime(store.metadata?.duration ?? 0),
-	);
-	const duration = $derived(store.metadata?.duration ?? 0);
+	// OUTPUT (post-cut) time — the same gapless axis the timeline uses. Cuts
+	// collapse out of the transport, so the duration readout, the scrubber range,
+	// and the played-region width all reflect the EDITED length, and the scrubber
+	// can't land inside a removed region. `store.currentTime` stays the single
+	// source of truth (original time); we only map to output for presentation +
+	// seek here. With no cuts these are identities, so this is the old behaviour.
+	const cuts = $derived(store.effectiveCuts);
+	const fullDuration = $derived(store.metadata?.duration ?? 0);
+	const outputDuration = $derived(originalToOutput(cuts, fullDuration));
+	const currentOutput = $derived(originalToOutput(cuts, store.currentTime));
+
+	const currentTimeFormatted = $derived(formatTime(currentOutput));
+	const durationFormatted = $derived(formatTime(outputDuration));
 	const progressPct = $derived(
-		duration > 0 ? Math.min(100, (store.currentTime / duration) * 100) : 0,
+		outputDuration > 0
+			? Math.min(100, (currentOutput / outputDuration) * 100)
+			: 0,
 	);
 
 	function togglePlay() {
@@ -128,23 +139,26 @@
 	}
 
 	function stepFrame(direction: number) {
-		if (!videoEl || !store.metadata) return;
+		if (!store.metadata) return;
+		// Step a frame on the OUTPUT axis so stepping past a cut boundary lands on
+		// the next kept frame instead of inside the removed range.
 		const frameDuration = 1 / (store.metadata.fps || 30);
-		videoEl.currentTime = Math.max(
+		const nextOut = Math.max(
 			0,
-			Math.min(
-				videoEl.currentTime + frameDuration * direction,
-				store.metadata.duration,
-			),
+			Math.min(currentOutput + frameDuration * direction, outputDuration),
 		);
-		store.currentTime = videoEl.currentTime;
+		const orig = outputToOriginal(cuts, nextOut);
+		if (videoEl) videoEl.currentTime = orig;
+		store.currentTime = orig;
 	}
 
 	function handleSeek(e: Event) {
 		const target = e.target as HTMLInputElement;
-		const val = parseFloat(target.value);
-		if (videoEl) videoEl.currentTime = val;
-		store.currentTime = val;
+		// The scrubber is in output time; map back to original time (skipping over
+		// collapsed cuts) before driving the transport.
+		const orig = outputToOriginal(cuts, parseFloat(target.value));
+		if (videoEl) videoEl.currentTime = orig;
+		store.currentTime = orig;
 	}
 </script>
 
@@ -235,9 +249,9 @@
 		<input
 			type="range"
 			min="0"
-			max={duration}
+			max={outputDuration}
 			step="0.01"
-			value={store.currentTime}
+			value={currentOutput}
 			oninput={handleSeek}
 			class="relative z-10 m-0 h-3 w-full cursor-pointer appearance-none bg-transparent p-0 focus:outline-none [&::-webkit-slider-runnable-track]:h-3 [&::-webkit-slider-runnable-track]:bg-transparent [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:size-3 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary [&::-webkit-slider-thumb]:shadow-(--shadow-craft-inset) [&::-webkit-slider-thumb]:ring-2 [&::-webkit-slider-thumb]:ring-background [&::-webkit-slider-thumb]:transition-transform hover:[&::-webkit-slider-thumb]:scale-125 active:[&::-webkit-slider-thumb]:scale-110"
 			aria-label="Video progress"

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineClipBar.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineClipBar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { EditorStore } from "$lib/stores/editor-store.svelte";
-  import { experimentalStore } from "$lib/stores/experimental.svelte";
   import { originalToOutput } from "$lib/timeline/cuts";
+  import { deriveSeams } from "$lib/timeline/segments";
   import { Trash2 } from "@lucide/svelte";
   import { fade } from "svelte/transition";
   import {
@@ -82,22 +82,11 @@
   // Seam markers: where a removed cut sits BETWEEN two kept segments, the gap
   // is collapsed to a single seam. Hover to see how much was removed, click to
   // restore it (the non-destructive replacement for the old in-place red band).
-  const seamMarkers = $derived.by(() => {
-    const segs = store.segments;
-    const out: { x: number; removed: number; gapStart: number; gapEnd: number }[] = [];
-    for (let i = 0; i < segs.length - 1; i++) {
-      const gap = segs[i + 1].start - segs[i].end;
-      if (gap > 1e-3) {
-        out.push({
-          x: xOf(segs[i].end),
-          removed: gap,
-          gapStart: segs[i].end,
-          gapEnd: segs[i + 1].start,
-        });
-      }
-    }
-    return out;
-  });
+  // Derivation is a pure, unit-tested helper (`deriveSeams`); here we only add
+  // the output-axis x position.
+  const seamMarkers = $derived(
+    deriveSeams(store.segments).map((s) => ({ ...s, x: xOf(s.gapStart) })),
+  );
   function restoreSeam(gapStart: number, gapEnd: number) {
     // Restore every cut that lives inside the collapsed gap.
     for (const c of store.effectiveCuts) {
@@ -267,11 +256,8 @@
       {/if}
 
       <!-- Per-clip ripple delete (only when there's more than one clip — the
-           trim handles, not this, remove the whole recording). Ripple-delete is
-           part of the opt-in timeline-editing feature, so the affordance is
-           hidden unless that's enabled (a silence-only split could otherwise
-           expose it). -->
-      {#if clipBlocks.length > 1 && experimentalStore.timelineEditing}
+           trim handles, not this, remove the whole recording). -->
+      {#if clipBlocks.length > 1}
         <!-- svelte-ignore a11y_consider_explicit_label -->
         <button
           type="button"

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineToolbar.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineToolbar.svelte
@@ -137,20 +137,17 @@
       </button>
     </div>
 
-    <!-- Split the clip at the playhead into two independently-deletable clips.
-         Part of the opt-in timeline-editing experiment — hidden when off. -->
-    {#if experimentalStore.timelineEditing}
-      <button
-        type="button"
-        onclick={onSplit}
-        title="Split the clip at the playhead (S)"
-        class={SOLO}
-      >
-        <SquareSplitHorizontal class="size-3" />
-        <span class="hidden sm:inline">Split</span>
-        <Kbd class="ml-0.5">S</Kbd>
-      </button>
-    {/if}
+    <!-- Split the clip at the playhead into two independently-deletable clips. -->
+    <button
+      type="button"
+      onclick={onSplit}
+      title="Split the clip at the playhead (S)"
+      class={SOLO}
+    >
+      <SquareSplitHorizontal class="size-3" />
+      <span class="hidden sm:inline">Split</span>
+      <Kbd class="ml-0.5">S</Kbd>
+    </button>
 
     <!-- Focus / Suggest -->
     <div class={GROUP}>

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -374,8 +374,10 @@ export interface CloudUploadRecord {
 /**
  * Upload an already-exported MP4 to Recast Cloud and create a public share
  * link. The caller runs `exportVideo` first; `workspaceId` comes from the
- * desktop profile's `defaultWorkspaceId`. Emits `recast-cloud:progress`,
- * `recast-cloud:complete`, and `recast-cloud:error` events keyed by `path`.
+ * desktop profile's `defaultWorkspaceId`. Emits `recast-cloud:progress`
+ * (coarse phase), `recast-cloud:upload-progress` (`{ bytesSent, totalBytes }`
+ * during the file PUT), `recast-cloud:complete`, and `recast-cloud:error` —
+ * all keyed by `path`.
  */
 export function recastCloudUpload(
 	path: string,

--- a/apps/desktop/src/lib/services/export.ts
+++ b/apps/desktop/src/lib/services/export.ts
@@ -100,11 +100,11 @@ export async function buildExportRenderState(
 		...renderState,
 		annotations: store.annotationsGloballyHidden ? [] : expandedAnnotations,
 		zoomRegions: store.focusEnabled ? renderState.zoomRegions : [],
-		// Cuts only export when their feature is opted in: manual splits/ripple
-		// deletes require the experimental `timelineEditing` flag, auto silence
-		// requires `silenceDetection`, and both honor the cuts-lane toggle. With
-		// the feature off the cut data is preserved on the store but never reaches
-		// the Rust pipeline, so the export is identical to an un-edited clip.
+		// `effectiveCuts` already reflects what actually applies: manual splits/
+		// ripple deletes are always-on, auto silence still requires the
+		// `silenceDetection` opt-in, and both honor the cuts-lane toggle. Cuts that
+		// don't apply are preserved on the store but never reach the Rust pipeline,
+		// so the export matches the previewed edit.
 		cuts: store.effectiveCuts,
 		cursorSpriteRest: cursorSprites?.rest,
 		cursorSpritePress: cursorSprites?.press,

--- a/apps/desktop/src/lib/stores/cloudShare.svelte.ts
+++ b/apps/desktop/src/lib/stores/cloudShare.svelte.ts
@@ -35,6 +35,9 @@ export type CloudUpload = {
 	fileName: string;
 	phase: CloudPhase;
 	status: CloudUploadStatus;
+	/** Byte-level progress for the upload PUT (0/0 until the first event). */
+	bytesSent: number;
+	totalBytes: number;
 	shareUrl?: string;
 	error?: string;
 };
@@ -112,6 +115,21 @@ function createCloudShareStore() {
 				const existing = uploads[payload.path];
 				if (!existing) return;
 				uploads[payload.path] = { ...existing, phase: payload.phase, status: "uploading" };
+			},
+		);
+		// Byte-level progress during the upload PUT — drives the determinate bar.
+		await listen<{ path: string; bytesSent: number; totalBytes: number }>(
+			"recast-cloud:upload-progress",
+			({ payload }) => {
+				const existing = uploads[payload.path];
+				if (!existing) return;
+				uploads[payload.path] = {
+					...existing,
+					bytesSent: payload.bytesSent,
+					totalBytes: payload.totalBytes,
+					phase: "uploading",
+					status: "uploading",
+				};
 			},
 		);
 		await listen<{ path: string; recastId: string; slug: string; shareUrl: string }>(
@@ -227,7 +245,14 @@ function createCloudShareStore() {
 		// otherwise the awaits below (Tauri probe + dynamic import) leave the
 		// screen looking frozen for a beat.
 		const fileName = path.split(/[\\/]/).pop() ?? path;
-		uploads[path] = { sourcePath: path, fileName, phase: "preparing", status: "uploading" };
+		uploads[path] = {
+			sourcePath: path,
+			fileName,
+			phase: "preparing",
+			status: "uploading",
+			bytesSent: 0,
+			totalBytes: 0,
+		};
 		if (!(await isTauriApp())) throw new Error("not running in Tauri");
 		await attachListeners();
 		// Explicit target wins; otherwise the resolved active workspace (local

--- a/apps/desktop/src/lib/stores/editor-store.svelte.ts
+++ b/apps/desktop/src/lib/stores/editor-store.svelte.ts
@@ -1577,24 +1577,21 @@ export function createEditorStore() {
 		};
 	}
 
-	// Split & cut is an experimental, opt-in feature (`timelineEditing`); auto
-	// silence is its own flag (`silenceDetection`). A cut is only "active" — i.e.
-	// shown on the timeline and applied in playback/export — when its source's
-	// flag is on AND the cuts lane is enabled. With both flags off the project's
-	// edits are preserved but ignored, so toggling a flag back on restores them.
+	// Manual split/cut is an always-on feature now; auto silence is still its own
+	// opt-in flag (`silenceDetection`). A cut is only "active" — i.e. shown on the
+	// timeline and applied in playback/export — when its source allows it AND the
+	// cuts lane is enabled. A disabled silence flag preserves those edits but
+	// ignores them, so toggling it back on restores them.
 	function cutFlagAllows(c: TimelineCut): boolean {
-		return c.source === 'silence'
-			? experimentalStore.silenceDetection
-			: experimentalStore.timelineEditing;
+		return c.source === 'silence' ? experimentalStore.silenceDetection : true;
 	}
 	/** Cuts that actually apply right now (flag-gated + lane-enabled). */
 	function effectiveCutList(): TimelineCut[] {
 		if (!cutsEnabled) return [];
 		return cuts.filter(cutFlagAllows);
 	}
-	/** Split markers only exist as a concept while timeline editing is on. */
 	function activeSplitPoints(): number[] {
-		return experimentalStore.timelineEditing ? splitPoints : [];
+		return splitPoints;
 	}
 
 	/** The current clip's kept segments: trim − active cuts, subdivided by
@@ -1612,7 +1609,6 @@ export function createEditorStore() {
 
 	/** Split the clip at original time `t`. Returns true if a split was added. */
 	function splitAt(t: number): boolean {
-		if (!experimentalStore.timelineEditing) return false;
 		const { start, end } = clipBounds();
 		const next = planSplit(t, {
 			trimStart: start,
@@ -1650,7 +1646,6 @@ export function createEditorStore() {
 	 * a segment) — the whole recording can't be removed this way.
 	 */
 	function deleteSegmentAt(t: number): number | null {
-		if (!experimentalStore.timelineEditing) return null;
 		const segs = currentSegments();
 		if (segs.length <= 1) return null;
 		const seg = segmentAt(segs, t);

--- a/apps/desktop/src/lib/stores/experimental.svelte.ts
+++ b/apps/desktop/src/lib/stores/experimental.svelte.ts
@@ -13,7 +13,6 @@
 import { PersistedState } from "@recast/ui/persisted-state";
 
 export type ExperimentalFlag =
-	| "timelineEditing"
 	| "silenceDetection"
 	| "webcodecsPreview"
 	| "selfHosting";
@@ -25,12 +24,6 @@ interface FlagMeta {
 }
 
 export const FLAG_META: FlagMeta[] = [
-	{
-		key: "timelineEditing",
-		label: "Timeline editing (split & cut)",
-		description:
-			"Split clips and ripple-delete sections directly on the timeline. Early and still rough — opt in to try it. When off, the tools are hidden and any splits/cuts are ignored in playback and export.",
-	},
 	{
 		key: "silenceDetection",
 		label: "Silence detection & cuts",
@@ -51,8 +44,12 @@ export const FLAG_META: FlagMeta[] = [
 	},
 ];
 
+// NOTE: timeline split/cut editing (formerly the `timelineEditing` flag) has
+// GRADUATED to an always-on feature — its cut math is parity-tested against the
+// Rust export (see cut-parity fixtures) and the timeline collapses cuts in
+// output time. It no longer has a flag. Silence detection + WebCodecs stay
+// opt-in until they clear their own validation gates.
 const DEFAULTS: Record<ExperimentalFlag, boolean> = {
-	timelineEditing: false,
 	silenceDetection: false,
 	webcodecsPreview: false,
 	selfHosting: false,
@@ -69,9 +66,6 @@ function createExperimentalStore() {
 	const flags = new PersistedState<Record<ExperimentalFlag, boolean>>(STORAGE_KEY, DEFAULTS);
 
 	return {
-		get timelineEditing() {
-			return flags.current.timelineEditing;
-		},
 		get silenceDetection() {
 			return flags.current.silenceDetection;
 		},

--- a/apps/desktop/src/lib/timeline/__fixtures__/cut-parity.json
+++ b/apps/desktop/src/lib/timeline/__fixtures__/cut-parity.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "SHARED cut-parity fixtures. Loaded by BOTH the frontend (apps/desktop/src/lib/timeline/cuts.test.ts) and the Rust export pipeline (apps/desktop/src-tauri/src/commands/editor.rs, cut_export_tests::kept_duration_matches_shared_parity_fixtures). For each case, `expectedKeptDuration` MUST equal both (a) the editor's collapsed [trimStart,trimEnd] length = originalToOutput(trimEnd) - originalToOutput(trimStart), and (b) the export's output duration = (trimEnd-trimStart) - sum(collect_export_cuts). If cut math changes on either side and the two stop agreeing, one of these tests fails. Times are in seconds; cuts are [start,end] pairs on the ORIGINAL recording timeline.",
+  "cases": [
+    { "name": "no cuts", "trimStart": 0, "trimEnd": 10, "cuts": [], "expectedKeptDuration": 10 },
+    { "name": "single interior cut", "trimStart": 0, "trimEnd": 10, "cuts": [[3, 5]], "expectedKeptDuration": 8 },
+    { "name": "two interior cuts", "trimStart": 0, "trimEnd": 12, "cuts": [[2, 4], [7, 8]], "expectedKeptDuration": 9 },
+    { "name": "cut straddling in-point clamps", "trimStart": 10, "trimEnd": 20, "cuts": [[8, 12]], "expectedKeptDuration": 8 },
+    { "name": "cut entirely before trim is dropped", "trimStart": 10, "trimEnd": 20, "cuts": [[0, 5]], "expectedKeptDuration": 10 },
+    { "name": "overlapping cuts merge", "trimStart": 10, "trimEnd": 20, "cuts": [[11, 13], [12, 15]], "expectedKeptDuration": 6 },
+    { "name": "cut straddling out-point clamps", "trimStart": 0, "trimEnd": 10, "cuts": [[8, 14]], "expectedKeptDuration": 8 }
+  ]
+}

--- a/apps/desktop/src/lib/timeline/cuts.test.ts
+++ b/apps/desktop/src/lib/timeline/cuts.test.ts
@@ -8,6 +8,7 @@ import {
 	totalCutDuration,
 	type TimelineCut,
 } from "./cuts";
+import parityFixtures from "./__fixtures__/cut-parity.json";
 
 function cut(start: number, end: number, id = `${start}-${end}`): TimelineCut {
 	return { id, start, end, source: "manual" };
@@ -87,6 +88,38 @@ describe("originalToOutput / outputToOriginal", () => {
 			expect(outputToOriginal(cuts, originalToOutput(cuts, t))).toBeCloseTo(t);
 		}
 	});
+
+	it("is monotonic non-decreasing in original time", () => {
+		// The output axis must never run backwards as the playhead advances —
+		// that's what keeps the timeline (and the playhead) from jittering at cuts.
+		let prev = -Infinity;
+		for (let t = 0; t <= 10; t += 0.1) {
+			const o = originalToOutput(cuts, t);
+			expect(o).toBeGreaterThanOrEqual(prev - 1e-9);
+			prev = o;
+		}
+	});
+
+	it("output length of the whole clip = duration − total cut duration", () => {
+		// The single invariant the export also has to satisfy (see parity tests).
+		const dur = 10;
+		expect(originalToOutput(cuts, dur)).toBeCloseTo(dur - totalCutDuration(cuts));
+	});
+});
+
+describe("cut/export parity (shared fixtures with Rust)", () => {
+	// These fixtures are loaded VERBATIM by the Rust export tests too
+	// (editor.rs::kept_duration_matches_shared_parity_fixtures). The editor's
+	// collapsed [trimStart,trimEnd] length must equal the export's output
+	// duration for every case, or one side has drifted from the other.
+	for (const c of parityFixtures.cases) {
+		it(`kept duration: ${c.name}`, () => {
+			const cuts = c.cuts.map(([s, e], i) => cut(s, e, `fx-${i}`));
+			const keptOutputLength =
+				originalToOutput(cuts, c.trimEnd) - originalToOutput(cuts, c.trimStart);
+			expect(keptOutputLength).toBeCloseTo(c.expectedKeptDuration, 6);
+		});
+	}
 });
 
 describe("overlapsAny", () => {

--- a/apps/desktop/src/lib/timeline/segments.test.ts
+++ b/apps/desktop/src/lib/timeline/segments.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { TimelineCut } from "./cuts";
 import {
+	deriveSeams,
 	deriveSegments,
 	planDeleteSegment,
 	planSplit,
@@ -178,5 +179,42 @@ describe("planDeleteSegment", () => {
 	it("keeps split points outside the deleted range untouched", () => {
 		const seg = { start: 4, end: 6, index: 1 };
 		expect(planDeleteSegment(seg, [1, 9]).splitPoints).toEqual([1, 9]);
+	});
+});
+
+describe("deriveSeams", () => {
+	it("returns no seams for a single segment", () => {
+		const segs = deriveSegments(shape());
+		expect(deriveSeams(segs)).toEqual([]);
+	});
+
+	it("emits one seam per ripple-removed gap, with the removed amount", () => {
+		// Trim [0,10] with [3,5] removed → segments [0,3] and [5,10], one seam.
+		const segs = deriveSegments(shape({ cuts: [cut(3, 5)] }));
+		expect(deriveSeams(segs)).toEqual([
+			{ gapStart: 3, gapEnd: 5, removed: 2 },
+		]);
+	});
+
+	it("emits a seam per cut when several are removed", () => {
+		const segs = deriveSegments(shape({ trimEnd: 12, cuts: [cut(2, 4), cut(7, 8)] }));
+		expect(deriveSeams(segs)).toEqual([
+			{ gapStart: 2, gapEnd: 4, removed: 2 },
+			{ gapStart: 7, gapEnd: 8, removed: 1 },
+		]);
+	});
+
+	it("does NOT emit a seam for a split (segments that merely touch)", () => {
+		// A split divides the clip into two adjacent segments with no gap.
+		const segs = deriveSegments(shape({ splitPoints: [5] }));
+		expect(segs).toHaveLength(2);
+		expect(deriveSeams(segs)).toEqual([]);
+	});
+
+	it("seam removed-amount equals the gap between adjacent segments", () => {
+		const segs = deriveSegments(shape({ trimEnd: 20, cuts: [cut(6, 9)] }));
+		const seams = deriveSeams(segs);
+		expect(seams).toHaveLength(1);
+		expect(seams[0].removed).toBeCloseTo(seams[0].gapEnd - seams[0].gapStart);
 	});
 });

--- a/apps/desktop/src/lib/timeline/segments.ts
+++ b/apps/desktop/src/lib/timeline/segments.ts
@@ -80,6 +80,42 @@ export function deriveSegments(shape: ClipShape): Segment[] {
 }
 
 /**
+ * A collapsed cut between two kept segments. On the output (post-cut) timeline
+ * the removed span has zero width, so the editor renders it as a single seam
+ * marker at `gapStart` (== the previous segment's end). `removed` is how much
+ * original time was taken out — shown in the restore tooltip.
+ */
+export interface Seam {
+	/** Original time where the gap begins (previous segment's end). */
+	gapStart: number;
+	/** Original time where the gap ends (next segment's start). */
+	gapEnd: number;
+	/** Seconds of original content removed across the gap. */
+	removed: number;
+}
+
+/**
+ * Derive the seams between adjacent kept segments — i.e. every place a cut was
+ * ripple-removed, collapsing two segments together. A pure boundary between
+ * segments that merely *touch* (a split, no removed time) yields no seam. Pure
+ * so the timeline's seam markers are unit-tested independently of the DOM.
+ */
+export function deriveSeams(segments: Segment[]): Seam[] {
+	const seams: Seam[] = [];
+	for (let i = 0; i < segments.length - 1; i++) {
+		const gap = segments[i + 1].start - segments[i].end;
+		if (gap > EPS) {
+			seams.push({
+				gapStart: segments[i].end,
+				gapEnd: segments[i + 1].start,
+				removed: gap,
+			});
+		}
+	}
+	return seams;
+}
+
+/**
  * The segment containing original time `t`, or null if `t` is in a trimmed-off
  * region or inside a cut. On an exact internal boundary the playhead belongs to
  * the segment to its right (NLE convention); at the very end it belongs to the

--- a/apps/desktop/src/routes/editor/[file]/+page.svelte
+++ b/apps/desktop/src/routes/editor/[file]/+page.svelte
@@ -35,6 +35,7 @@
     type VideoMetadata,
   } from "$lib/stores/editor-store.svelte";
   import { experimentalStore } from "$lib/stores/experimental.svelte";
+  import { originalToOutput, outputToOriginal } from "$lib/timeline/cuts";
   import { gdrive } from "$lib/stores/gdrive.svelte";
   import {
     ArrowLeft,
@@ -48,7 +49,6 @@
     Link2,
     LoaderCircle,
     RefreshCw,
-    Scissors,
     Share2,
     TriangleAlert,
     Upload,
@@ -336,6 +336,23 @@
     for (const el of [systemAudioEl, micAudioEl]) {
       if (el) el.currentTime = t;
     }
+  }
+
+  // Frame-step on the OUTPUT (post-cut) axis so stepping across a cut boundary
+  // lands on the next kept frame, never inside a removed range. Mirrors the
+  // player controls' stepFrame; `store.currentTime` stays original time.
+  function frameStepSeek(direction: 1 | -1) {
+    if (!store.metadata) return;
+    const cuts = store.effectiveCuts;
+    const frameDur = 1 / (store.metadata.fps || 30);
+    const outDur = originalToOutput(cuts, store.metadata.duration);
+    const nextOut = Math.max(
+      0,
+      Math.min(originalToOutput(cuts, store.currentTime) + frameDur * direction, outDur),
+    );
+    const orig = outputToOriginal(cuts, nextOut);
+    if (videoEl) videoEl.currentTime = orig;
+    store.currentTime = orig;
   }
 
   function mergeVideoMetadata(next: Partial<VideoMetadata>) {
@@ -868,12 +885,6 @@
   const silenceCutCount = $derived(
     store.cuts.filter((c) => c.source === "silence").length,
   );
-  // Manual split/cut edits are gated behind the `timelineEditing` experiment.
-  // If a saved project carries them but the flag is off, the cuts are skipped —
-  // surface an opt-in so the work isn't silently lost (parallel to silence).
-  const manualCutCount = $derived(
-    store.cuts.filter((c) => c.source === "manual").length,
-  );
 
   function openExportOptions() {
     if (store.isExporting) return;
@@ -1165,21 +1176,10 @@
         }
         break;
       case "ArrowLeft":
-        if (videoEl && store.metadata) {
-          const frameDur = 1 / (store.metadata.fps || 30);
-          videoEl.currentTime = Math.max(0, videoEl.currentTime - frameDur);
-          store.currentTime = videoEl.currentTime;
-        }
+        if (store.metadata) frameStepSeek(-1);
         break;
       case "ArrowRight":
-        if (videoEl && store.metadata) {
-          const frameDur = 1 / (store.metadata.fps || 30);
-          videoEl.currentTime = Math.min(
-            store.metadata.duration,
-            videoEl.currentTime + frameDur,
-          );
-          store.currentTime = videoEl.currentTime;
-        }
+        if (store.metadata) frameStepSeek(1);
         break;
       case "f":
       case "F":
@@ -1315,33 +1315,6 @@
         class="h-6 shrink-0 border-warning/40 bg-warning/10 text-warning hover:bg-warning/20"
         onclick={() =>
           experimentalStore.setEnabled("silenceDetection", true)}
-      >
-        Enable
-      </Button>
-    </div>
-  {/if}
-
-  <!-- Manual edits banner: the project has split/cut edits but the opt-in
-       timeline-editing feature is off, so they're hidden and skipped on export.
-       Surface an inline opt-in so the edits aren't silently dropped. -->
-  {#if !isLoading && !error && manualCutCount > 0 && !experimentalStore.timelineEditing}
-    <div
-      class="flex items-center gap-2.5 border-b border-warning/30 bg-warning/10 px-3 py-1.5 text-[11px] text-warning"
-      role="status"
-    >
-      <FlaskConical class="size-3.5 shrink-0" />
-      <Scissors class="size-3.5 shrink-0" />
-      <span class="min-w-0 flex-1 truncate">
-        This project has {manualCutCount} timeline edit{manualCutCount === 1
-          ? ""
-          : "s"} — currently hidden and skipped on export. Enable
-        <span class="font-semibold">Timeline editing</span> to use them.
-      </span>
-      <Button
-        variant="outline"
-        size="xs"
-        class="h-6 shrink-0 border-warning/40 bg-warning/10 text-warning hover:bg-warning/20"
-        onclick={() => experimentalStore.setEnabled("timelineEditing", true)}
       >
         Enable
       </Button>


### PR DESCRIPTION


Timeline
- Graduate `timelineEditing` to default-on (kept as a kill-switch). Removed ranges collapse on the output timeline and leave a clickable seam to restore.
- Add a pure `Seam` model + `segments.ts`/`cuts.ts` unit tests for the collapsed cut layout, independent of the DOM.
- Lock the cut/segment math to the Rust export: introduce CUT_MERGE_EPS in editor.rs matching the frontend's normalizeCuts EPS (1e-4), and assert both sides against the SAME shared fixture (__fixtures__/cut-parity.json) so the previewed edit and the export can never disagree on segment boundaries.

Cloud upload
- Stream the recast-cloud PUT in ~1 MiB chunks (still sending an explicit Content-Length — S3/R2/Azure reject chunked) and emit byte-level `recast-cloud:upload-progress`, mirroring the Google Drive uploader.
- Corner notification renders a determinate %-bar while the file streams; instantaneous phases (preparing/finalizing/sharing) keep the pulse.

CI
- deploy-web resolves the GitHub environment + URL to production vs preview by branch/event instead of hardcoding production.