### PR TITLE
fix: link macOS Info.plist to enable camera and mic permissions

### DIFF
--- a/.changeset/late-states-write.md
+++ b/.changeset/late-states-write.md
@@ -1,0 +1,5 @@
+---
+"recast-desktop": patch
+---
+
+Fix camera and microphone permissions not working on macOS

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -58,12 +58,13 @@
       "binaries/ffmpeg",
       "binaries/ffprobe"
     ],
-     "windows": {
+    "windows": {
       "digestAlgorithm": "sha256",
       "timestampUrl": "http://timestamp.digicert.com"
     },
     "macOS": {
-      "minimumSystemVersion": "13.0"
+      "minimumSystemVersion": "13.0",
+      "infoPlist": "Info.plist"
     },
     "linux": {
       "appimage": {}


### PR DESCRIPTION
This fixes the macOS Apple Silicon camera bug by linking the Info.plist in tauri.conf.json so local dev works properly. Fixes #35 
<img width="1264" height="783" alt="image" src="https://github.com/user-attachments/assets/5783effc-d001-4ba2-9b3b-fd0e6f1f10a6" />
