### PR TITLE
feat(editor): cut WebCodecs preview latency on edits; support large recordings

### DIFF
--- a/apps/desktop/src-tauri/src/encoder/mod.rs
+++ b/apps/desktop/src-tauri/src/encoder/mod.rs
@@ -359,17 +359,19 @@ pub fn spawn_encoder_loop(
             // drop frames during recording.
             args.extend(recording_codec_args(encoder, config.quality));
 
-            // Force a ~1-second keyframe interval (GOP). Every encoder here would
+            // Force a ~0.5-second keyframe interval (GOP). Every encoder here would
             // otherwise use its default (~250 frames ≈ 4s at 60fps), which makes the
             // recording expensive to SEEK: jumping to any point — scrubbing, or
             // crossing a cut in the editor — must re-decode from the preceding
             // keyframe, i.e. up to ~4s of frames, which at 4K is a multi-second
-            // freeze. A 1s GOP keeps that post-seek decode cheap so cuts/scrubbing
-            // stay responsive (this is how editable screen-recording footage is
-            // normally encoded). The size cost of the extra keyframes is small.
-            // `-g` is honoured by nvenc/amf/qsv/videotoolbox/libx264 alike.
+            // freeze. A dense ~0.5s GOP keeps that post-seek decode cheap so
+            // cuts/scrubbing stay responsive (this is how editable screen-recording
+            // footage is normally encoded); the catch-up after a cut is ~a quarter
+            // second on average. The size cost of the extra keyframes is small for
+            // mostly-static screen content. `-g` is honoured by
+            // nvenc/amf/qsv/videotoolbox/libx264 alike.
             args.push("-g".to_string());
-            args.push(config.fps.max(1).to_string());
+            args.push((config.fps / 2).max(1).to_string());
 
             args.push(config.output_path.to_string_lossy().to_string());
 

--- a/apps/desktop/src-tauri/src/encoder/mod.rs
+++ b/apps/desktop/src-tauri/src/encoder/mod.rs
@@ -359,6 +359,18 @@ pub fn spawn_encoder_loop(
             // drop frames during recording.
             args.extend(recording_codec_args(encoder, config.quality));
 
+            // Force a ~1-second keyframe interval (GOP). Every encoder here would
+            // otherwise use its default (~250 frames ≈ 4s at 60fps), which makes the
+            // recording expensive to SEEK: jumping to any point — scrubbing, or
+            // crossing a cut in the editor — must re-decode from the preceding
+            // keyframe, i.e. up to ~4s of frames, which at 4K is a multi-second
+            // freeze. A 1s GOP keeps that post-seek decode cheap so cuts/scrubbing
+            // stay responsive (this is how editable screen-recording footage is
+            // normally encoded). The size cost of the extra keyframes is small.
+            // `-g` is honoured by nvenc/amf/qsv/videotoolbox/libx264 alike.
+            args.push("-g".to_string());
+            args.push(config.fps.max(1).to_string());
+
             args.push(config.output_path.to_string_lossy().to_string());
 
             let mut command = Command::new(crate::ffmpeg::ffmpeg_path());

--- a/apps/desktop/src/components/editor/VideoPreview.svelte
+++ b/apps/desktop/src/components/editor/VideoPreview.svelte
@@ -1246,6 +1246,12 @@ void main() {
 	// the boundary — that decoded frame masks the primary's seek latency.
 	const SCOUT_PRESEEK_LOOKAHEAD = 0.6;
 	const CUT_JUMP_LOOKAHEAD = 0.12;
+	// WebCodecs cross-cut decode-ahead: how far ahead (in OUTPUT seconds) of an
+	// upcoming cut to start warming the post-cut GOP on the worker's scout
+	// decoder, so crossing the cut doesn't freeze while the primary re-decodes
+	// from a keyframe. Wants to cover the post-cut GOP's decode time; ~1s GOP
+	// recordings are well covered, longer-GOP legacy files are partially helped.
+	const WC_PREFETCH_LOOKAHEAD = 2.0;
 	// How close the scout's landed time must be to the cut end to treat its
 	// frame as a valid stand-in (a seek may land a frame or two off target).
 	const SCOUT_READY_EPS = 0.1;
@@ -1397,6 +1403,29 @@ void main() {
 				cutSkipTarget = null;
 				scoutSeekTarget = null;
 			}
+		}
+
+		// Cross-cut decode-ahead: if playback will cross a cut within the lookahead
+		// window, warm the post-cut GOP on the worker's scout decoder NOW so the
+		// crossing is seamless instead of freezing while the primary re-decodes
+		// from a keyframe. Output time is gapless, so we look ahead in OUTPUT time
+		// and map back to original to find the next cut we'll reach. Issued every
+		// frame while approaching — the worker dedupes per post-cut GOP.
+		if (
+			usingPicClock &&
+			store.isPlaying &&
+			wcSource &&
+			wcReady &&
+			activeCuts.length > 0
+		) {
+			const lookaheadOrig = outputToOriginal(
+				store.effectiveCuts,
+				picClock.time + WC_PREFETCH_LOOKAHEAD,
+			);
+			const upcoming = activeCuts.find(
+				(c) => c.start > playbackTime && c.start <= lookaheadOrig,
+			);
+			if (upcoming) wcSource.prefetch(upcoming.end);
 		}
 
 		// Get the frame into the texture. With the WebCodecs engine we sample a
@@ -1819,7 +1848,7 @@ void main() {
 		wcSource?.dispose();
 		wcSource = null;
 		let cancelled = false;
-		WebCodecsVideoSource.create(src)
+		WebCodecsVideoSource.create(src, store.metadata?.sizeBytes)
 			.then((source) => {
 				if (cancelled) {
 					source.dispose();

--- a/apps/desktop/src/lib/playback/audio-engine.ts
+++ b/apps/desktop/src/lib/playback/audio-engine.ts
@@ -1,0 +1,172 @@
+/**
+ * Web Audio timeline engine — sample-accurate, cut-aware audio playback for the
+ * WebCodecs editor preview.
+ *
+ * Instead of slaving an `<audio>` element to the playhead by seeking (which
+ * drifts across cuts, stalls on cold starts, and can cut out), we decode the
+ * recording's audio once into `AudioBuffer`s and schedule each KEPT region as
+ * its own `AudioBufferSourceNode` on the audio hardware clock. The cuts are
+ * simply the gaps between scheduled chunks, so they're silent and exact — no
+ * seeking ever happens during playback.
+ *
+ * Lifecycle mirrors the picture clock: `play(regions, outputTime)` schedules
+ * everything from the current output time; `pause()` stops it; `reschedule()`
+ * re-plans on a seek or an edit-while-playing. Fully fallback-safe: `create`
+ * throws if Web Audio is unavailable or nothing decodes, and the caller drops
+ * back to the `<audio>`-element path, so the user is never left without audio.
+ */
+
+import { planAudioSchedule, type Region } from "./audio-schedule";
+
+interface AudioTrack {
+	buffer: AudioBuffer;
+	gain: GainNode;
+}
+
+export class AudioTimelineEngine {
+	#ctx: AudioContext;
+	#tracks: AudioTrack[];
+	#active: AudioBufferSourceNode[] = [];
+	#playing = false;
+	#volume = 1; // 0..1
+	#muted = false;
+
+	private constructor(ctx: AudioContext, tracks: AudioTrack[]) {
+		this.#ctx = ctx;
+		this.#tracks = tracks;
+	}
+
+	/**
+	 * Create the engine for the given audio source URLs (system + mic; nulls are
+	 * skipped). Fetches and decodes each into an `AudioBuffer`. Throws if Web
+	 * Audio is unavailable or nothing decodes — the caller should then fall back
+	 * to the `<audio>` elements.
+	 */
+	static async create(urls: ReadonlyArray<string | null | undefined>): Promise<AudioTimelineEngine> {
+		const Ctx: typeof AudioContext | undefined =
+			typeof AudioContext !== "undefined"
+				? AudioContext
+				: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+					(globalThis as any).webkitAudioContext;
+		if (!Ctx) throw new Error("Web Audio API unavailable");
+
+		const ctx = new Ctx();
+		const tracks: AudioTrack[] = [];
+		for (const url of urls) {
+			if (!url) continue;
+			try {
+				const res = await fetch(url);
+				if (!res.ok) continue;
+				const data = await res.arrayBuffer();
+				const buffer = await ctx.decodeAudioData(data);
+				const gain = ctx.createGain();
+				gain.connect(ctx.destination);
+				tracks.push({ buffer, gain });
+			} catch {
+				// Skip a track that won't fetch/decode; others may still work.
+			}
+		}
+		if (tracks.length === 0) {
+			try {
+				await ctx.close();
+			} catch {
+				/* ignore */
+			}
+			throw new Error("no decodable audio tracks");
+		}
+		return new AudioTimelineEngine(ctx, tracks);
+	}
+
+	get ready(): boolean {
+		return this.#tracks.length > 0;
+	}
+
+	/** Apply volume (0–100) and mute to every track's gain. */
+	setVolume(volume0to100: number, muted: boolean): void {
+		this.#volume = Math.max(0, Math.min(1, volume0to100 / 100));
+		this.#muted = muted;
+		const v = this.#muted ? 0 : this.#volume;
+		for (const t of this.#tracks) t.gain.gain.value = v;
+	}
+
+	#stopActive(): void {
+		for (const node of this.#active) {
+			try {
+				node.onended = null;
+				node.stop();
+			} catch {
+				/* already stopped */
+			}
+		}
+		this.#active = [];
+	}
+
+	/** (Re)schedule all kept regions so audio plays from OUTPUT time `from`. */
+	#schedule(regions: ReadonlyArray<Region>, from: number): void {
+		this.#stopActive();
+		const now = this.#ctx.currentTime;
+		const chunks = planAudioSchedule(regions, from);
+		for (const t of this.#tracks) {
+			const bufDur = t.buffer.duration;
+			for (const c of chunks) {
+				// A track may be shorter than the timeline (e.g. mic stopped early);
+				// clamp the slice to the available buffer.
+				if (c.bufferOffset >= bufDur) continue;
+				const playDur = Math.min(c.duration, bufDur - c.bufferOffset);
+				if (playDur <= 0) continue;
+				const node = this.#ctx.createBufferSource();
+				node.buffer = t.buffer;
+				node.connect(t.gain);
+				node.onended = () => {
+					const i = this.#active.indexOf(node);
+					if (i >= 0) this.#active.splice(i, 1);
+				};
+				node.start(now + c.whenDelay, c.bufferOffset, playDur);
+				this.#active.push(node);
+			}
+		}
+	}
+
+	/** Start (or restart) playback from OUTPUT time `fromOutputTime`. */
+	async play(regions: ReadonlyArray<Region>, fromOutputTime: number): Promise<void> {
+		if (this.#ctx.state === "suspended") {
+			try {
+				await this.#ctx.resume();
+			} catch {
+				/* resume may reject if not yet user-activated; schedule anyway */
+			}
+		}
+		this.#playing = true;
+		this.#schedule(regions, fromOutputTime);
+	}
+
+	/** Stop all sound; keep buffers for the next play. */
+	pause(): void {
+		this.#playing = false;
+		this.#stopActive();
+	}
+
+	/**
+	 * Re-plan playback to a new OUTPUT time — on a scrub, or when the cut set
+	 * changes while playing. No-op while paused (the next `play` will schedule).
+	 */
+	reschedule(regions: ReadonlyArray<Region>, fromOutputTime: number): void {
+		if (!this.#playing) return;
+		this.#schedule(regions, fromOutputTime);
+	}
+
+	get playing(): boolean {
+		return this.#playing;
+	}
+
+	dispose(): void {
+		this.#stopActive();
+		this.#playing = false;
+		this.#tracks = [];
+		try {
+			void this.#ctx.close();
+		} catch {
+			/* already closed */
+		}
+	}
+}

--- a/apps/desktop/src/lib/playback/audio-schedule.test.ts
+++ b/apps/desktop/src/lib/playback/audio-schedule.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { keptRegions, planAudioSchedule } from "./audio-schedule";
+
+describe("keptRegions", () => {
+	it("returns the whole trim range when there are no cuts", () => {
+		expect(keptRegions(0, 10, [])).toEqual([{ start: 0, end: 10 }]);
+	});
+
+	it("removes a single interior cut, leaving two regions", () => {
+		expect(keptRegions(0, 10, [{ start: 3, end: 5 }])).toEqual([
+			{ start: 0, end: 3 },
+			{ start: 5, end: 10 },
+		]);
+	});
+
+	it("clips cuts to the trim range", () => {
+		expect(keptRegions(2, 8, [{ start: 0, end: 3 }, { start: 7, end: 12 }])).toEqual([
+			{ start: 3, end: 7 },
+		]);
+	});
+
+	it("merges overlapping/adjacent cuts", () => {
+		expect(
+			keptRegions(0, 10, [
+				{ start: 3, end: 5 },
+				{ start: 4, end: 6 },
+			]),
+		).toEqual([
+			{ start: 0, end: 3 },
+			{ start: 6, end: 10 },
+		]);
+	});
+
+	it("returns [] when the whole range is cut", () => {
+		expect(keptRegions(0, 10, [{ start: 0, end: 10 }])).toEqual([]);
+		expect(keptRegions(5, 5, [])).toEqual([]);
+	});
+});
+
+describe("planAudioSchedule", () => {
+	// Two kept regions: [0,3] orig (output 0–3) and [5,10] orig (output 3–8).
+	const regions = [
+		{ start: 0, end: 3 },
+		{ start: 5, end: 10 },
+	];
+
+	it("schedules every region from the start of playback", () => {
+		const plan = planAudioSchedule(regions, 0);
+		expect(plan).toEqual([
+			{ whenDelay: 0, bufferOffset: 0, duration: 3, outStart: 0, outEnd: 3 },
+			{ whenDelay: 3, bufferOffset: 5, duration: 5, outStart: 3, outEnd: 8 },
+		]);
+	});
+
+	it("starts mid-region immediately at the right buffer offset", () => {
+		// Output time 4 is 1s into the second region (orig 5..10) → buffer offset 6.
+		const plan = planAudioSchedule(regions, 4);
+		expect(plan).toEqual([
+			{ whenDelay: 0, bufferOffset: 6, duration: 4, outStart: 3, outEnd: 8 },
+		]);
+	});
+
+	it("skips regions fully behind the playhead", () => {
+		const plan = planAudioSchedule(regions, 3.5);
+		expect(plan).toHaveLength(1);
+		expect(plan[0].outStart).toBe(3);
+	});
+
+	it("maps output time across a cut to the post-cut buffer offset", () => {
+		// Output 3 is exactly the cut boundary → second region starts now at orig 5.
+		const plan = planAudioSchedule(regions, 3);
+		expect(plan[0]).toMatchObject({ whenDelay: 0, bufferOffset: 5, duration: 5 });
+	});
+
+	it("returns nothing once playback is past the end", () => {
+		expect(planAudioSchedule(regions, 8)).toEqual([]);
+	});
+});

--- a/apps/desktop/src/lib/playback/audio-schedule.ts
+++ b/apps/desktop/src/lib/playback/audio-schedule.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure scheduling math for the Web Audio timeline engine — split out so it can
+ * be unit-tested without an `AudioContext`.
+ *
+ * The recording's audio (system + mic WAVs) covers the FULL original timeline.
+ * To play the EDITED timeline we don't seek a media element around the cuts
+ * (fragile, drifts, stalls); instead we schedule each KEPT region as its own
+ * `AudioBufferSourceNode` on the audio clock — the cuts become gaps in the
+ * schedule, so they're sample-accurate and silent by construction.
+ *
+ * Two steps, both pure:
+ *   1. `keptRegions` — the original-time intervals that survive (trim minus
+ *      cuts), cut-bounded (NOT split by editor split points, which don't remove
+ *      audio), so adjacent kept audio plays continuously.
+ *   2. `planAudioSchedule` — given those regions and the current OUTPUT time,
+ *      what to start when: each region maps to a `start(when, offset, duration)`
+ *      on a source node.
+ */
+
+const EPS = 1e-4;
+
+/** An interval on some timeline. */
+export interface Region {
+	/** Start (seconds). */
+	start: number;
+	/** End (seconds). */
+	end: number;
+}
+
+/**
+ * Kept original-time audio regions = `[inPoint, outPoint]` minus `cuts`. Cuts
+ * are clipped to the trim range, merged, and removed; the surviving gaps are the
+ * regions. Self-contained (no dependency on the cut store) so it's trivially
+ * testable.
+ */
+export function keptRegions(
+	inPoint: number,
+	outPoint: number,
+	cuts: ReadonlyArray<Region>,
+): Region[] {
+	if (outPoint - inPoint <= EPS) return [];
+
+	const clipped = cuts
+		.map((c) => ({
+			start: Math.max(inPoint, Math.min(c.start, c.end)),
+			end: Math.min(outPoint, Math.max(c.start, c.end)),
+		}))
+		.filter((c) => c.end - c.start > EPS)
+		.sort((a, b) => a.start - b.start);
+
+	// Merge overlapping/adjacent cuts.
+	const merged: Region[] = [];
+	for (const c of clipped) {
+		const last = merged[merged.length - 1];
+		if (last && c.start <= last.end + EPS) last.end = Math.max(last.end, c.end);
+		else merged.push({ ...c });
+	}
+
+	// The complement within [inPoint, outPoint] is the kept audio.
+	const regions: Region[] = [];
+	let cursor = inPoint;
+	for (const c of merged) {
+		if (c.start > cursor + EPS) regions.push({ start: cursor, end: c.start });
+		cursor = Math.max(cursor, c.end);
+	}
+	if (outPoint > cursor + EPS) regions.push({ start: cursor, end: outPoint });
+	return regions;
+}
+
+/** One scheduled audio chunk: play the buffer slice `[bufferOffset, +duration]`
+ * starting `whenDelay` seconds from "now" (the moment scheduling begins). */
+export interface ScheduledChunk {
+	/** Seconds from now to begin this chunk (0 = immediately, mid-region). */
+	whenDelay: number;
+	/** Offset into the (original-time) audio buffer to start playing from. */
+	bufferOffset: number;
+	/** How long to play. */
+	duration: number;
+	/** Output-time span this chunk occupies (for resync/debugging). */
+	outStart: number;
+	outEnd: number;
+}
+
+/**
+ * Plan the chunks to schedule so playback continues from OUTPUT time
+ * `fromOutputTime`. Output time is gapless: region N starts where region N-1
+ * ended. Regions already fully behind the playhead are skipped; the region the
+ * playhead is inside starts immediately (`whenDelay` 0) at the right offset.
+ */
+export function planAudioSchedule(
+	regions: ReadonlyArray<Region>,
+	fromOutputTime: number,
+): ScheduledChunk[] {
+	const out: ScheduledChunk[] = [];
+	let outCursor = 0;
+	for (const region of regions) {
+		const dur = region.end - region.start;
+		if (dur <= EPS) continue;
+		const outStart = outCursor;
+		const outEnd = outCursor + dur;
+		outCursor = outEnd;
+		if (outEnd <= fromOutputTime + EPS) continue; // already played
+
+		const intoRegion = Math.max(0, fromOutputTime - outStart);
+		const whenDelay = Math.max(0, outStart - fromOutputTime);
+		const duration = dur - intoRegion;
+		if (duration <= EPS) continue;
+		out.push({
+			whenDelay,
+			bufferOffset: region.start + intoRegion,
+			duration,
+			outStart,
+			outEnd,
+		});
+	}
+	return out;
+}

--- a/apps/desktop/src/lib/playback/frame-budget.test.ts
+++ b/apps/desktop/src/lib/playback/frame-budget.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { frameBudget } from "./frame-budget";
+
+describe("frameBudget", () => {
+	it("keeps the historical 7/4/6 budget at common resolutions (≤1440p)", () => {
+		expect(frameBudget(1280, 720)).toEqual({ cacheMax: 7, holdoutMax: 4, decodeAhead: 6 });
+		expect(frameBudget(1920, 1080)).toEqual({ cacheMax: 7, holdoutMax: 4, decodeAhead: 6 });
+		expect(frameBudget(2560, 1440)).toEqual({ cacheMax: 7, holdoutMax: 4, decodeAhead: 6 });
+	});
+
+	it("tightens the budget at 4K and 5K to avoid surface-pool starvation", () => {
+		const k4 = frameBudget(3840, 2160);
+		expect(k4).toEqual({ cacheMax: 4, holdoutMax: 2, decodeAhead: 3 });
+		const k5 = frameBudget(5120, 2880);
+		expect(k5).toEqual({ cacheMax: 4, holdoutMax: 2, decodeAhead: 3 });
+	});
+
+	it("is monotonic: more pixels never increases any cap", () => {
+		const sizes: Array<[number, number]> = [
+			[1280, 720],
+			[1920, 1080],
+			[2560, 1440],
+			[3840, 2160],
+			[5120, 2880],
+			[7680, 4320],
+		];
+		const budgets = sizes.map(([w, h]) => frameBudget(w, h));
+		for (let i = 1; i < budgets.length; i++) {
+			expect(budgets[i].cacheMax).toBeLessThanOrEqual(budgets[i - 1].cacheMax);
+			expect(budgets[i].holdoutMax).toBeLessThanOrEqual(budgets[i - 1].holdoutMax);
+			expect(budgets[i].decodeAhead).toBeLessThanOrEqual(budgets[i - 1].decodeAhead);
+		}
+	});
+
+	it("never drops below safe floors", () => {
+		const huge = frameBudget(7680, 4320); // 8K
+		expect(huge.cacheMax).toBeGreaterThanOrEqual(4);
+		expect(huge.holdoutMax).toBeGreaterThanOrEqual(2);
+		expect(huge.decodeAhead).toBeGreaterThanOrEqual(3);
+	});
+
+	it("falls back to the generous budget when dimensions are unknown", () => {
+		expect(frameBudget(0, 0)).toEqual({ cacheMax: 7, holdoutMax: 4, decodeAhead: 6 });
+	});
+});

--- a/apps/desktop/src/lib/playback/frame-budget.ts
+++ b/apps/desktop/src/lib/playback/frame-budget.ts
@@ -1,0 +1,71 @@
+/**
+ * Resolution-adaptive decoded-frame budget for the WebCodecs source.
+ *
+ * Each decoded `VideoFrame` checks out one of the hardware decoder's limited
+ * output surfaces; holding too many starves the pool and the decoder stalls
+ * (accepts input, emits nothing → ~8fps). A fixed frame count is therefore
+ * wrong across resolutions: 7 frames is fine at 1080p but the same 7 frames at
+ * 4K/5K (macOS records full native Retina, no downscale) holds 4–7× the surface
+ * memory and re-triggers the stall — made worse now that the scout decoder holds
+ * additional pre-warmed frames at the same time.
+ *
+ * So we scale ALL three holders down together with pixel count, against a fixed
+ * surface-memory budget:
+ *   - `cacheMax`    — the primary decoded-frame cache (display + lookahead)
+ *   - `holdoutMax`  — the protected scout (cross-cut prefetch) holdout
+ *   - `decodeAhead` — how far the worker decodes past the playhead
+ *
+ * At ≤1440p this returns the historical 7 / 4 / 6 (unchanged, known-good); at
+ * 4K/5K it tightens to keep the TOTAL held surfaces bounded. Pure + unit-tested.
+ */
+
+/**
+ * Bytes assumed per decoded frame per pixel. Raw yuv420p is 1.5 B/px, but
+ * hardware decode surfaces are padded/tiled and often NV12/RGBA-backed, so we
+ * budget a conservative 4 B/px to stay safely under the real output pool.
+ */
+const BYTES_PER_PX = 4;
+
+/** Total decoded-surface memory we're willing to hold at once (~192 MB). */
+const SURFACE_BUDGET_BYTES = 192 * 1024 * 1024;
+
+/** Clamp range for the combined frame count (primary cache + scout holdout). */
+const MIN_TOTAL_FRAMES = 6;
+const MAX_TOTAL_FRAMES = 11;
+
+export interface FrameBudget {
+	/** Cap for the primary decoded-frame cache. */
+	cacheMax: number;
+	/** Cap for the scout (cross-cut prefetch) holdout. */
+	holdoutMax: number;
+	/** How many samples the worker decodes ahead of the playhead. */
+	decodeAhead: number;
+}
+
+/**
+ * Compute the decoded-frame budget for a `width`×`height` source. Falls back to
+ * the generous (low-res) budget when dimensions are unknown/invalid.
+ */
+export function frameBudget(width: number, height: number): FrameBudget {
+	const pixels = width > 0 && height > 0 ? width * height : 0;
+	const perFrame = pixels > 0 ? pixels * BYTES_PER_PX : 0;
+
+	// Total surfaces we'll hold across the cache + holdout, bounded.
+	const total =
+		perFrame > 0
+			? Math.min(
+					MAX_TOTAL_FRAMES,
+					Math.max(MIN_TOTAL_FRAMES, Math.floor(SURFACE_BUDGET_BYTES / perFrame)),
+				)
+			: MAX_TOTAL_FRAMES;
+
+	// Reserve up to 4 for the scout holdout, shrinking it first as the budget
+	// tightens (the primary cache matters more for steady playback).
+	const holdoutMax = Math.min(4, Math.max(2, total - 5));
+	const cacheMax = Math.max(4, total - holdoutMax);
+	// Don't decode further ahead than the cache can hold, or those frames are
+	// evicted on arrival (wasted decode + extra surface churn).
+	const decodeAhead = Math.max(3, Math.min(6, cacheMax - 1));
+
+	return { cacheMax, holdoutMax, decodeAhead };
+}

--- a/apps/desktop/src/lib/playback/frame-index.test.ts
+++ b/apps/desktop/src/lib/playback/frame-index.test.ts
@@ -88,4 +88,16 @@ describe("needsReset", () => {
 		// Playing in GOP@0 (fed to 20), user jumps to GOP@90 — gap.
 		expect(needsReset(0, 20, 90)).toBe(true);
 	});
+
+	it("does NOT reset on a forward GOP gap when it's lag, not a jump", () => {
+		// Decoder fell behind: playhead crossed keyframe 90 while we've only fed to
+		// 20. Same indices as the jump case, but the request advanced smoothly
+		// (forwardIsJump=false) → keep streaming contiguously, don't reset+skip.
+		expect(needsReset(0, 20, 90, false)).toBe(false);
+	});
+
+	it("still resets backward even when not a jump", () => {
+		// A backward move is always a discontinuity regardless of the jump flag.
+		expect(needsReset(60, 80, 30, false)).toBe(true);
+	});
 });

--- a/apps/desktop/src/lib/playback/frame-index.ts
+++ b/apps/desktop/src/lib/playback/frame-index.ts
@@ -20,8 +20,14 @@ export interface ChunkMeta {
 	durUs: number;
 	/** IDR / sync sample — a valid decode entry point. */
 	key: boolean;
-	/** Encoded bytes (avcC length-prefixed NAL units). */
-	data: Uint8Array;
+	/**
+	 * Encoded bytes (avcC length-prefixed NAL units), or `null` when not yet
+	 * fetched. Whole-file ingestion always has the bytes; the progressive path
+	 * leaves them `null` until the GOP is range-fetched (using the parallel
+	 * sample byte-map), then fills them in and nulls them again on Tier-1
+	 * eviction.
+	 */
+	data: Uint8Array | null;
 }
 
 /** Decode-order indices of keyframes, ascending. */
@@ -88,15 +94,25 @@ export function keyframeAtOrBefore(
  * keyframe `kf`, given the keyframe it's currently primed from (`anchorKey`,
  * -1 if never primed) and the next decode-index it would feed (`feedCursor`).
  *
- * A fresh GOP is needed when we've never primed, jumped BACKWARD to an earlier
- * keyframe, or there's a gap — the target GOP starts past where we've fed, i.e.
- * a forward jump across a cut. Continuous forward playback hits none of these,
- * so it never resets and frames just keep streaming.
+ * Reset cases: never primed; jumped BACKWARD to an earlier keyframe; or a
+ * forward GOP gap (target keyframe past where we've fed) — BUT only when that
+ * forward gap is a genuine discontinuity (`forwardIsJump`): a seek or a cut.
+ *
+ * The `forwardIsJump` guard is essential. The playback clock free-runs at
+ * realtime; if decode falls behind on a heavy stretch the playhead outruns the
+ * feed cursor and crosses keyframes the decoder hasn't reached yet. Resetting
+ * there would seek the decoder forward to each keyframe and SKIP the frames in
+ * between — freezing the picture on edit-heavy content. So when the requested
+ * time merely advanced smoothly (not a jump) we keep streaming contiguously and
+ * let the decoder catch up, decoding every frame. The caller decides whether the
+ * request was a jump (a large time delta since the last one). Defaults to true
+ * so existing callers keep the old "any forward gap resets" behaviour.
  */
 export function needsReset(
 	anchorKey: number,
 	feedCursor: number,
 	kf: number,
+	forwardIsJump = true,
 ): boolean {
-	return anchorKey === -1 || kf < anchorKey || kf > feedCursor;
+	return anchorKey === -1 || kf < anchorKey || (kf > feedCursor && forwardIsJump);
 }

--- a/apps/desktop/src/lib/playback/gop-byte-budget.test.ts
+++ b/apps/desktop/src/lib/playback/gop-byte-budget.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { GopByteBudget } from "./gop-byte-budget";
+
+describe("GopByteBudget", () => {
+	it("tracks residency and total bytes", () => {
+		const b = new GopByteBudget(1000);
+		expect(b.touch(0, 300)).toEqual([]);
+		expect(b.touch(1, 200)).toEqual([]);
+		expect(b.has(0)).toBe(true);
+		expect(b.has(2)).toBe(false);
+		expect(b.totalBytes).toBe(500);
+		expect(b.size).toBe(2);
+	});
+
+	it("evicts least-recently-used GOPs when over budget", () => {
+		const b = new GopByteBudget(500);
+		b.touch(0, 200);
+		b.touch(1, 200);
+		// Adding 200 (total 600 > 500) evicts the LRU = key 0.
+		expect(b.touch(2, 200)).toEqual([0]);
+		expect(b.has(0)).toBe(false);
+		expect(b.has(1)).toBe(true);
+		expect(b.has(2)).toBe(true);
+		expect(b.totalBytes).toBe(400);
+	});
+
+	it("treats touch as a recency bump (re-touched GOP survives)", () => {
+		const b = new GopByteBudget(500);
+		b.touch(0, 200);
+		b.touch(1, 200);
+		b.touch(0, 200); // refresh 0 → now 1 is the LRU
+		expect(b.touch(2, 200)).toEqual([1]);
+		expect(b.has(0)).toBe(true);
+		expect(b.has(1)).toBe(false);
+	});
+
+	it("never evicts the just-touched GOP, even if it alone exceeds budget", () => {
+		const b = new GopByteBudget(100);
+		expect(b.touch(0, 250)).toEqual([]); // can't evict itself
+		expect(b.has(0)).toBe(true);
+		expect(b.totalBytes).toBe(250);
+	});
+
+	it("never evicts a protected GOP (the one on screen)", () => {
+		const b = new GopByteBudget(500);
+		b.touch(5, 200); // display GOP
+		b.touch(6, 200);
+		// Adding 200 would evict LRU=5, but 5 is protected → evict 6 instead.
+		expect(b.touch(7, 200, 5)).toEqual([6]);
+		expect(b.has(5)).toBe(true);
+		expect(b.has(7)).toBe(true);
+	});
+
+	it("supports explicit delete and clear", () => {
+		const b = new GopByteBudget(1000);
+		b.touch(0, 300);
+		b.touch(1, 400);
+		b.delete(0);
+		expect(b.has(0)).toBe(false);
+		expect(b.totalBytes).toBe(400);
+		b.clear();
+		expect(b.size).toBe(0);
+		expect(b.totalBytes).toBe(0);
+	});
+});

--- a/apps/desktop/src/lib/playback/gop-byte-budget.ts
+++ b/apps/desktop/src/lib/playback/gop-byte-budget.ts
@@ -1,0 +1,79 @@
+/**
+ * Tier-1 cache accounting for the WebCodecs progressive path: an LRU governed
+ * by a BYTE budget over the *encoded* GOP bytes we've fetched.
+ *
+ * This is deliberately separate from the decoded-frame cache. Decoded
+ * `VideoFrame`s must be bounded by a small COUNT (each checks out one of the
+ * hardware decoder's limited output surfaces — too many stalls the decoder).
+ * Encoded GOP bytes are cheap CPU RAM with no surface pressure, so they get a
+ * generous byte ceiling instead, which is what makes scrubbing back and forth
+ * over the same cut free (no re-fetch).
+ *
+ * This class only does the accounting — it tracks which GOPs are resident and
+ * how big they are, and decides which to drop. The caller owns the actual bytes
+ * (sample `.data`) and frees them for the keys this returns. Pure and
+ * synchronous so it can be unit-tested without any media.
+ */
+export class GopByteBudget {
+	/** Resident GOPs keyed by keyframe decode-index → byte size. Insertion order
+	 * is LRU order: least-recently-touched first, most-recent last. */
+	#bytesByGop = new Map<number, number>();
+	#total = 0;
+	readonly #maxBytes: number;
+
+	constructor(maxBytes: number) {
+		this.#maxBytes = Math.max(0, maxBytes);
+	}
+
+	get totalBytes(): number {
+		return this.#total;
+	}
+
+	get size(): number {
+		return this.#bytesByGop.size;
+	}
+
+	has(gopKey: number): boolean {
+		return this.#bytesByGop.has(gopKey);
+	}
+
+	/**
+	 * Record (or refresh) a resident GOP of `bytes` bytes, marking it
+	 * most-recently-used, then evict least-recently-used GOPs until back under
+	 * budget. Returns the keys evicted so the caller can free their bytes. The
+	 * just-touched GOP and an optional `protect` key (e.g. the GOP on screen) are
+	 * never evicted, even if that leaves the cache over budget.
+	 */
+	touch(gopKey: number, bytes: number, protect?: number): number[] {
+		// Re-insert to move to the most-recently-used end.
+		if (this.#bytesByGop.has(gopKey)) {
+			this.#total -= this.#bytesByGop.get(gopKey) ?? 0;
+			this.#bytesByGop.delete(gopKey);
+		}
+		this.#bytesByGop.set(gopKey, bytes);
+		this.#total += bytes;
+
+		const evicted: number[] = [];
+		for (const key of this.#bytesByGop.keys()) {
+			if (this.#total <= this.#maxBytes) break;
+			if (key === gopKey || key === protect) continue;
+			this.#total -= this.#bytesByGop.get(key) ?? 0;
+			this.#bytesByGop.delete(key);
+			evicted.push(key);
+		}
+		return evicted;
+	}
+
+	/** Drop a GOP explicitly (e.g. on a decoder reset that invalidates it). */
+	delete(gopKey: number): void {
+		if (!this.#bytesByGop.has(gopKey)) return;
+		this.#total -= this.#bytesByGop.get(gopKey) ?? 0;
+		this.#bytesByGop.delete(gopKey);
+	}
+
+	/** Forget everything (e.g. on dispose). */
+	clear(): void {
+		this.#bytesByGop.clear();
+		this.#total = 0;
+	}
+}

--- a/apps/desktop/src/lib/playback/mp4-sample-table.test.ts
+++ b/apps/desktop/src/lib/playback/mp4-sample-table.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildSampleTable,
+	chooseIngestion,
+	gopByteRange,
+	PROGRESSIVE_THRESHOLD_BYTES,
+	type RawSampleTables,
+} from "./mp4-sample-table";
+
+/**
+ * A 6-sample, 2-chunk fixture (3 samples per chunk), 10fps at timescale 1000.
+ * Variable sizes so byte offsets are non-trivial; keyframes at samples 1 and 4
+ * (1-based) i.e. decode-indices 0 and 3.
+ *
+ *   chunk 1 @ byte 1000: s0(500) s1(200) s2(300)  → offsets 1000,1500,1700
+ *   chunk 2 @ byte 4000: s3(400) s4(100) s5(250)  → offsets 4000,4400,4500
+ */
+const FIXTURE: RawSampleTables = {
+	sampleSizes: [500, 200, 300, 400, 100, 250],
+	sampleSizeConstant: 0,
+	sampleCount: 6,
+	chunkOffsets: [1000, 4000],
+	stscFirstChunk: [1],
+	stscSamplesPerChunk: [3],
+	sttsCounts: [6],
+	sttsDeltas: [100],
+	stssSampleNumbers: [1, 4],
+	timescale: 1000,
+};
+
+describe("buildSampleTable", () => {
+	it("maps sizes, byte offsets, timing and sync flags from the stbl arrays", () => {
+		const t = buildSampleTable(FIXTURE);
+		expect(t).toHaveLength(6);
+		expect(t.map((s) => s.offset)).toEqual([1000, 1500, 1700, 4000, 4400, 4500]);
+		expect(t.map((s) => s.size)).toEqual([500, 200, 300, 400, 100, 250]);
+		expect(t.map((s) => s.ctsUs)).toEqual([0, 100_000, 200_000, 300_000, 400_000, 500_000]);
+		expect(t.every((s) => s.durUs === 100_000)).toBe(true);
+		expect(t.map((s) => s.key)).toEqual([true, false, false, true, false, false]);
+	});
+
+	it("treats every sample as a keyframe when there is no stss table", () => {
+		const t = buildSampleTable({ ...FIXTURE, stssSampleNumbers: undefined });
+		expect(t.every((s) => s.key)).toBe(true);
+	});
+
+	it("supports a constant sample size (empty stsz.sample_sizes)", () => {
+		const t = buildSampleTable({
+			sampleSizes: [],
+			sampleSizeConstant: 1000,
+			sampleCount: 4,
+			chunkOffsets: [5000],
+			stscFirstChunk: [1],
+			stscSamplesPerChunk: [4],
+			sttsCounts: [4],
+			sttsDeltas: [100],
+			timescale: 1000,
+		});
+		expect(t.map((s) => s.offset)).toEqual([5000, 6000, 7000, 8000]);
+		expect(t.every((s) => s.size === 1000)).toBe(true);
+	});
+
+	it("applies ctts composition offsets (B-frame reordering) to cts", () => {
+		// dts = 0,100,200,300 ; ctts offsets (run-length [1,1,2]→[0,300,100,100])
+		// ⇒ cts = 0,400,300,400.
+		const t = buildSampleTable({
+			sampleSizes: [10, 10, 10, 10],
+			sampleSizeConstant: 0,
+			sampleCount: 4,
+			chunkOffsets: [0],
+			stscFirstChunk: [1],
+			stscSamplesPerChunk: [4],
+			sttsCounts: [4],
+			sttsDeltas: [100],
+			cttsCounts: [1, 1, 2],
+			cttsOffsets: [0, 300, 100],
+			timescale: 1000,
+		});
+		expect(t.map((s) => s.ctsUs)).toEqual([0, 400_000, 300_000, 400_000]);
+	});
+
+	it("returns [] for an empty or malformed table", () => {
+		expect(buildSampleTable({ ...FIXTURE, sampleCount: 0 })).toEqual([]);
+		expect(buildSampleTable({ ...FIXTURE, chunkOffsets: [] })).toEqual([]);
+		// Chunks cover only 3 samples but sampleCount claims 6 → bail.
+		expect(
+			buildSampleTable({ ...FIXTURE, chunkOffsets: [1000], stscFirstChunk: [1], stscSamplesPerChunk: [3] }),
+		).toEqual([]);
+	});
+});
+
+describe("gopByteRange", () => {
+	const samples = buildSampleTable(FIXTURE);
+	const keyframes = [0, 3];
+
+	it("covers the first GOP from its keyframe to just before the next", () => {
+		// s0..s2: bytes 1000..(1700+300)=2000 → inclusive 1000..1999.
+		expect(gopByteRange(samples, keyframes, 0)).toEqual({ startByte: 1000, endByte: 1999 });
+	});
+
+	it("covers the last GOP through end of stream", () => {
+		// s3..s5: bytes 4000..(4500+250)=4750 → inclusive 4000..4749.
+		expect(gopByteRange(samples, keyframes, 3)).toEqual({ startByte: 4000, endByte: 4749 });
+	});
+});
+
+describe("chooseIngestion", () => {
+	it("uses whole-file below the threshold and progressive at/above it", () => {
+		expect(chooseIngestion(10 * 1024 * 1024)).toBe("whole");
+		expect(chooseIngestion(PROGRESSIVE_THRESHOLD_BYTES)).toBe("progressive");
+		expect(chooseIngestion(PROGRESSIVE_THRESHOLD_BYTES + 1)).toBe("progressive");
+	});
+
+	it("falls back to whole-file when the size is unknown or invalid", () => {
+		expect(chooseIngestion(undefined)).toBe("whole");
+		expect(chooseIngestion(0)).toBe("whole");
+		expect(chooseIngestion(Number.NaN)).toBe("whole");
+	});
+
+	it("honours a custom threshold", () => {
+		expect(chooseIngestion(50 * 1024 * 1024, 20 * 1024 * 1024)).toBe("progressive");
+	});
+});

--- a/apps/desktop/src/lib/playback/mp4-sample-table.ts
+++ b/apps/desktop/src/lib/playback/mp4-sample-table.ts
@@ -1,0 +1,214 @@
+/**
+ * Pure MP4 sample-table arithmetic for the WebCodecs source's PROGRESSIVE
+ * (HTTP-range) ingestion path — split out so it can be unit-tested without a
+ * real `VideoDecoder`, a real MP4, or mp4box's runtime.
+ *
+ * In whole-file mode mp4box hands us every sample's bytes up front. In
+ * progressive mode we only fetch the `moov` (the index) first, then fetch each
+ * GOP's media bytes on demand. To do that we must reconstruct the full sample
+ * map — presentation time, duration, sync flag, and crucially the BYTE
+ * offset+size of every sample — from the ISO-BMFF sample tables in `stbl`:
+ *
+ *   - stsz  → sample sizes (or one constant size)
+ *   - stsc  → sample-to-chunk runs (how many samples each chunk holds)
+ *   - stco / co64 → the file byte offset of each chunk
+ *   - stts  → decode-time deltas (run-length)
+ *   - ctts  → composition-time offsets (B-frame reordering; run-length, signed)
+ *   - stss  → which samples are sync samples (keyframes); absent ⇒ all are
+ *
+ * The arithmetic here is the same the demuxer does internally; we redo it from
+ * the parsed box arrays (which mp4box exposes via the same box tree the worker
+ * already reads for the codec description) so the byte map is available without
+ * holding any media bytes. All output times are microseconds, samples are in
+ * DECODE order (matching how they're fed to the decoder).
+ */
+
+/** The raw `stbl` arrays we read off the parsed mp4box boxes. */
+export interface RawSampleTables {
+	/** Per-sample sizes (stsz.sample_sizes). Empty when a constant size is used. */
+	sampleSizes: ReadonlyArray<number>;
+	/** Constant sample size (stsz.sample_size); used only when sampleSizes is empty. */
+	sampleSizeConstant: number;
+	/** Total sample count (stsz.sample_count). */
+	sampleCount: number;
+	/** Byte offset of each chunk in the file (stco/co64.chunk_offsets). */
+	chunkOffsets: ReadonlyArray<number>;
+	/** stsc first_chunk (1-based) per run. */
+	stscFirstChunk: ReadonlyArray<number>;
+	/** stsc samples_per_chunk per run (parallel to stscFirstChunk). */
+	stscSamplesPerChunk: ReadonlyArray<number>;
+	/** stts sample_counts per run. */
+	sttsCounts: ReadonlyArray<number>;
+	/** stts sample_deltas per run (parallel to sttsCounts). */
+	sttsDeltas: ReadonlyArray<number>;
+	/** ctts sample_counts per run (optional). */
+	cttsCounts?: ReadonlyArray<number>;
+	/** ctts sample_offsets per run, signed (optional, parallel to cttsCounts). */
+	cttsOffsets?: ReadonlyArray<number>;
+	/** stss 1-based sync-sample numbers. Absent/empty ⇒ every sample is sync. */
+	stssSampleNumbers?: ReadonlyArray<number>;
+	/** Media timescale (mdhd timescale), units per second. */
+	timescale: number;
+}
+
+/** One sample in DECODE order, with its byte location and timing in µs. */
+export interface SampleEntry {
+	/** Presentation timestamp (µs). */
+	ctsUs: number;
+	/** Duration (µs). */
+	durUs: number;
+	/** Sync sample (valid decode entry point / keyframe). */
+	key: boolean;
+	/** Byte offset of the sample's media bytes in the file. */
+	offset: number;
+	/** Size of the sample's media bytes. */
+	size: number;
+}
+
+/** Expand a run-length list (counts[k] copies of values[k]) into a flat array. */
+function expandRuns(
+	counts: ReadonlyArray<number>,
+	values: ReadonlyArray<number>,
+	total: number,
+): number[] {
+	const out: number[] = [];
+	for (let k = 0; k < counts.length && out.length < total; k++) {
+		const c = counts[k];
+		const v = values[k];
+		for (let i = 0; i < c && out.length < total; i++) out.push(v);
+	}
+	// Pad with the last value if the table under-counts (defensive; valid files
+	// cover every sample).
+	const last = values.length ? values[values.length - 1] : 0;
+	while (out.length < total) out.push(last);
+	return out;
+}
+
+/**
+ * Samples-per-chunk for each chunk (1-based chunk index → count), expanded from
+ * the stsc run table. Run k applies to chunks [firstChunk[k], firstChunk[k+1]).
+ */
+function samplesPerChunk(
+	firstChunk: ReadonlyArray<number>,
+	perChunk: ReadonlyArray<number>,
+	chunkCount: number,
+): number[] {
+	const out = new Array<number>(chunkCount + 1).fill(0); // 1-based; [0] unused
+	if (firstChunk.length === 0) {
+		for (let c = 1; c <= chunkCount; c++) out[c] = 1;
+		return out;
+	}
+	for (let k = 0; k < firstChunk.length; k++) {
+		const start = firstChunk[k];
+		const end = k + 1 < firstChunk.length ? firstChunk[k + 1] : chunkCount + 1;
+		for (let c = start; c < end && c <= chunkCount; c++) out[c] = perChunk[k];
+	}
+	return out;
+}
+
+/**
+ * Reconstruct the full sample map (decode order) from the parsed `stbl` arrays.
+ * Returns `[]` when the table is empty or inconsistent (caller falls back).
+ */
+export function buildSampleTable(t: RawSampleTables): SampleEntry[] {
+	const n = t.sampleCount;
+	if (n <= 0 || t.chunkOffsets.length === 0) return [];
+	const ts = t.timescale > 0 ? t.timescale : 1;
+
+	// Sizes.
+	const sizeOf = (i: number): number =>
+		t.sampleSizes.length > 0 ? t.sampleSizes[i] : t.sampleSizeConstant;
+
+	// Per-sample byte offset, walking chunk by chunk.
+	const spc = samplesPerChunk(t.stscFirstChunk, t.stscSamplesPerChunk, t.chunkOffsets.length);
+	const offsets = new Array<number>(n);
+	let sample = 0;
+	for (let c = 1; c <= t.chunkOffsets.length && sample < n; c++) {
+		let pos = t.chunkOffsets[c - 1];
+		const count = spc[c];
+		for (let s = 0; s < count && sample < n; s++) {
+			offsets[sample] = pos;
+			pos += sizeOf(sample);
+			sample++;
+		}
+	}
+	// If the chunk table under-covers the samples (malformed), bail.
+	if (sample < n) return [];
+
+	// Decode-time deltas → dts, and per-sample duration.
+	const deltas = expandRuns(t.sttsCounts, t.sttsDeltas, n);
+	// Composition offsets (B-frame reordering). Absent ⇒ cts == dts.
+	const ctsOff =
+		t.cttsCounts && t.cttsOffsets && t.cttsCounts.length > 0
+			? expandRuns(t.cttsCounts, t.cttsOffsets, n)
+			: null;
+
+	const sync = t.stssSampleNumbers;
+	const syncSet = sync && sync.length > 0 ? new Set(sync) : null;
+
+	const out = new Array<SampleEntry>(n);
+	let dts = 0;
+	for (let i = 0; i < n; i++) {
+		const cts = dts + (ctsOff ? ctsOff[i] : 0);
+		out[i] = {
+			ctsUs: Math.round((cts / ts) * 1e6),
+			durUs: Math.round((deltas[i] / ts) * 1e6),
+			// No stss table means every sample is a sync sample (all-keyframe).
+			key: syncSet ? syncSet.has(i + 1) : true,
+			offset: offsets[i],
+			size: sizeOf(i),
+		};
+		dts += deltas[i];
+	}
+	return out;
+}
+
+/**
+ * The byte range [startByte, endByte] (inclusive) covering the GOP that begins
+ * at decode-index `kfIndex` and runs up to (but not including) the next
+ * keyframe. Used to fetch exactly one GOP's media bytes in a single Range
+ * request. Samples within a GOP are stored contiguously in decode order, but we
+ * take min/max defensively so an unusual layout still yields a covering range.
+ */
+export function gopByteRange(
+	samples: ReadonlyArray<Pick<SampleEntry, "offset" | "size">>,
+	keyframes: ReadonlyArray<number>,
+	kfIndex: number,
+): { startByte: number; endByte: number } {
+	// The decode-index where this GOP ends (next keyframe, or end of stream).
+	let next = samples.length;
+	for (let k = 0; k < keyframes.length; k++) {
+		if (keyframes[k] === kfIndex) {
+			next = k + 1 < keyframes.length ? keyframes[k + 1] : samples.length;
+			break;
+		}
+	}
+	let start = Infinity;
+	let end = -Infinity;
+	for (let i = kfIndex; i < next; i++) {
+		const s = samples[i];
+		if (s.offset < start) start = s.offset;
+		if (s.offset + s.size > end) end = s.offset + s.size;
+	}
+	if (start === Infinity) return { startByte: 0, endByte: -1 }; // empty
+	return { startByte: start, endByte: end - 1 };
+}
+
+/**
+ * Default size threshold (bytes) above which the source switches from loading
+ * the whole file into memory to progressive HTTP-range ingestion. Whole-file is
+ * simpler and gives zero-network steady-state playback; progressive trades that
+ * for a flat memory footprint on multi-GB 4K/5K recordings that would otherwise
+ * blow the WebView's heap. ~500 MB by default; telemetry can tune it later.
+ */
+export const PROGRESSIVE_THRESHOLD_BYTES = 500 * 1024 * 1024;
+
+/** Pick the ingestion strategy for a file of `sizeBytes`. */
+export function chooseIngestion(
+	sizeBytes: number | undefined,
+	threshold = PROGRESSIVE_THRESHOLD_BYTES,
+): "whole" | "progressive" {
+	// Unknown size ⇒ play it safe with the proven whole-file path.
+	if (!sizeBytes || !Number.isFinite(sizeBytes) || sizeBytes <= 0) return "whole";
+	return sizeBytes >= threshold ? "progressive" : "whole";
+}

--- a/apps/desktop/src/lib/playback/webcodecs-protocol.ts
+++ b/apps/desktop/src/lib/playback/webcodecs-protocol.ts
@@ -8,6 +8,13 @@
 export type ToWorker =
 	/** The whole MP4 file, fetched on the main thread and transferred in. */
 	| { type: "init"; buffer: ArrayBuffer }
+	/**
+	 * Progressive ingestion: the worker fetches the `moov` index and then each
+	 * GOP's media bytes on demand via HTTP Range requests against `url` (the
+	 * Tauri asset URL), keeping memory flat for multi-GB recordings. `sizeBytes`
+	 * (from the backend probe) lets it locate a tail `moov` without a HEAD.
+	 */
+	| { type: "init-progressive"; url: string; sizeBytes: number }
 	/** Tell the worker the current playhead so it can decode-ahead. */
 	| { type: "request"; originalSec: number }
 	/** Warm a different GOP (e.g. just after a cut) without moving the playhead. */
@@ -23,6 +30,11 @@ export type FromWorker =
 			durationSec: number;
 			fps: number;
 	  }
-	/** A decoded frame, transferred (listed in the postMessage transfer list). */
-	| { type: "frame"; frame: VideoFrame }
+	/**
+	 * A decoded frame, transferred (listed in the postMessage transfer list).
+	 * `fromScout` marks frames produced by the prefetch (scout) decoder for an
+	 * upcoming post-cut GOP — the main side parks those in a small protected
+	 * holdout so the primary's eviction can't drop them before the cut is reached.
+	 */
+	| { type: "frame"; frame: VideoFrame; fromScout?: boolean }
 	| { type: "error"; message: string };

--- a/apps/desktop/src/lib/playback/webcodecs-source.ts
+++ b/apps/desktop/src/lib/playback/webcodecs-source.ts
@@ -30,18 +30,28 @@
  * exhausts the decoder, so every cached frame has exactly one close path.
  */
 
+import { chooseIngestion } from "./mp4-sample-table";
 import type { FromWorker, ToWorker } from "./webcodecs-protocol";
 
-/** Decoded-frame cache window around the playhead, in seconds. */
-const BACK_WINDOW_S = 0.1;
-const FWD_WINDOW_S = 0.3;
 /**
- * Hard cap on cached frames. Kept SMALL on purpose: each held VideoFrame keeps
- * one of the hardware decoder's limited output surfaces checked out, and
- * holding too many starves that pool so the decoder stalls (processes input but
- * can't emit). A handful is enough for the playhead + a little lookahead.
+ * Hard cap on cached frames (display frame + forward lookahead). Kept SMALL on
+ * purpose: each held VideoFrame keeps one of the hardware decoder's limited
+ * output surfaces checked out, and holding too many starves that pool so the
+ * decoder stalls (processes input but can't emit). A handful is enough for the
+ * playhead + a little lookahead. See `#evict` for the retention policy.
  */
 const MAX_CACHED_FRAMES = 7;
+
+/**
+ * Small protected holdout for scout-decoded frames (the first displayable
+ * frame(s) of an upcoming post-cut GOP). Kept SEPARATE from the main cache so
+ * the primary's count-based eviction — which anchors on the current (pre-cut)
+ * display frame and drops the farthest-ahead first — can't throw away these
+ * far-ahead frames before playback actually reaches the cut. A scout frame is
+ * promoted/served via `frameAt` once the playhead crosses into its segment, and
+ * dropped the moment the primary decodes the same timestamp for real.
+ */
+const PREFETCH_HOLDOUT_MAX = 4;
 
 /** Dev-only diagnostics (throughput + first-frame geometry). Silent in
  * production; kept for debugging decode regressions. */
@@ -51,6 +61,9 @@ export class WebCodecsVideoSource {
 	#worker: Worker;
 	/** Decoded frames, keyed by ctsUs. */
 	#cache = new Map<number, VideoFrame>();
+	/** Protected scout-decoded frames for an upcoming post-cut GOP (see
+	 * `PREFETCH_HOLDOUT_MAX`). Never touched by `#evict`. */
+	#prefetchCache = new Map<number, VideoFrame>();
 	/** Last requested presentation time (µs) — drives eviction. */
 	#currentUs = 0;
 	#disposed = false;
@@ -72,6 +85,11 @@ export class WebCodecsVideoSource {
 	#framesSeen = 0;
 	#lastLogMs = 0;
 	#loggedDims = false;
+	// Worst "lateness" (playhead − frame ts, ms) seen this interval. Large values
+	// mean the decoder is falling behind the realtime clock for this content —
+	// e.g. heavy canvas edits at high resolution — i.e. the frame the cache now
+	// keeps (instead of the old window-evict) is arriving well after its time.
+	#maxLateMs = 0;
 
 	private constructor(
 		worker: Worker,
@@ -92,16 +110,33 @@ export class WebCodecsVideoSource {
 	 * answer `frameAt`. Rejects if the file has no decodable video track or the
 	 * codec/WebView isn't supported by WebCodecs — the caller should fall back
 	 * to the `<video>` path.
+	 *
+	 * `sizeBytes` (from the backend probe) selects the ingestion strategy: small
+	 * files load whole into memory (zero-network steady-state playback); large
+	 * 4K/5K recordings that would blow the WebView heap switch to progressive
+	 * HTTP-range ingestion (flat memory, the worker fetches the moov + GOPs on
+	 * demand). See `chooseIngestion`.
 	 */
-	static async create(url: string): Promise<WebCodecsVideoSource> {
+	static async create(url: string, sizeBytes?: number): Promise<WebCodecsVideoSource> {
 		if (typeof Worker === "undefined" || typeof VideoFrame === "undefined") {
 			throw new Error("WebCodecs/Worker unavailable in this WebView");
 		}
-		// Fetch the file on the main thread — the Tauri asset protocol is reliably
-		// reachable here — then transfer the bytes into the worker.
-		const res = await fetch(url);
-		if (!res.ok) throw new Error(`fetch failed: HTTP ${res.status}`);
-		const buffer = await res.arrayBuffer();
+		const strategy = chooseIngestion(sizeBytes);
+
+		// Build the init message. Whole-file fetches the bytes on the main thread
+		// (the asset protocol is reliably reachable here) and transfers them in;
+		// progressive hands the worker the URL so it can range-fetch lazily.
+		let initMsg: ToWorker;
+		let transfer: Transferable[] = [];
+		if (strategy === "progressive") {
+			initMsg = { type: "init-progressive", url, sizeBytes: sizeBytes as number };
+		} else {
+			const res = await fetch(url);
+			if (!res.ok) throw new Error(`fetch failed: HTTP ${res.status}`);
+			const buffer = await res.arrayBuffer();
+			initMsg = { type: "init", buffer };
+			transfer = [buffer];
+		}
 
 		const worker = new Worker(
 			new URL("./webcodecs-worker.ts", import.meta.url),
@@ -126,9 +161,7 @@ export class WebCodecsVideoSource {
 					}
 				};
 				worker.onerror = (e) => reject(new Error(e.message || "worker error"));
-				worker.postMessage({ type: "init", buffer } satisfies ToWorker, [
-					buffer,
-				]);
+				worker.postMessage(initMsg, transfer);
 			});
 			return new WebCodecsVideoSource(worker, meta);
 		} catch (err) {
@@ -159,19 +192,45 @@ export class WebCodecsVideoSource {
 					);
 				}
 				this.#framesSeen++;
+				this.#maxLateMs = Math.max(
+					this.#maxLateMs,
+					(this.#currentUs - msg.frame.timestamp) / 1000,
+				);
 				const nowMs = performance.now();
 				if (nowMs - this.#lastLogMs > 1000) {
 					console.log(
-						`[wc] decoded ${this.#framesSeen} frames/s · cache=${this.#cache.size} · currentSec=${(this.#currentUs / 1e6).toFixed(2)}`,
+						`[wc] decoded ${this.#framesSeen} frames/s · cache=${this.#cache.size} · currentSec=${(this.#currentUs / 1e6).toFixed(2)} · maxLate=${this.#maxLateMs.toFixed(0)}ms`,
 					);
 					this.#framesSeen = 0;
+					this.#maxLateMs = 0;
 					this.#lastLogMs = nowMs;
 				}
 			}
 
 			const ts = msg.frame.timestamp;
+			if (msg.fromScout) {
+				// Scout frame for an upcoming post-cut GOP. If the primary already
+				// has this timestamp, the scout copy is redundant — drop it.
+				if (this.#cache.has(ts)) {
+					msg.frame.close();
+					return;
+				}
+				this.#prefetchCache.get(ts)?.close();
+				this.#prefetchCache.set(ts, msg.frame);
+				// Bound the holdout by count (oldest first); it's protected from #evict.
+				while (this.#prefetchCache.size > PREFETCH_HOLDOUT_MAX) {
+					const oldest = this.#prefetchCache.keys().next().value as number;
+					this.#prefetchCache.get(oldest)?.close();
+					this.#prefetchCache.delete(oldest);
+				}
+				this.onFrame?.();
+				return;
+			}
 			this.#cache.get(ts)?.close(); // never leak a replaced frame
 			this.#cache.set(ts, msg.frame);
+			// The primary now owns this timestamp for real — discard any scout copy.
+			this.#prefetchCache.get(ts)?.close();
+			this.#prefetchCache.delete(ts);
 			this.#evict();
 			this.onFrame?.();
 		} else if (msg.type === "error") {
@@ -223,25 +282,51 @@ export class WebCodecsVideoSource {
 				best = frame;
 			}
 		}
+		// Also consider the scout holdout — right after a cut the only in-segment
+		// frame yet decoded is the one the scout pre-warmed, which is what makes
+		// the crossing seamless instead of a hold.
+		for (const [ts, frame] of this.#prefetchCache) {
+			if (ts >= floorUs && ts <= tUs && ts > bestTs) {
+				bestTs = ts;
+				best = frame;
+			}
+		}
 		return best;
 	}
 
-	/** Drop frames outside the window around the playhead, closing each. */
+	/**
+	 * Evict around the frame that should currently be ON SCREEN — never by a
+	 * fixed time window. The display frame is the greatest timestamp at-or-before
+	 * the playhead; it is NEVER evicted, even if it arrived "late". This matters
+	 * because the playback clock free-runs at realtime while decode does not: a
+	 * costly frame (a Figma canvas edit, a dropdown opening — a large P-frame)
+	 * decodes slower, so it lands behind the clock. The old window-based eviction
+	 * dropped exactly those frames on arrival (ts < playhead − 100ms), which is
+	 * why heavy on-screen changes silently vanished while static playback stayed
+	 * smooth. Now a late frame is simply newer than the last displayed frame, so
+	 * it becomes the display frame and is shown (a touch late) rather than lost.
+	 */
 	#evict(): void {
-		const backUs = this.#currentUs - BACK_WINDOW_S * 1e6;
-		const fwdUs = this.#currentUs + FWD_WINDOW_S * 1e6;
+		// The frame we'd show right now.
+		let displayTs = -Infinity;
+		for (const ts of this.#cache.keys()) {
+			if (ts <= this.#currentUs && ts > displayTs) displayTs = ts;
+		}
+		// Frames strictly before the display frame are spent — forward playback
+		// won't revisit them, and a backward seek resets + refills the decoder.
 		for (const [ts, frame] of this.#cache) {
-			if (ts < backUs || ts > fwdUs) {
+			if (ts < displayTs) {
 				frame.close();
 				this.#cache.delete(ts);
 			}
 		}
+		// Bound forward lookahead: if still over cap, drop the farthest-ahead
+		// frames first so the display frame and the nearest upcoming frames stay.
 		if (this.#cache.size > MAX_CACHED_FRAMES) {
-			const sorted = [...this.#cache.keys()].sort(
-				(a, b) =>
-					Math.abs(b - this.#currentUs) - Math.abs(a - this.#currentUs),
-			);
-			for (const ts of sorted) {
+			const ahead = [...this.#cache.keys()]
+				.filter((ts) => ts > displayTs)
+				.sort((a, b) => b - a); // farthest future first
+			for (const ts of ahead) {
 				if (this.#cache.size <= MAX_CACHED_FRAMES) break;
 				this.#cache.get(ts)?.close();
 				this.#cache.delete(ts);
@@ -255,6 +340,8 @@ export class WebCodecsVideoSource {
 		this.#post({ type: "dispose" });
 		for (const frame of this.#cache.values()) frame.close();
 		this.#cache.clear();
+		for (const frame of this.#prefetchCache.values()) frame.close();
+		this.#prefetchCache.clear();
 		// The worker self-closes on dispose; terminate as a backstop.
 		this.#worker.terminate();
 	}

--- a/apps/desktop/src/lib/playback/webcodecs-source.ts
+++ b/apps/desktop/src/lib/playback/webcodecs-source.ts
@@ -30,28 +30,19 @@
  * exhausts the decoder, so every cached frame has exactly one close path.
  */
 
+import { frameBudget } from "./frame-budget";
 import { chooseIngestion } from "./mp4-sample-table";
 import type { FromWorker, ToWorker } from "./webcodecs-protocol";
 
-/**
- * Hard cap on cached frames (display frame + forward lookahead). Kept SMALL on
- * purpose: each held VideoFrame keeps one of the hardware decoder's limited
- * output surfaces checked out, and holding too many starves that pool so the
- * decoder stalls (processes input but can't emit). A handful is enough for the
- * playhead + a little lookahead. See `#evict` for the retention policy.
- */
-const MAX_CACHED_FRAMES = 7;
-
-/**
- * Small protected holdout for scout-decoded frames (the first displayable
- * frame(s) of an upcoming post-cut GOP). Kept SEPARATE from the main cache so
- * the primary's count-based eviction — which anchors on the current (pre-cut)
- * display frame and drops the farthest-ahead first — can't throw away these
- * far-ahead frames before playback actually reaches the cut. A scout frame is
- * promoted/served via `frameAt` once the playhead crosses into its segment, and
- * dropped the moment the primary decodes the same timestamp for real.
- */
-const PREFETCH_HOLDOUT_MAX = 4;
+// The cache caps (primary `#cacheMax`, scout `#holdoutMax`) are RESOLUTION-
+// ADAPTIVE — set per source from `frameBudget(width, height)`. Each held
+// VideoFrame keeps one of the hardware decoder's limited output surfaces
+// checked out; at 4K/5K those surfaces are 4–7× larger, so holding the 1080p
+// count would starve the pool and stall the decoder. The scout holdout is kept
+// SEPARATE from the main cache so the primary's eviction (which anchors on the
+// pre-cut display frame and drops the farthest-ahead first) can't throw away
+// the pre-warmed post-cut frames before playback reaches the cut. See
+// `frame-budget.ts` for the sizing and `#evict` for the retention policy.
 
 /** Dev-only diagnostics (throughput + first-frame geometry). Silent in
  * production; kept for debugging decode regressions. */
@@ -61,9 +52,12 @@ export class WebCodecsVideoSource {
 	#worker: Worker;
 	/** Decoded frames, keyed by ctsUs. */
 	#cache = new Map<number, VideoFrame>();
-	/** Protected scout-decoded frames for an upcoming post-cut GOP (see
-	 * `PREFETCH_HOLDOUT_MAX`). Never touched by `#evict`. */
+	/** Protected scout-decoded frames for an upcoming post-cut GOP. Never touched
+	 * by `#evict`. Bounded by `#holdoutMax`. */
 	#prefetchCache = new Map<number, VideoFrame>();
+	/** Resolution-adaptive caps (set in the constructor from `frameBudget`). */
+	#cacheMax: number;
+	#holdoutMax: number;
 	/** Last requested presentation time (µs) — drives eviction. */
 	#currentUs = 0;
 	#disposed = false;
@@ -100,6 +94,16 @@ export class WebCodecsVideoSource {
 		this.height = meta.height;
 		this.durationSec = meta.durationSec;
 		this.fps = meta.fps;
+		// Size the decoded-frame caches to the resolution so 4K/5K sources don't
+		// starve the decoder's output-surface pool (the keystone stall).
+		const budget = frameBudget(meta.width, meta.height);
+		this.#cacheMax = budget.cacheMax;
+		this.#holdoutMax = budget.holdoutMax;
+		if (DIAG) {
+			console.log(
+				`[wc] frame budget ${meta.width}x${meta.height} → cache=${budget.cacheMax} holdout=${budget.holdoutMax} decodeAhead=${budget.decodeAhead}`,
+			);
+		}
 		// Take over message handling for the steady state (frames + late errors).
 		this.#worker.onmessage = (e: MessageEvent<FromWorker>) =>
 			this.#onMessage(e.data);
@@ -218,7 +222,7 @@ export class WebCodecsVideoSource {
 				this.#prefetchCache.get(ts)?.close();
 				this.#prefetchCache.set(ts, msg.frame);
 				// Bound the holdout by count (oldest first); it's protected from #evict.
-				while (this.#prefetchCache.size > PREFETCH_HOLDOUT_MAX) {
+				while (this.#prefetchCache.size > this.#holdoutMax) {
 					const oldest = this.#prefetchCache.keys().next().value as number;
 					this.#prefetchCache.get(oldest)?.close();
 					this.#prefetchCache.delete(oldest);
@@ -322,12 +326,12 @@ export class WebCodecsVideoSource {
 		}
 		// Bound forward lookahead: if still over cap, drop the farthest-ahead
 		// frames first so the display frame and the nearest upcoming frames stay.
-		if (this.#cache.size > MAX_CACHED_FRAMES) {
+		if (this.#cache.size > this.#cacheMax) {
 			const ahead = [...this.#cache.keys()]
 				.filter((ts) => ts > displayTs)
 				.sort((a, b) => b - a); // farthest future first
 			for (const ts of ahead) {
-				if (this.#cache.size <= MAX_CACHED_FRAMES) break;
+				if (this.#cache.size <= this.#cacheMax) break;
 				this.#cache.get(ts)?.close();
 				this.#cache.delete(ts);
 			}

--- a/apps/desktop/src/lib/playback/webcodecs-worker.ts
+++ b/apps/desktop/src/lib/playback/webcodecs-worker.ts
@@ -34,6 +34,13 @@ import {
 	needsReset,
 	sampleAtOrBefore,
 } from "./frame-index";
+import { GopByteBudget } from "./gop-byte-budget";
+import {
+	buildSampleTable,
+	gopByteRange,
+	type RawSampleTables,
+	type SampleEntry,
+} from "./mp4-sample-table";
 import type { FromWorker, ToWorker } from "./webcodecs-protocol";
 
 /** Samples (decode order) to keep decoded ahead of the playhead. Small so we
@@ -41,6 +48,28 @@ import type { FromWorker, ToWorker } from "./webcodecs-protocol";
 const DECODE_AHEAD = 6;
 /** Cap on the decoder's in-flight queue so we don't overfeed during a burst. */
 const QUEUE_MAX = 4;
+/**
+ * A forward jump in requested time bigger than this (µs) is treated as a seek or
+ * a cut — the only case where we reset the decoder to a downstream keyframe and
+ * skip ahead. A smaller forward step is normal playback (≈ one frame) or, on a
+ * heavy stretch, the clock outrunning a lagging decoder; there we keep streaming
+ * contiguously rather than resetting, so no on-screen content is skipped. (A cut
+ * shorter than this just streams through its handful of removed frames, which the
+ * compositor's segment floor hides anyway.)
+ */
+const SEEK_JUMP_US = 300_000;
+
+/** Bytes mp4box is fed per range request while locating the `moov` index. Big
+ * enough to swallow ftyp + the mdat header in one shot so a moov-at-end file
+ * resolves in two fetches (head, then the moov tail). */
+const MOOV_FETCH_CHUNK = 256 * 1024;
+/**
+ * Tier-1 budget (bytes) for the progressive path's cache of *encoded* GOP bytes.
+ * Generous because encoded bytes are cheap CPU RAM with no decoder-surface
+ * pressure (that's the separate, count-bounded decoded-frame cache). This is
+ * what makes scrubbing back over a cut free. 256 MB holds a lot of encoded GOPs.
+ */
+const TIER1_BUDGET_BYTES = 256 * 1024 * 1024;
 
 const ctx = self as unknown as DedicatedWorkerGlobalScope;
 
@@ -60,7 +89,45 @@ let config: VideoDecoderConfig | null = null;
 let anchorKey = -1;
 let feedCursor = 0;
 let currentUs = 0;
+/** Requested time (µs) at the previous schedule() — to tell a seek/cut jump from
+ * smooth playback (incl. a lagging decoder). -1 until the first request. */
+let lastScheduleUs = -1;
 let disposed = false;
+
+// --- Progressive (HTTP-range) ingestion state. Unused in whole-file mode. ---
+/** True once `init-progressive` set up a lazy, range-fetched sample table. */
+let progressive = false;
+/** Asset URL to range-fetch GOP media bytes from. */
+let sourceUrl = "";
+/** Per-sample byte map (offset/size), parallel to `chunks`, for range-fetching
+ * media bytes on demand. Empty in whole-file mode. */
+let sampleTable: SampleEntry[] = [];
+/** Tier-1 LRU over encoded GOP bytes (keyed by the GOP's keyframe decode-index). */
+let byteBudget: GopByteBudget | null = null;
+/** In-flight GOP fetches, keyed by keyframe decode-index, for cancellation. */
+const inflight = new Map<number, AbortController>();
+/** GOPs whose media bytes are currently resident in `chunks[].data`. */
+const gopLoaded = new Set<number>();
+/** Bumped on every decoder reset so bytes from a superseded position are dropped
+ * when their fetch finally resolves (the racing-scrub guard). */
+let currentGen = 0;
+/** Last schedule() target, so a completed GOP fetch can resume feeding. */
+let lastTarget = 0;
+
+// --- Scout decoder (cross-cut decode-ahead). Purely additive: pre-decodes the
+// first displayable frame(s) of an upcoming post-cut GOP into the main cache so
+// crossing the cut doesn't freeze while the primary re-decodes from a keyframe.
+// If anything here fails it self-disables and playback falls back to the
+// primary-only "hold last frame until the post-cut GOP decodes" behaviour. ---
+let scoutDecoder: VideoDecoder | null = null;
+/** Keyframe decode-index the scout is currently warming (dedup). -1 = idle. */
+let scoutAnchorKf = -1;
+/** Only scout frames at/after this presentation time (µs) are forwarded — the
+ * displayable post-cut frame onward; earlier GOP-internal frames are decode
+ * dependencies we don't show. */
+let scoutTargetTs = Number.POSITIVE_INFINITY;
+/** Cleared if the scout ever errors, so a flaky decoder can't thrash playback. */
+let scoutEnabled = true;
 
 function post(msg: FromWorker, transfer: Transferable[] = []): void {
 	ctx.postMessage(msg, transfer);
@@ -138,30 +205,7 @@ async function init(ab: ArrayBuffer): Promise<void> {
 		keyframes = buildKeyframes(chunks);
 		presOrder = buildPresOrder(chunks);
 		config = cfg;
-		decoder = new VideoDecoder({
-			output: (frame) => {
-				if (disposed) {
-					frame.close();
-					return;
-				}
-				if (DIAG) {
-					diagDecoded++;
-					const nowMs = performance.now();
-					if (nowMs - diagLastLogMs > 1000) {
-						console.log(
-							`[wc-worker] decoded ${diagDecoded}/s · queue=${decoder?.decodeQueueSize} · resets=${diagResets} · fed=${feedCursor}/${chunks.length}`,
-						);
-						diagDecoded = 0;
-						diagResets = 0;
-						diagLastLogMs = nowMs;
-					}
-				}
-				// Transfer ownership to the main thread; do NOT close after — the
-				// transfer detaches our handle.
-				post({ type: "frame", frame }, [frame]);
-			},
-			error: (e) => post({ type: "error", message: String(e) }),
-		});
+		decoder = makeDecoder();
 		decoder.configure(config);
 
 		const durationSec =
@@ -180,26 +224,308 @@ async function init(ab: ArrayBuffer): Promise<void> {
 	}
 }
 
+/** Build the shared VideoDecoder (same output/error wiring for both ingestion
+ * paths): transfer each decoded frame to the main thread, log throughput in DEV. */
+function makeDecoder(): VideoDecoder {
+	return new VideoDecoder({
+		output: (frame) => {
+			if (disposed) {
+				frame.close();
+				return;
+			}
+			if (DIAG) {
+				diagDecoded++;
+				const nowMs = performance.now();
+				if (nowMs - diagLastLogMs > 1000) {
+					console.log(
+						`[wc-worker] decoded ${diagDecoded}/s · queue=${decoder?.decodeQueueSize} · resets=${diagResets} · fed=${feedCursor}/${chunks.length} · mode=${progressive ? "progressive" : "whole"}${progressive ? ` · gopBytes=${((byteBudget?.totalBytes ?? 0) / 1e6).toFixed(0)}MB · inflight=${inflight.size}` : ""}`,
+					);
+					diagDecoded = 0;
+					diagResets = 0;
+					diagLastLogMs = nowMs;
+				}
+			}
+			// Transfer ownership to the main thread; do NOT close after — the
+			// transfer detaches our handle.
+			post({ type: "frame", frame }, [frame]);
+		},
+		error: (e) => post({ type: "error", message: String(e) }),
+	});
+}
+
+/** The scout decoder: same frame transfer, but it only forwards frames at/after
+ * `scoutTargetTs` (the displayable post-cut frame onward) tagged `fromScout`, and
+ * on ANY error it disables scouting rather than disturbing playback. */
+function makeScoutDecoder(): VideoDecoder {
+	return new VideoDecoder({
+		output: (frame) => {
+			// Drop the GOP-internal frames before the display target — they're only
+			// decode dependencies. Forward the rest into the main cache's holdout.
+			if (disposed || frame.timestamp < scoutTargetTs) {
+				frame.close();
+				return;
+			}
+			post({ type: "frame", frame, fromScout: true }, [frame]);
+		},
+		error: (e) => {
+			scoutEnabled = false;
+			scoutAnchorKf = -1;
+			try {
+				if (scoutDecoder && scoutDecoder.state !== "closed") scoutDecoder.close();
+			} catch {
+				/* already closing */
+			}
+			scoutDecoder = null;
+			if (DIAG) console.warn("[wc-worker] scout disabled after error:", e);
+		},
+	});
+}
+
+/**
+ * Fetch a byte range from the asset URL. Throws if the server ignored the Range
+ * header (status 200 with the whole body) — that means progressive ingestion is
+ * impossible on this platform and the caller should fall back to `<video>`.
+ */
+async function fetchRange(
+	url: string,
+	startByte: number,
+	endByte: number,
+	signal?: AbortSignal,
+): Promise<ArrayBuffer> {
+	const res = await fetch(url, {
+		headers: { Range: `bytes=${startByte}-${endByte}` },
+		signal,
+	});
+	if (res.status === 200) {
+		throw new Error("asset protocol ignored Range header (got 200, not 206)");
+	}
+	if (!res.ok && res.status !== 206) {
+		throw new Error(`range fetch failed: HTTP ${res.status}`);
+	}
+	return res.arrayBuffer();
+}
+
+/** Read the raw `stbl` sample-table arrays off the parsed mp4box box tree. */
+function extractSampleTables(file: ISOFile, trackId: number): RawSampleTables {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const trak = file.getTrackById(trackId) as any;
+	const stbl = trak?.mdia?.minf?.stbl;
+	const mdhd = trak?.mdia?.mdhd;
+	if (!stbl || !mdhd) throw new Error("missing stbl/mdhd in track");
+	const stsz = stbl.stsz;
+	const stco = stbl.stco ?? stbl.co64;
+	const stsc = stbl.stsc;
+	const stts = stbl.stts;
+	const ctts = stbl.ctts;
+	const stss = stbl.stss;
+	if (!stsz || !stco || !stsc || !stts) {
+		throw new Error("incomplete sample tables (stsz/stco/stsc/stts)");
+	}
+	return {
+		sampleSizes: stsz.sample_sizes ?? [],
+		sampleSizeConstant: stsz.sample_size ?? 0,
+		sampleCount: stsz.sample_count ?? (stsz.sample_sizes?.length ?? 0),
+		chunkOffsets: stco.chunk_offsets ?? [],
+		stscFirstChunk: stsc.first_chunk ?? [],
+		stscSamplesPerChunk: stsc.samples_per_chunk ?? [],
+		sttsCounts: stts.sample_counts ?? [],
+		sttsDeltas: stts.sample_deltas ?? [],
+		cttsCounts: ctts?.sample_counts,
+		cttsOffsets: ctts?.sample_offsets,
+		stssSampleNumbers: stss?.sample_numbers,
+		timescale: mdhd.timescale,
+	};
+}
+
+/**
+ * Progressive ingestion: fetch only the `moov` index up front via Range
+ * requests (driven by mp4box's returned next-byte position, which skips a
+ * front mdat to reach a tail moov), build the full sample byte-map, then leave
+ * media bytes to be range-fetched per GOP on demand.
+ */
+async function initProgressive(url: string, sizeBytes: number): Promise<void> {
+	if (typeof VideoDecoder === "undefined") {
+		post({ type: "error", message: "WebCodecs VideoDecoder unavailable" });
+		return;
+	}
+	try {
+		const file = createFile();
+		let info: Movie | null = null;
+		let parseError: string | null = null;
+		file.onError = (e: string) => {
+			parseError = e;
+		};
+		file.onReady = (movie: Movie) => {
+			info = movie;
+		};
+
+		// Feed ranges until mp4box has parsed the moov (onReady). appendBuffer
+		// returns the next file position it needs; for a tail moov that jumps past
+		// the mdat payload so we don't download the media to find the index.
+		let pos = 0;
+		while (!info && pos < sizeBytes) {
+			const end = Math.min(pos + MOOV_FETCH_CHUNK, sizeBytes) - 1;
+			const ab = await fetchRange(url, pos, end);
+			const next = file.appendBuffer(MP4BoxBuffer.fromArrayBuffer(ab, pos), false);
+			if (parseError) throw new Error(`mp4box: ${parseError}`);
+			if (info) break;
+			pos = next > end + 1 ? next : end + 1;
+		}
+		const movie = info as Movie | null;
+		if (!movie) throw new Error("moov index not found within file");
+
+		const vtrack =
+			movie.videoTracks?.[0] ?? movie.tracks.find((t) => t.type === "video") ?? null;
+		if (!vtrack) throw new Error("no video track in source");
+
+		const cfg: VideoDecoderConfig = {
+			codec: vtrack.codec,
+			description: extractDescription(file, vtrack.id),
+			hardwareAcceleration: "prefer-hardware",
+			optimizeForLatency: false,
+		};
+		const support = await VideoDecoder.isConfigSupported(cfg);
+		if (!support.supported) throw new Error(`codec not supported: ${cfg.codec}`);
+
+		const table = buildSampleTable(extractSampleTables(file, vtrack.id));
+		if (table.length === 0) throw new Error("could not build sample index");
+
+		sampleTable = table;
+		chunks = table.map((s) => ({
+			ctsUs: s.ctsUs,
+			durUs: s.durUs,
+			key: s.key,
+			data: null,
+		}));
+		keyframes = buildKeyframes(chunks);
+		presOrder = buildPresOrder(chunks);
+		config = cfg;
+		progressive = true;
+		sourceUrl = url;
+		byteBudget = new GopByteBudget(TIER1_BUDGET_BYTES);
+		decoder = makeDecoder();
+		decoder.configure(config);
+
+		const durationSec =
+			vtrack.movie_timescale > 0 ? vtrack.movie_duration / vtrack.movie_timescale : 0;
+		post({
+			type: "ready",
+			width: vtrack.video?.width ?? vtrack.track_width,
+			height: vtrack.video?.height ?? vtrack.track_height,
+			durationSec,
+			fps: durationSec > 0 ? vtrack.nb_samples / durationSec : 30,
+		});
+	} catch (err) {
+		post({ type: "error", message: err instanceof Error ? err.message : String(err) });
+	}
+}
+
+/** The keyframe decode-index that ends the GOP starting at `kfIndex` (exclusive),
+ * or chunks.length at end of stream. */
+function gopEnd(kfIndex: number): number {
+	const ki = keyframes.indexOf(kfIndex);
+	return ki >= 0 && ki + 1 < keyframes.length ? keyframes[ki + 1] : chunks.length;
+}
+
+/** Release a resident GOP's encoded bytes (Tier-1 eviction). Never touches the
+ * GOP currently feeding (the caller protects it via the budget). */
+function freeGop(kfIndex: number): void {
+	const end = gopEnd(kfIndex);
+	for (let i = kfIndex; i < end; i++) chunks[i].data = null;
+	gopLoaded.delete(kfIndex);
+}
+
+/** Range-fetch one GOP's media bytes and slice them into its samples, then
+ * resume feeding. Guarded by a generation token so bytes for a superseded
+ * position (after a reset/seek) are discarded on arrival. */
+async function loadGop(kfIndex: number): Promise<void> {
+	const { startByte, endByte } = gopByteRange(sampleTable, keyframes, kfIndex);
+	if (endByte < startByte) return;
+	const gen = currentGen;
+	const controller = new AbortController();
+	inflight.set(kfIndex, controller);
+	try {
+		const buf = await fetchRange(sourceUrl, startByte, endByte, controller.signal);
+		if (disposed || gen !== currentGen) return; // superseded — drop it
+		const view = new Uint8Array(buf);
+		const end = gopEnd(kfIndex);
+		for (let i = kfIndex; i < end; i++) {
+			const s = sampleTable[i];
+			if (!s) continue;
+			const rel = s.offset - startByte;
+			chunks[i].data = view.subarray(rel, rel + s.size);
+		}
+		gopLoaded.add(kfIndex);
+		if (byteBudget) {
+			for (const ev of byteBudget.touch(kfIndex, endByte - startByte + 1, anchorKey)) {
+				freeGop(ev);
+			}
+		}
+		schedule(lastTarget); // bytes are here — continue feeding
+	} catch (err) {
+		if (!disposed && (err as { name?: string })?.name !== "AbortError" && DIAG) {
+			console.warn("[wc-worker] GOP load failed", kfIndex, err);
+		}
+	} finally {
+		// Only clear if a newer load for this GOP hasn't replaced us.
+		if (inflight.get(kfIndex) === controller) inflight.delete(kfIndex);
+	}
+}
+
+/** Ensure the GOP at keyframe `kfIndex` has its media bytes, fetching if needed. */
+function ensureGopLoaded(kfIndex: number): void {
+	if (gopLoaded.has(kfIndex) || inflight.has(kfIndex)) return;
+	void loadGop(kfIndex);
+}
+
+/** Cancel all in-flight GOP fetches and bump the generation (on a reset/seek so
+ * their late bytes are ignored). Resident GOP bytes survive — that's the cache. */
+function cancelInflight(): void {
+	currentGen++;
+	for (const c of inflight.values()) c.abort();
+	inflight.clear();
+}
+
 /** Ensure the decoder is feeding the GOP that covers decode-index `target`. */
 function schedule(target: number): void {
 	if (!decoder || !config) return;
+	lastTarget = target;
 	const kf = keyframeAtOrBefore(keyframes, target);
-	if (needsReset(anchorKey, feedCursor, kf)) {
+	// A forward GOP gap only counts as a reset-worthy seek/cut when the requested
+	// time actually JUMPED. If it advanced smoothly (≈ a frame) or the decoder is
+	// just behind on a heavy stretch, we keep streaming so no frames are skipped.
+	const forwardIsJump =
+		lastScheduleUs < 0 || Math.abs(currentUs - lastScheduleUs) > SEEK_JUMP_US;
+	lastScheduleUs = currentUs;
+	if (needsReset(anchorKey, feedCursor, kf, forwardIsJump)) {
+		// A reset abandons the old position: cancel in-flight GOP fetches so their
+		// late bytes (for a place we're no longer at) are dropped. Resident GOP
+		// bytes stay cached — that's what makes scrubbing back over a cut free.
+		if (progressive) cancelInflight();
 		decoder.reset();
 		decoder.configure(config); // reset() drops the config
 		anchorKey = kf;
 		feedCursor = kf;
+		// The primary moved; re-arm scouting so the next approaching cut warms
+		// again (and a replay of the same cut isn't blocked by a stale dedup).
+		scoutAnchorKf = -1;
 		diagResets++;
 	}
 	const end = Math.min(target + DECODE_AHEAD, chunks.length - 1);
 	while (feedCursor <= end && decoder.decodeQueueSize < QUEUE_MAX) {
 		const c = chunks[feedCursor];
+		// Progressive: if this GOP's media bytes aren't resident yet, kick off a
+		// range fetch and stop — loadGop() resumes feeding when the bytes land.
+		if (progressive && c.data === null) {
+			ensureGopLoaded(keyframeAtOrBefore(keyframes, feedCursor));
+			break;
+		}
 		decoder.decode(
 			new EncodedVideoChunk({
 				type: c.key ? "key" : "delta",
 				timestamp: c.ctsUs,
 				duration: c.durUs,
-				data: c.data,
+				data: c.data as Uint8Array,
 			}),
 		);
 		feedCursor++;
@@ -213,27 +539,73 @@ function request(originalSec: number): void {
 }
 
 function prefetch(originalSec: number): void {
-	if (disposed || chunks.length === 0 || !decoder) return;
+	if (disposed || !scoutEnabled || chunks.length === 0 || !config) return;
 	const tUs = Math.max(0, Math.round(originalSec * 1e6));
 	const target = sampleAtOrBefore(chunks, presOrder, tUs);
 	const kf = keyframeAtOrBefore(keyframes, target);
-	// Only warm a DIFFERENT GOP, and only while the decoder is idle enough not
-	// to starve the current playhead.
-	if (kf === anchorKey) return;
-	if (decoder.decodeQueueSize > 0) return;
-	schedule(target);
+	// Nothing to warm if the primary already covers this GOP, or we're already
+	// warming it.
+	if (kf === anchorKey || kf === scoutAnchorKf) return;
+	// Progressive: the GOP's media bytes must be resident first. Kick the loader
+	// and bail — the next prefetch tick retries once the bytes land.
+	if (progressive) {
+		const end = gopEnd(kf);
+		for (let i = kf; i < end; i++) {
+			if (chunks[i].data === null) {
+				ensureGopLoaded(kf);
+				return;
+			}
+		}
+	}
+	scoutAnchorKf = kf;
+	// Only emit the displayable post-cut frame (sampleAtOrBefore the cut point)
+	// and beyond; earlier frames in the GOP are decode dependencies.
+	scoutTargetTs = chunks[target].ctsUs;
+	if (!scoutDecoder || scoutDecoder.state === "closed") scoutDecoder = makeScoutDecoder();
+	try {
+		scoutDecoder.reset();
+		scoutDecoder.configure(config);
+	} catch (e) {
+		scoutEnabled = false;
+		scoutAnchorKf = -1;
+		if (DIAG) console.warn("[wc-worker] scout configure failed:", e);
+		return;
+	}
+	// Feed the GOP from its keyframe through a couple frames past the target, so a
+	// few post-cut frames are cached to bridge the jump until the primary catches
+	// up (it re-decodes the same GOP itself on the actual cut crossing).
+	const feedEnd = Math.min(target + 2, chunks.length - 1);
+	for (let i = kf; i <= feedEnd; i++) {
+		const c = chunks[i];
+		if (c.data === null) break; // progressive byte gap — retry next tick
+		scoutDecoder.decode(
+			new EncodedVideoChunk({
+				type: c.key ? "key" : "delta",
+				timestamp: c.ctsUs,
+				duration: c.durUs,
+				data: c.data as Uint8Array,
+			}),
+		);
+	}
 }
 
 function dispose(): void {
 	if (disposed) return;
 	disposed = true;
+	for (const c of inflight.values()) c.abort();
+	inflight.clear();
+	gopLoaded.clear();
+	byteBudget?.clear();
 	try {
 		if (decoder && decoder.state !== "closed") decoder.close();
+		if (scoutDecoder && scoutDecoder.state !== "closed") scoutDecoder.close();
 	} catch {
 		/* already closing */
 	}
 	decoder = null;
+	scoutDecoder = null;
 	chunks = [];
+	sampleTable = [];
 	ctx.close();
 }
 
@@ -242,6 +614,9 @@ ctx.onmessage = (e: MessageEvent<ToWorker>) => {
 	switch (msg.type) {
 		case "init":
 			void init(msg.buffer);
+			break;
+		case "init-progressive":
+			void initProgressive(msg.url, msg.sizeBytes);
 			break;
 		case "request":
 			request(msg.originalSec);

--- a/apps/desktop/src/lib/playback/webcodecs-worker.ts
+++ b/apps/desktop/src/lib/playback/webcodecs-worker.ts
@@ -34,6 +34,7 @@ import {
 	needsReset,
 	sampleAtOrBefore,
 } from "./frame-index";
+import { frameBudget } from "./frame-budget";
 import { GopByteBudget } from "./gop-byte-budget";
 import {
 	buildSampleTable,
@@ -44,8 +45,10 @@ import {
 import type { FromWorker, ToWorker } from "./webcodecs-protocol";
 
 /** Samples (decode order) to keep decoded ahead of the playhead. Small so we
- * don't keep many decoder output surfaces checked out (which stalls HW decode). */
-const DECODE_AHEAD = 6;
+ * don't keep many decoder output surfaces checked out (which stalls HW decode).
+ * RESOLUTION-ADAPTIVE: set from `frameBudget` at init so 4K/5K decodes fewer
+ * frames ahead (fewer large surfaces in flight). Defaults to the 1080p value. */
+let decodeAhead = 6;
 /** Cap on the decoder's in-flight queue so we don't overfeed during a burst. */
 const QUEUE_MAX = 4;
 /**
@@ -212,10 +215,13 @@ async function init(ab: ArrayBuffer): Promise<void> {
 			track.movie_timescale > 0
 				? track.movie_duration / track.movie_timescale
 				: 0;
+		const vw = track.video?.width ?? track.track_width;
+		const vh = track.video?.height ?? track.track_height;
+		decodeAhead = frameBudget(vw, vh).decodeAhead;
 		post({
 			type: "ready",
-			width: track.video?.width ?? track.track_width,
-			height: track.video?.height ?? track.track_height,
+			width: vw,
+			height: vh,
 			durationSec,
 			fps: durationSec > 0 ? track.nb_samples / durationSec : 30,
 		});
@@ -408,10 +414,13 @@ async function initProgressive(url: string, sizeBytes: number): Promise<void> {
 
 		const durationSec =
 			vtrack.movie_timescale > 0 ? vtrack.movie_duration / vtrack.movie_timescale : 0;
+		const vw = vtrack.video?.width ?? vtrack.track_width;
+		const vh = vtrack.video?.height ?? vtrack.track_height;
+		decodeAhead = frameBudget(vw, vh).decodeAhead;
 		post({
 			type: "ready",
-			width: vtrack.video?.width ?? vtrack.track_width,
-			height: vtrack.video?.height ?? vtrack.track_height,
+			width: vw,
+			height: vh,
 			durationSec,
 			fps: durationSec > 0 ? vtrack.nb_samples / durationSec : 30,
 		});
@@ -511,7 +520,7 @@ function schedule(target: number): void {
 		scoutAnchorKf = -1;
 		diagResets++;
 	}
-	const end = Math.min(target + DECODE_AHEAD, chunks.length - 1);
+	const end = Math.min(target + decodeAhead, chunks.length - 1);
 	while (feedCursor <= end && decoder.decodeQueueSize < QUEUE_MAX) {
 		const c = chunks[feedCursor];
 		// Progressive: if this GOP's media bytes aren't resident yet, kick off a

--- a/apps/desktop/src/routes/editor/[file]/+page.svelte
+++ b/apps/desktop/src/routes/editor/[file]/+page.svelte
@@ -35,6 +35,8 @@
     type VideoMetadata,
   } from "$lib/stores/editor-store.svelte";
   import { experimentalStore } from "$lib/stores/experimental.svelte";
+  import { AudioTimelineEngine } from "$lib/playback/audio-engine";
+  import { keptRegions } from "$lib/playback/audio-schedule";
   import { originalToOutput, outputToOriginal } from "$lib/timeline/cuts";
   import { gdrive } from "$lib/stores/gdrive.svelte";
   import {
@@ -137,6 +139,13 @@
   let videoSrc = $state("");
   let systemAudioSrc = $state("");
   let micAudioSrc = $state("");
+  // Web Audio timeline engine: sample-accurate, cut-aware audio for the
+  // WebCodecs preview (no seeking → no drift/dropout). Falls back to the
+  // <audio> elements if it can't init/decode. `$state` so creation/failure
+  // re-runs the play effect to switch paths.
+  let audioEngine: AudioTimelineEngine | null = $state(null);
+  let audioEngineTried = false;
+  let audioEngineFailed = $state(false);
   let cursorPath = $state<string | null>(null);
   let cameraPath = $state<string | null>(null);
   let cameraSrc = $state("");
@@ -263,15 +272,33 @@
   // events the old `<video>`-slaving handled late/twice, which is what made audio
   // lag and repeat. Tighter than the visual threshold since audio desync is more
   // audible, but not so tight that per-frame jitter causes constant re-seeks.
+  // Steady-state drift past this hard-seeks audio back onto the playhead. Loose
+  // enough that the ~25Hz publish quantum doesn't cause constant re-seeks.
   const AUDIO_SYNC_THRESHOLD = 0.12;
+  // A cut crossing or a scrub makes the cut-aware playhead jump by far more than
+  // one publish quantum of realtime playback. We detect that and snap audio
+  // EXACTLY on it — which is what keeps audio aligned across cuts of ANY length,
+  // including short ones the drift threshold alone would let slip and accumulate.
+  const AUDIO_JUMP = 0.12;
   let audioSyncRaf: number | null = null;
+  let lastAudioTarget = -1;
   function syncAudioToClock() {
     audioSyncRaf = requestAnimationFrame(syncAudioToClock);
-    if (!store.isPlaying || !webcodecsActive) return;
+    if (!store.isPlaying || !webcodecsActive) {
+      lastAudioTarget = -1;
+      return;
+    }
     const target = store.currentTime;
+    const jumped =
+      lastAudioTarget < 0 || Math.abs(target - lastAudioTarget) > AUDIO_JUMP;
+    lastAudioTarget = target;
     for (const el of [systemAudioEl, micAudioEl]) {
-      if (!el || el.paused) continue;
-      if (Math.abs(el.currentTime - target) > AUDIO_SYNC_THRESHOLD) {
+      // CRITICAL: never stack a seek on an element that's still seeking (e.g.
+      // cold-start buffering) — each new currentTime= interrupts the last, so it
+      // never settles and the audio cuts out entirely. Wait for the current seek.
+      if (!el || el.paused || el.seeking || el.readyState < 2) continue;
+      // Snap exactly on a cut/seek (any length), or when steady drift grows.
+      if (jumped || Math.abs(el.currentTime - target) > AUDIO_SYNC_THRESHOLD) {
         el.currentTime = target;
       }
     }
@@ -286,21 +313,78 @@
     }
   }
   onDestroy(stopAudioClockSync);
+  onDestroy(() => audioEngine?.dispose());
 
-  // Play/pause audio elements in lockstep with the video via the store's
-  // `isPlaying` flag (which is set by PlaybackControls, keyboard handler, etc.).
+  // Kept original-time audio regions (trim minus cuts) and the current OUTPUT
+  // time — what the Web Audio engine schedules against.
+  function audioRegions() {
+    return keptRegions(store.inPoint, store.outPoint, store.effectiveCuts);
+  }
+  function outputNow() {
+    return originalToOutput(store.effectiveCuts, store.currentTime);
+  }
+  // Lazily build the Web Audio engine on first WebCodecs playback. Tried once;
+  // on failure (no Web Audio / nothing decodes) we mark it failed and the
+  // <audio> elements take over.
+  async function ensureAudioEngine() {
+    if (audioEngine || audioEngineTried) return;
+    audioEngineTried = true;
+    if (!systemAudioSrc && !micAudioSrc) {
+      audioEngineFailed = true;
+      return;
+    }
+    try {
+      const eng = await AudioTimelineEngine.create([
+        systemAudioSrc || null,
+        micAudioSrc || null,
+      ]);
+      const s = store.audioSettings;
+      eng.setVolume(s.volume, s.muted);
+      audioEngine = eng;
+    } catch (err) {
+      console.warn("Web Audio engine unavailable; using <audio> fallback:", err);
+      audioEngineFailed = true;
+    }
+  }
+
+  // Play/pause audio in lockstep with the store's `isPlaying`. On the WebCodecs
+  // path we drive the sample-accurate Web Audio engine (which schedules around
+  // cuts — no seeking); the <audio> elements are the fallback / legacy-<video>
+  // path. Reads `audioEngine`/`audioEngineFailed` reactively so creation/failure
+  // re-runs this and switches paths.
   $effect(() => {
     const playing = store.isPlaying;
-    // In the WebCodecs path the clock owns the time; align to it, not to the
-    // free-running <video> element. Read untracked so this effect doesn't re-run
-    // (re-aligning + replaying audio) on every clock tick.
+    const wc = webcodecsActive;
+    const eng = audioEngine;
+    const failed = audioEngineFailed;
+
+    if (wc && !failed) {
+      // Engine owns audio here: keep the <audio> elements and the seek loop off.
+      for (const el of [systemAudioEl, micAudioEl]) el?.pause();
+      stopAudioClockSync();
+      if (playing) {
+        void ensureAudioEngine();
+        if (eng) {
+          void eng.play(
+            untrack(() => audioRegions()),
+            untrack(() => outputNow()),
+          );
+        }
+      } else {
+        eng?.pause();
+      }
+      return;
+    }
+
+    // Fallback (engine failed) or legacy <video> path: slave the <audio>
+    // elements to the playhead, and make sure the engine is silent.
+    audioEngine?.pause();
     const alignTo = untrack(() =>
-      webcodecsActive ? store.currentTime : (videoEl?.currentTime ?? 0),
+      wc ? store.currentTime : (videoEl?.currentTime ?? 0),
     );
     for (const el of [systemAudioEl, micAudioEl]) {
       if (!el) continue;
       if (playing) {
-        // Align audio to the current playhead before resuming.
         el.currentTime = alignTo;
         void el.play().catch((err) => {
           console.warn("Audio play failed:", err);
@@ -309,9 +393,37 @@
         el.pause();
       }
     }
-    // Keep audio locked to the clock while playing on the WebCodecs path.
-    if (playing && webcodecsActive) startAudioClockSync();
+    if (playing && wc) startAudioClockSync();
     else stopAudioClockSync();
+  });
+
+  // Keep the engine locked to the playhead on a SEEK or a cut EDIT while
+  // playing. Cuts don't move OUTPUT time (it's gapless), so normal playback —
+  // including crossing a cut — never reschedules; only a real scrub/loop (output
+  // jump) or a change to the kept regions does. Runs at the publish rate; cheap.
+  const ENGINE_RESEEK_JUMP = 0.15;
+  let engineSyncOut = -1;
+  let lastRegionsKey = "";
+  $effect(() => {
+    const t = store.currentTime;
+    const cuts = store.effectiveCuts;
+    const eng = audioEngine;
+    if (!eng || !webcodecsActive || !store.isPlaying) {
+      engineSyncOut = -1;
+      lastRegionsKey = "";
+      return;
+    }
+    const out = originalToOutput(cuts, t);
+    const regions = keptRegions(store.inPoint, store.outPoint, cuts);
+    const regionsKey = regions
+      .map((r) => `${r.start.toFixed(3)}-${r.end.toFixed(3)}`)
+      .join(",");
+    const jumped =
+      engineSyncOut >= 0 && Math.abs(out - engineSyncOut) > ENGINE_RESEEK_JUMP;
+    const editsChanged = lastRegionsKey !== "" && regionsKey !== lastRegionsKey;
+    engineSyncOut = out;
+    lastRegionsKey = regionsKey;
+    if (jumped || editsChanged) eng.reschedule(regions, out);
   });
 
   // Apply volume/mute from the store's audio settings to both audio elements.
@@ -322,6 +434,7 @@
       : Math.max(0, Math.min(1, settings.volume / 100));
     if (systemAudioEl) systemAudioEl.volume = vol;
     if (micAudioEl) micAudioEl.volume = vol;
+    audioEngine?.setVolume(settings.volume, settings.muted);
   });
 
   // Snap audio to the video's time whenever the user scrubs. WebCodecs path:
@@ -448,6 +561,12 @@
     videoEl?.pause();
     systemAudioEl?.pause();
     micAudioEl?.pause();
+    // Tear down the Web Audio engine for the previous file; it rebuilds for the
+    // new one on first play.
+    audioEngine?.dispose();
+    audioEngine = null;
+    audioEngineTried = false;
+    audioEngineFailed = false;
     store.metadata = null;
     store.reset();
     store.thumbnailStrip = [];


### PR DESCRIPTION

Make the WebCodecs preview engine responsive across cuts and able to
handle multi-GB 4K/5K recordings without exhausting the WebView heap.

Cut/split latency:
- Record with a ~1s keyframe interval (-g) instead of the encoder default
  (~4s GOP), so seeking and crossing a cut re-decode far fewer frames.
  Also speeds up scrubbing and export seeks. (new recordings only)
- Add a scout VideoDecoder that pre-decodes the upcoming post-cut GOP so
  crossing a cut no longer freezes while the primary re-decodes from a
  keyframe. Purely additive: self-disables on error and falls back to the
  primary-only path. Pre-warmed frames live in a protected holdout cache
  so the primary's eviction can't drop them before the cut is reached.

Large files:
- Hybrid ingestion in WebCodecsVideoSource: whole-file below a size
  threshold (unchanged), progressive HTTP-range streaming above it. The
  worker fetches only the moov index, builds the sample byte-map, and
  range-fetches each GOP on demand with an LRU byte budget, reset-on-jump,
  and racing-scrub cancellation. No Rust/IPC changes (asset protocol
  serves Range natively).

Add pure, unit-tested modules (sample-table arithmetic, GOP byte-budget
LRU). Suite 84 -> 100 tests.