### PR TITLE
Refactoring

### DIFF
--- a/.changeset/late-states-write.md
+++ b/.changeset/late-states-write.md
@@ -1,5 +1,0 @@
----
-"recast-desktop": patch
----
-
-Fix camera and microphone permissions not working on macOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,21 @@ See [`.changeset/README.md`](.changeset/README.md) for the full flow.
 `pnpm release:prepare <version>` consumes pending changesets and the current
 `[Unreleased]` block into a new dated section.
 
+## [Unreleased]
+
+## [0.2.8] — 2026-06-28
+
+### Highlights
+- **Camera and microphone work on macOS again** — fixed a permissions problem that stopped macOS from capturing your camera and mic.
+
+### Changed
+- Tightened copy across the desktop app and website. Removed em dashes and over-explanation from settings, experimental-feature, and editor-panel descriptions, and from a few marketing sections, so the text says what a feature does without explaining how it works internally.
+
+### Fixed
+- Website build no longer fails during prerender. A leftover static `robots.txt` was shadowing the dynamic `/robots.txt` route, so the route was never prerendered and the build errored out. The static file is gone; `/robots.txt` and `/sitemap.xml` now come from their routes.
+- Corrected the Loom and Cap comparison on the Features page. Dropped a "pause and resume is paid in Loom" row (it is free), changed Cap's "share to your own storage" from "Not supported" to "Pro only" (Cap Pro supports custom S3 and Google Drive), and relabelled per-seat pricing.
+- Fix camera and microphone permissions not working on macOS
+
 ## [0.2.7] — 2026-06-28
 
 ### Highlights

--- a/apps/desktop/src/components/FirstRunConsent.svelte
+++ b/apps/desktop/src/components/FirstRunConsent.svelte
@@ -16,7 +16,7 @@
 		desktopConsent.setProduct(product);
 		desktopConsent.setErrors(errors);
 		desktopConsent.markFirstRunSeen();
-		// Apply to the live analytics client (inits / opts-in / opts-out as needed).
+		// Inits / opts-in / opts-out the live analytics client as needed.
 		syncConsent();
 		onclose();
 	}

--- a/apps/desktop/src/components/common/LazyExternalImage.svelte
+++ b/apps/desktop/src/components/common/LazyExternalImage.svelte
@@ -61,10 +61,8 @@
     };
   });
 
-  // Read the pre-converted URL straight from the store so we never call
-  // `convertFileSrc` here — that conversion happens once at `setPath` time.
-  // URL identity is stable across re-renders, which is what stops `<img>`
-  // elements from re-decoding when surrounding state churns.
+  // Pre-converted at setPath time (not here): stable URL identity keeps <img>
+  // from re-decoding when surrounding state churns.
   const fullUrl = $derived(assetsStore.urls[assetId]);
   const thumbUrl = $derived(assetsStore.thumbUrls[assetId]);
   const src = $derived.by(() => {
@@ -74,11 +72,9 @@
   });
   const showOfflineBadge = $derived(!src && !online);
 
-  // When `src` actually changes (initial mount, or thumb→full upgrade), check
-  // whether the rendered <img> is already complete from the WebView image
-  // cache. If yes, promote `loaded` synchronously — `onload` does not refire
-  // for an image that arrived already-decoded, which is the failure mode that
-  // produced the persistent skeleton flicker on tab return.
+  // On src change, promote `loaded` if the <img> is already cache-complete:
+  // `onload` doesn't refire for an already-decoded image (caused skeleton
+  // flicker on tab return).
   $effect(() => {
     if (src === lastSrc) return;
     lastSrc = src;

--- a/apps/desktop/src/components/corner-notifications.svelte
+++ b/apps/desktop/src/components/corner-notifications.svelte
@@ -63,9 +63,7 @@
     }
   }
 
-  // Phase → human label for the Recast Cloud share card. The upload runs
-  // export → upload → finalize → share; only the cloud-side phases surface
-  // here (the export phase has its own progress UI).
+  // Only the cloud-side phases surface here; export has its own progress UI.
   function cloudPhaseLabel(phase: string) {
     switch (phase) {
       case "preparing":
@@ -82,9 +80,7 @@
   }
 </script>
 
-<!-- Non-blocking notification stack pinned to the bottom-right corner. Hosts
-     the auto-updater card and the "what's new" card; both stay out of the way
-     and never trap focus or block the view. -->
+<!-- Non-blocking notification stack, bottom-right; never traps focus. -->
 <div
   class="pointer-events-none fixed bottom-4 right-4 z-50 flex w-[320px] flex-col gap-2"
 >
@@ -192,9 +188,7 @@
     </div>
   {/if}
 
-  <!-- Google Drive upload stack — one card per in-flight or recently
-       completed upload. Dismiss removes the card; cancel signals the Rust
-       side to abort an upload still in flight. -->
+  <!-- Google Drive uploads — one card each; cancel aborts an in-flight upload. -->
   {#each gdrive.activeUploads as upload (upload.uploadId)}
     {@const up = upload}
     <div
@@ -287,9 +281,7 @@
     </div>
   {/each}
 
-  <!-- Recast Cloud share stack — one card per in-flight or completed share.
-       The upload PUT shows a determinate byte-% bar; the instantaneous phases
-       (preparing/finalizing/sharing) fall back to an indeterminate pulse. -->
+  <!-- Recast Cloud shares — one card each; PUT shows byte-%, other phases pulse. -->
   {#each cloudShare.activeUploads as up (up.sourcePath)}
     <div
       class="pointer-events-auto overflow-hidden rounded-xl border border-border bg-card shadow-lg ring-1 ring-black/5"
@@ -340,7 +332,6 @@
       {#if up.status === "uploading"}
         <div class="px-4 pb-3">
           {#if up.phase === "uploading" && up.totalBytes > 0}
-            <!-- Determinate bar while the file PUT streams (byte progress). -->
             <div class="h-1 overflow-hidden rounded-full bg-muted">
               <div
                 class="h-full rounded-full bg-primary transition-[width] duration-200"
@@ -353,8 +344,6 @@
               </span>
             </div>
           {:else}
-            <!-- Instantaneous phases (preparing/finalizing/sharing) have no byte
-                 count, so keep an indeterminate pulse. -->
             <div class="h-1 overflow-hidden rounded-full bg-muted">
               <div class="h-full w-1/3 animate-pulse rounded-full bg-primary"></div>
             </div>

--- a/apps/desktop/src/components/editor/EditorToolbar.svelte
+++ b/apps/desktop/src/components/editor/EditorToolbar.svelte
@@ -47,9 +47,6 @@
     onToggleTimeline,
   }: Props = $props();
 
-  // Segmented panel-toggle button styling, mirroring the undo/redo group:
-  // an "on" toggle reads as a pressed key (raised card surface), "off" sits
-  // flush and muted. Kept as one helper so both toggles stay identical.
   const toggleClass = (active: boolean) =>
     cn(
       "cursor-pointer flex size-6 items-center justify-center rounded-md transition-colors duration-150",
@@ -60,8 +57,7 @@
   let showPresetsPicker = $state(false);
   let showRevertConfirm = $state(false);
 
-  // Mod+P (export presets) is dispatched by the central shortcut registry —
-  // no per-component `window` listener to leak under HMR.
+  // Mod+P via the central shortcut registry — avoids a per-component window listener leaking under HMR.
   onMount(() =>
     registerShortcutHandlers({
       "editor.presets": () => {
@@ -79,9 +75,7 @@
     store.padding = preset.padding;
     store.backgroundBlur = preset.blur;
     if (preset.layout) store.layoutMode = preset.layout;
-    // Map the preset's aspect string onto the store's OutputAspect. Anything
-    // we don't recognise (e.g. "Source") falls back to the source-matched
-    // canvas, the v1 default.
+    // Unrecognised aspects (e.g. "Source") fall back to the source-matched canvas.
     const aspectMap: Record<
       string,
       import("$lib/stores/editor-store.svelte").OutputAspect
@@ -92,16 +86,11 @@
       "1.91:1": "1.91:1",
     };
     store.outputAspect = aspectMap[preset.aspect] ?? "source";
-    // Remember which preset was applied so the toolbar can surface it as
-    // a chip — purely a UI affordance; the visual effects above are what
-    // actually drive the renderer.
+    // UI-only: lets the toolbar surface the applied preset as a chip.
     store.lastAppliedPresetId = preset.id;
   }
 
-  // Drop the active preset back to the source-matched canvas without
-  // touching background / padding / blur — leaves the user's tweaks alone
-  // but removes any letterbox bars. Visual mirror of `applyPreset` so undo
-  // collapses the whole gesture into a single stack entry.
+  // Reset to source aspect (removes letterbox bars) without touching background/padding/blur.
   function clearPreset() {
     if (
       store.outputAspect === "source" &&
@@ -114,9 +103,7 @@
     store.lastAppliedPresetId = null;
   }
 
-  // Resolve the chip label from the persisted preset id. If the id no
-  // longer exists in PRESETS (e.g. removed across versions) we fall back
-  // to the raw aspect string so users still see something useful.
+  // null if the persisted id no longer exists in PRESETS (removed across versions).
   const activePreset = $derived.by(() => {
     const id = store.lastAppliedPresetId;
     if (!id) return null;
@@ -133,7 +120,6 @@
   class="flex h-full w-full items-center gap-1.5 px-2 text-[11px]"
   data-tauri-drag-region
 >
-  <!-- Left: back + filename -->
   <div class="flex items-center gap-0.5">
     <Tooltip.Root>
       <Tooltip.Trigger>
@@ -162,7 +148,6 @@
     ></span>
   {/if}
 
-  <!-- Center: presets + undo/redo -->
   <div class="mx-auto flex items-center gap-1.5" data-tauri-drag-region>
     <Tooltip.Root>
       <Tooltip.Trigger>
@@ -180,9 +165,6 @@
       <Tooltip.Content>Browse social & studio presets</Tooltip.Content>
     </Tooltip.Root>
 
-    <!-- Active-preset chip. Only renders when a preset has been applied
-         (per-project state). Click the body to re-open the picker; click
-         the trailing × to drop back to source aspect. -->
     {#if activePreset || store.outputAspect !== "source"}
       <div
         class="flex h-6 items-center gap-1 rounded-md border border-primary/30 bg-primary/10 pl-1.5 pr-0.5 text-[11px] font-semibold text-primary"
@@ -276,11 +258,7 @@
     </div>
   </div>
 
-  <!-- Right: layout toggles + revert + save + export -->
   <div class="ml-auto flex items-center gap-1">
-    <!-- Panel toggles (VS Code / Cursor style): show/hide the timeline and
-         the right properties panel. Grouped as a segmented control so they
-         read as a pair of view switches, distinct from the action buttons. -->
     <div
       class="flex items-center gap-0.5 rounded-lg bg-muted/60 p-0.5 ring-1 ring-inset ring-border/40"
     >

--- a/apps/desktop/src/components/editor/ExportDialog.svelte
+++ b/apps/desktop/src/components/editor/ExportDialog.svelte
@@ -51,8 +51,7 @@
     { value: "source", label: "Source", desc: "Original resolution" },
   ];
 
-  // Encoder effort — orthogonal to resolution. Same visual quality target;
-  // trades encode time against file size. "Balanced" is the historical default.
+  // Encoder effort — orthogonal to resolution; trades encode time for file size.
   const speeds: { value: ExportSpeed; label: string; desc: string }[] = [
     { value: "fast", label: "Fast", desc: "Quicker · larger" },
     { value: "balanced", label: "Balanced", desc: "Recommended" },
@@ -89,11 +88,9 @@
     store.exportFps = v;
   }
 
-  // Frame-rate options derived from the SOURCE recording. We only ever offer
-  // the source rate (default, preserves the original) plus standard lower rates
-  // — never higher, since duplicating frames adds size without smoothness. If
-  // the user's stored choice exceeds the current source (e.g. a different clip),
-  // it falls back to Original at export via the Rust-side clamp.
+  // Source rate plus standard lower rates only — never higher (duplicating
+  // frames adds size without smoothness). A stored choice above the current
+  // source falls back to Original via the Rust-side clamp.
   const sourceFps = $derived(Math.max(1, Math.round(store.metadata?.fps ?? 60)));
   const fpsOptions = $derived([
     { value: null as number | null, label: "Original", desc: `${sourceFps} fps` },
@@ -105,8 +102,7 @@
         desc: f === 24 ? "Cinematic" : "Smaller file",
       })),
   ]);
-  // Only worth showing when there's an actual choice (source > 24). Uses the
-  // store directly rather than `isGif` (declared further down) to avoid a
+  // Reads the store directly rather than `isGif` (declared below) to avoid a
   // use-before-declaration.
   const showFps = $derived(
     store.exportFormat !== "gif" && fpsOptions.length > 1,
@@ -118,12 +114,9 @@
   );
   const clipDuration = $derived(Math.max(0, clipEnd - store.trimStart));
   const sourceDuration = $derived(store.metadata?.duration ?? 0);
-  // Time removed by cuts (manual deletes + accepted silence) that fall inside
-  // the trim — clamped to the trim window and merged so overlaps don't double
-  // count. Mirrors the Rust export's collect_export_cuts.
+  // Cut time inside the trim window, clamped and merged. Mirrors the Rust
+  // export's collect_export_cuts. `effectiveCuts` already drops opted-off cuts.
   const removedDuration = $derived.by(() => {
-    // `effectiveCuts` already drops cuts whose feature is opted off, so the
-    // figure matches exactly what the export pipeline will remove.
     if (store.effectiveCuts.length === 0) return 0;
     const clamped = store.effectiveCuts
       .map((c) => ({
@@ -134,7 +127,6 @@
       .filter((c) => c.end > c.start);
     return totalCutDuration(clamped);
   });
-  // The actual exported length: trimmed clip minus the cuts inside it.
   const outputDuration = $derived(Math.max(0, clipDuration - removedDuration));
   const hasTrim = $derived(
     store.trimStart > 0 ||
@@ -151,11 +143,8 @@
     ditherModes.find((d) => d.value === store.gifSettings.dither),
   );
 
-  // The body lays its option sections out in two columns on roomy viewports
-  // (wider, not taller) and collapses to a single stacked column when there
-  // isn't space. The flow-dialog wrapper observes the width/height this body
-  // reports and morphs its chrome to match — so we just declare the target
-  // width here; the growth is the wrapper's morph.
+  // Two columns on roomy viewports, single stacked column when tight. The
+  // flow-dialog wrapper morphs its chrome to the width this body reports.
   let viewportWidth = $state(
     typeof window !== "undefined" ? window.innerWidth : 1280,
   );
@@ -521,10 +510,8 @@
 {/snippet}
 
 {#snippet fpsSection()}
-  <!-- Frame rate: output fps for MP4/WebM. Defaults to Original (the source
-       rate) so exports keep the recording's smoothness; lower rates shrink
-       the file. Hidden for GIF (its own fps control) and when the source is
-       already ≤24 fps (no meaningful choice). -->
+  <!-- Output fps for MP4/WebM. Hidden for GIF (own fps control) and when the
+       source is already ≤24 fps (no meaningful choice). -->
   <section
     in:fly={{ y: 8, duration: 240, delay: 185, easing: cubicOut }}
     class="flex flex-col gap-2.5"
@@ -575,8 +562,7 @@
 {/snippet}
 
 {#snippet speedSection()}
-  <!-- Speed: encoder effort. Hidden for GIF, which uses a palette 2-pass
-       and ignores these codec preset knobs entirely. -->
+  <!-- Hidden for GIF, which uses a palette 2-pass and ignores codec presets. -->
   <section
     in:fly={{ y: 8, duration: 240, delay: 200, easing: cubicOut }}
     class="flex flex-col gap-2.5"
@@ -645,7 +631,6 @@
     </div>
   </header>
 
-  <!-- Stat strip — full width across the top, above the option columns. -->
   <section
     in:fly={{ y: 8, duration: 240, delay: 70, easing: cubicOut }}
     class="flex items-stretch divide-x divide-border/40 border-b border-border/40 bg-muted/15 px-5 py-2.5"
@@ -718,11 +703,8 @@
       {/if}
     </div>
   {:else}
-    <!-- Roomy viewports: two columns so the dialog grows wider, not taller.
-         Left = what & resolution (Format, Quality); right = motion & effort
-         (Frame rate, Speed) — or the GIF panel, which replaces the codec
-         knobs GIF doesn't use. items-start keeps each section top-aligned so
-         the shorter column doesn't stretch its cards. -->
+    <!-- Two columns: left = Format/Quality, right = Frame rate/Speed (or the
+         GIF panel, which replaces the codec knobs GIF doesn't use). -->
     <div class="grid grid-cols-2 items-start gap-x-6 gap-y-5 px-5 py-5">
       <div class="flex min-w-0 flex-col gap-5">
         {@render formatSection()}

--- a/apps/desktop/src/components/editor/ExportDialog.svelte
+++ b/apps/desktop/src/components/editor/ExportDialog.svelte
@@ -8,6 +8,7 @@
     GifQuality,
   } from "$lib/stores/editor-store.svelte";
   import { totalCutDuration } from "$lib/timeline/cuts";
+  import { clockCentis as formatTime } from "$lib/format/time";
   import {
     Check,
     Circle,
@@ -111,13 +112,6 @@
     store.exportFormat !== "gif" && fpsOptions.length > 1,
   );
 
-  function formatTime(seconds: number) {
-    if (!Number.isFinite(seconds) || seconds <= 0) return "0:00.00";
-    const mins = Math.floor(seconds / 60);
-    const secs = Math.floor(seconds % 60);
-    const cs = Math.floor((seconds % 1) * 100);
-    return `${mins}:${secs.toString().padStart(2, "0")}.${cs.toString().padStart(2, "0")}`;
-  }
 
   const clipEnd = $derived(
     store.trimEnd > 0 ? store.trimEnd : (store.metadata?.duration ?? 0),

--- a/apps/desktop/src/components/editor/ExportFlowDialog.svelte
+++ b/apps/desktop/src/components/editor/ExportFlowDialog.svelte
@@ -37,10 +37,8 @@
     error,
   }: Props = $props();
 
-  // Body is sized intrinsically; the outer dialog Tweens its width + height to
-  // match what the body reports via ResizeObserver. This way each phase body
-  // declares its natural size and the wrapper just follows — no per-phase
-  // hardcoded dimensions that drift as the bodies evolve.
+  // Outer dialog Tweens its size to whatever the body reports via ResizeObserver,
+  // so each phase declares its natural size and the wrapper follows.
   let bodyEl = $state<HTMLDivElement | null>(null);
   let measuredW = $state(440);
   let measuredH = $state(0);
@@ -48,8 +46,7 @@
   const wTween = new Tween(440, { duration: 320, easing: cubicOut });
   const hTween = new Tween(0, { duration: 320, easing: cubicOut });
 
-  // Track first measurement per open-cycle so we can snap to the initial size
-  // instead of growing from zero (which would fight the scale-in entrance).
+  // Snap to the first measured size per open-cycle instead of growing from zero (which fights the scale-in).
   let snapNext = $state(true);
   $effect(() => {
     if (!open) snapNext = true;
@@ -89,8 +86,7 @@
     }
   });
 
-  // Re-focus on phase change so screen-readers re-announce + keyboard focus
-  // stays inside the dialog as content swaps under the user.
+  // Re-focus on phase change so screen-readers re-announce and focus stays in the dialog.
   $effect(() => {
     phase;
     if (open) tick().then(() => dialogRef?.focus());
@@ -115,10 +111,7 @@
     };
   }
 
-  // Custom out-transition that absolute-positions the leaving phase so it
-  // doesn't keep pushing the body's measured size while it fades. The new
-  // phase mounts in normal flow → ResizeObserver picks up its natural size
-  // → Tween animates the wrapper to match concurrent with the fade.
+  // Absolute-position the leaving phase so it stops pushing the body's measured size while it fades out.
   function phaseOut(node: HTMLElement) {
     const parent = node.parentElement;
     if (parent) {
@@ -160,12 +153,7 @@
       style="width: {wTween.current}px; height: {hTween.current || measuredH || 0}px; max-width: min(820px, calc(100vw - 2rem)); max-height: calc(100vh - 4rem);"
       class="relative flex flex-col overflow-hidden rounded-2xl border border-border/60 bg-popover/95 shadow-2xl ring-1 ring-border/40 backdrop-blur-xl focus:outline-none"
     >
-      <!--
-        Body wrap is `position: relative` so the leaving phase can pin itself
-        with `position: absolute` during its fade-out. The active phase sits
-        in normal flow; ResizeObserver measures its natural size and the
-        wrapper morphs to match.
-      -->
+      <!-- relative so the leaving phase can pin itself absolute during fade-out -->
       <div bind:this={bodyEl} class="relative w-fit min-w-[280px]">
         {#key phase}
           <div

--- a/apps/desktop/src/components/editor/PresetPicker.svelte
+++ b/apps/desktop/src/components/editor/PresetPicker.svelte
@@ -256,8 +256,12 @@
   import {
     aspectClass,
     bgPreviewStyle,
+    buildModel,
+    clampIndex,
+    filterPresets,
     frameInsetPct,
-    score,
+    groupPresets,
+    rowMoveIndex,
     wallpaperId,
   } from "./preset-picker.logic";
   import {
@@ -300,54 +304,9 @@
     currentId ? (PRESETS.find((p) => p.id === currentId) ?? null) : null,
   );
 
-  const filtered = $derived(
-    PRESETS.map((p) => ({ p, s: score(p, query) }))
-      .filter((x) => x.s > 0)
-      .sort((a, b) => b.s - a.s)
-      .map((x) => x.p),
-  );
-
-  const grouped = $derived.by<[string, Preset[]][]>(() => {
-    if (query.trim()) return [["Results", filtered]];
-    const map = new Map<string, Preset[]>();
-    for (const p of filtered) {
-      if (!map.has(p.category)) map.set(p.category, []);
-      map.get(p.category)!.push(p);
-    }
-    const entries = [...map.entries()];
-    // Pin the currently-applied preset to the top for instant re-apply.
-    if (currentPreset) entries.unshift(["Current", [currentPreset]]);
-    return entries;
-  });
-
-  type Cell = { preset: Preset; index: number };
-  type Group = { category: string; rows: Cell[][] };
-
-  // Layout model: each category chunked into rows of COLS, with an explicit
-  // running `index` per cell. Indices are unique even though the pinned
-  // "Current" preset also appears in its own category — so we never rely on
-  // indexOf (which would collide on the duplicate).
-  const model = $derived.by(() => {
-    const groups: Group[] = [];
-    const flat: Preset[] = [];
-    const rows: Cell[][] = [];
-    let counter = 0;
-    for (const [category, items] of grouped) {
-      const groupRows: Cell[][] = [];
-      for (let i = 0; i < items.length; i += COLS) {
-        const cells: Cell[] = [];
-        for (let j = i; j < Math.min(i + COLS, items.length); j++) {
-          const cell = { preset: items[j], index: counter++ };
-          cells.push(cell);
-          flat.push(items[j]);
-        }
-        groupRows.push(cells);
-        rows.push(cells);
-      }
-      groups.push({ category, rows: groupRows });
-    }
-    return { groups, flat, rows };
-  });
+  const filtered = $derived(filterPresets(PRESETS, query));
+  const grouped = $derived(groupPresets(filtered, query, currentPreset));
+  const model = $derived(buildModel(grouped, COLS));
 
   $effect(() => {
     if (open) {
@@ -373,31 +332,17 @@
     close();
   }
 
-  // Find the [rowPos, col] of the current cursor within the global row list.
-  function locate(index: number): [number, number] {
-    for (let r = 0; r < model.rows.length; r++) {
-      const c = model.rows[r].findIndex((cell) => cell.index === index);
-      if (c !== -1) return [r, c];
-    }
-    return [0, 0];
-  }
-
   // Vertical move: jump a whole row, preserving the column (clamped when the
-  // target row is shorter). This is the fix for the old behaviour where Down
-  // walked DOM order and slid sideways.
+  // target row is shorter) — see `rowMoveIndex`. No-op at the top/bottom edge.
   function moveRow(dir: 1 | -1) {
-    const [row, col] = locate(selectedIndex);
-    const target = model.rows[row + dir];
-    if (!target) return;
-    selectedIndex = target[Math.min(col, target.length - 1)].index;
+    const next = rowMoveIndex(model, selectedIndex, dir);
+    if (next === null) return;
+    selectedIndex = next;
     scrollSelectedIntoView();
   }
 
   function moveCol(delta: 1 | -1) {
-    selectedIndex = Math.max(
-      0,
-      Math.min(model.flat.length - 1, selectedIndex + delta),
-    );
+    selectedIndex = clampIndex(selectedIndex + delta, model.flat.length);
     scrollSelectedIntoView();
   }
 

--- a/apps/desktop/src/components/editor/PresetPicker.svelte
+++ b/apps/desktop/src/components/editor/PresetPicker.svelte
@@ -254,6 +254,13 @@
 <script lang="ts">
   import LazyExternalImage from "$components/common/LazyExternalImage.svelte";
   import {
+    aspectClass,
+    bgPreviewStyle,
+    frameInsetPct,
+    score,
+    wallpaperId,
+  } from "./preset-picker.logic";
+  import {
     Briefcase,
     Camera,
     Check,
@@ -292,21 +299,6 @@
   const currentPreset = $derived(
     currentId ? (PRESETS.find((p) => p.id === currentId) ?? null) : null,
   );
-
-  function score(p: Preset, q: string): number {
-    if (!q) return 1;
-    const n = q.toLowerCase();
-    const label = p.label.toLowerCase();
-    const cat = p.category.toLowerCase();
-    if (label.startsWith(n)) return 100;
-    if (cat.startsWith(n)) return 90;
-    if (label.includes(n)) return 80;
-    if (cat.includes(n)) return 60;
-    if ((p.description ?? "").toLowerCase().includes(n)) return 40;
-    if ((p.keywords ?? []).some((k) => k.toLowerCase().includes(n))) return 30;
-    if (p.aspect.toLowerCase().includes(n)) return 20;
-    return 0;
-  }
 
   const filtered = $derived(
     PRESETS.map((p) => ({ p, s: score(p, query) }))
@@ -461,40 +453,6 @@
       );
       el?.scrollIntoView({ block: "nearest" });
     });
-  }
-
-  function bgPreviewStyle(p: Preset): string {
-    if ((p.bg === "gradient" || p.bg === "color") && p.value)
-      return `background:${p.value}`;
-    return "background:var(--color-muted)";
-  }
-
-  // WYSIWYG-ish frame inset. `padding` is a percent of the shorter source edge
-  // and the canvas is source+padding on each side, so the video occupies
-  // 1/(1+2p) of that edge — mirror that here so the thumbnail frames like the
-  // real export.
-  function frameInsetPct(padding: number): number {
-    const p = Math.max(0, padding) / 100;
-    return Math.min(20, (p / (1 + 2 * p)) * 100);
-  }
-
-  function wallpaperId(p: Preset): string {
-    return (p.value ?? "").replace(/^asset:\/\/?/, "").replace(/^asset:/, "");
-  }
-
-  function aspectClass(aspect: string): string {
-    switch (aspect) {
-      case "1:1":
-        return "aspect-square";
-      case "9:16":
-        return "aspect-[9/16]";
-      case "16:9":
-        return "aspect-video";
-      case "1.91:1":
-        return "aspect-[1.91/1]";
-      default:
-        return "aspect-video";
-    }
   }
 
   function categoryIcon(category: string): typeof Sparkles {

--- a/apps/desktop/src/components/editor/SilenceReviewPopover.svelte
+++ b/apps/desktop/src/components/editor/SilenceReviewPopover.svelte
@@ -1,15 +1,22 @@
 <script lang="ts">
-  import {
-    detectSilence,
-    type SilenceDetectOptions,
-    type SilenceSegment,
-  } from "$lib/ipc";
+  import { detectSilence, type SilenceSegment } from "$lib/ipc";
   import type { EditorStore } from "$lib/stores/editor-store.svelte";
   import { overlapsAny } from "$lib/timeline/cuts";
   import {
     clockDecis as formatTime,
     compactDuration as formatDuration,
   } from "$lib/format/time";
+  import {
+    BULK_MIN_CONFIDENCE,
+    confidenceBarClass,
+    confidenceLabel,
+    confidenceTextClass,
+    cutBounds,
+    parseSensitivity,
+    SENSITIVITY_OPTIONS,
+    SENSITIVITY_PRESETS,
+    type Sensitivity,
+  } from "./silence-review.logic";
   import {
     AlertTriangle,
     Check,
@@ -32,48 +39,17 @@
 
   let { store, onclose }: Props = $props();
 
-  // A small margin kept at each end of a cut so speech onsets/tails right
-  // beside the silence are never clipped.
-  const CUT_PADDING = 0.12;
-  // Bulk "Cut all" only takes confident suggestions — uncertain ones are
-  // left for the user to judge individually.
-  const BULK_MIN_CONFIDENCE = 0.5;
-
-  // Detection sensitivity. "Balanced" uses the Rust-side defaults; the other
-  // two trade recall against false positives. Persisted across sessions.
-  type Sensitivity = "relaxed" | "balanced" | "aggressive";
+  // Persisted across sessions (presets/options live in silence-review.logic).
   const SENSITIVITY_KEY = "recast-silence-sensitivity";
-  const PRESETS: Record<Sensitivity, SilenceDetectOptions> = {
-    relaxed: {
-      flatnessDb: 3,
-      minAudioSilence: 1,
-      minSegment: 1.5,
-    },
-    balanced: {},
-    aggressive: {
-      flatnessDb: 8,
-      minAudioSilence: 0.4,
-      minSegment: 0.6,
-    },
-  };
-  const SENSITIVITY_OPTIONS: Array<{ id: Sensitivity; label: string }> = [
-    { id: "relaxed", label: "Relaxed" },
-    { id: "balanced", label: "Balanced" },
-    { id: "aggressive", label: "Aggressive" },
-  ];
 
-  function loadSensitivity(): Sensitivity {
-    const v = safeStorage.get<string>(SENSITIVITY_KEY, "");
-    return v === "relaxed" || v === "aggressive" ? v : "balanced";
-  }
-
-  let sensitivity = $state<Sensitivity>(loadSensitivity());
+  let sensitivity = $state<Sensitivity>(
+    parseSensitivity(safeStorage.get<string>(SENSITIVITY_KEY, "")),
+  );
 
   function setSensitivity(next: Sensitivity) {
     if (next === sensitivity) return;
     sensitivity = next;
     safeStorage.set(SENSITIVITY_KEY, next);
-    // The load effect re-runs because it reads `sensitivity`.
   }
 
   type Status = "idle" | "loading" | "ready" | "error" | "empty";
@@ -82,7 +58,7 @@
   // Suggestions the user hasn't yet cut or dismissed.
   let pending = $state<SilenceSegment[]>([]);
 
-  // Re-runs whenever `sensitivity` changes (it is read below).
+  // Re-runs whenever `sensitivity` changes.
   $effect(() => {
     void sensitivity;
     void loadSuggestions();
@@ -101,7 +77,7 @@
         store.audioPath,
         store.microphonePath,
         store.cursorPath,
-        PRESETS[sensitivity],
+        SENSITIVITY_PRESETS[sensitivity],
       );
       // Drop anything already removed by a cut, or previously dismissed,
       // then surface the strongest candidates first.
@@ -133,35 +109,15 @@
     return overlapsAny(blockers, seg.start, seg.end);
   }
 
-  function confidenceLabel(c: number): string {
-    if (c >= 0.66) return "Strong";
-    if (c >= 0.4) return "Likely";
-    return "Uncertain";
-  }
-
-  function confidenceTextClass(c: number): string {
-    if (c >= 0.66) return "text-success";
-    if (c >= 0.4) return "text-warning";
-    return "text-muted-foreground";
-  }
-
-  function confidenceBarClass(c: number): string {
-    if (c >= 0.66) return "bg-success";
-    if (c >= 0.4) return "bg-warning";
-    return "bg-muted-foreground/60";
-  }
-
   function previewAt(seg: SilenceSegment) {
     store.currentTime = seg.start;
   }
 
   /** Apply the keep-margin and commit a cut. Returns true if a cut landed. */
   function commitCut(seg: SilenceSegment): boolean {
-    const pad = Math.min(CUT_PADDING, (seg.end - seg.start) / 3);
-    const start = seg.start + pad;
-    const end = seg.end - pad;
-    if (end - start < 0.2) return false;
-    return store.addCut(start, end, "silence") !== null;
+    const b = cutBounds(seg.start, seg.end);
+    if (!b) return false;
+    return store.addCut(b.start, b.end, "silence") !== null;
   }
 
   function cut(seg: SilenceSegment) {
@@ -196,9 +152,7 @@
     status = "empty";
   }
 
-  // Reverts the user's accumulated "dismiss" decisions for this project so
-  // previously-rejected suggestions can be re-surfaced. Re-runs detection
-  // immediately so the popover repopulates without a manual click.
+  // Clear dismissed decisions and re-scan so rejected suggestions re-surface.
   function resetDismissedAndRescan() {
     store.clearDismissedSilences();
     void loadSuggestions();

--- a/apps/desktop/src/components/editor/SilenceReviewPopover.svelte
+++ b/apps/desktop/src/components/editor/SilenceReviewPopover.svelte
@@ -7,6 +7,10 @@
   import type { EditorStore } from "$lib/stores/editor-store.svelte";
   import { overlapsAny } from "$lib/timeline/cuts";
   import {
+    clockDecis as formatTime,
+    compactDuration as formatDuration,
+  } from "$lib/format/time";
+  import {
     AlertTriangle,
     Check,
     Eye,
@@ -116,15 +120,6 @@
     }
   }
 
-  function formatTime(s: number): string {
-    const m = Math.floor(s / 60);
-    const rem = s - m * 60;
-    return `${m}:${rem.toFixed(1).padStart(4, "0")}`;
-  }
-
-  function formatDuration(s: number): string {
-    return s >= 1 ? `${s.toFixed(1)}s` : `${Math.round(s * 1000)}ms`;
-  }
 
   // Zoom regions and annotations a cut must not bisect — splitting one would
   // need overlay-time surgery the MVP intentionally avoids.

--- a/apps/desktop/src/components/editor/Timeline.svelte
+++ b/apps/desktop/src/components/editor/Timeline.svelte
@@ -23,10 +23,8 @@
   } from "./_components/timeline/timeline-helpers";
   import { originalToOutput, outputToOriginal } from "$lib/timeline/cuts";
 
-  // Orchestrator. Owns the scroll container, sizing, transport state
-  // (JKL/playback speed), keyboard routing, and the click-to-seek scrubber.
-  // Visual subviews (toolbar, ruler, clip bar, zoom lane, playhead) live
-  // under `_components/timeline/` and receive only the data they render.
+  // Orchestrator: owns the scroll container, sizing, transport (JKL/speed),
+  // keyboard routing, and the click-to-seek scrubber. Subviews live under `_components/timeline/`.
 
   interface Props {
     store: EditorStore;
@@ -42,16 +40,11 @@
   const SPEEDS = [0.25, 0.5, 1.0, 1.5, 2.0] as const;
   let playbackSpeed = $state(1.0);
 
-  // Time-display mode. Cycles smpte → seconds → frames; affects every
-  // user-visible label (toolbar chip, playhead pill, trim tooltips, card
-  // subtitles). Lives in the orchestrator so a single click flips the
-  // entire timeline at once.
+  // Lives in the orchestrator so one click flips every timeline label at once.
   let timeMode = $state<TimeMode>("smpte");
 
-  // JKL transport: cycles 1×→2×→4× on each consecutive press, like Avid /
-  // Premiere. K parks playback. We don't drive reverse playback through
-  // <video>'s playbackRate (browsers don't support negative rates reliably);
-  // J instead schedules a rAF loop that decrements currentTime.
+  // JKL transport (Avid/Premiere): consecutive L/J cycles 1×→2×→4×, K parks.
+  // J drives reverse via a rAF loop (browsers don't reliably support negative playbackRate).
   let shuttleDirection = $state<-1 | 0 | 1>(0);
   let shuttleSpeedIndex = $state(0);
   const SHUTTLE_SPEEDS = [1, 2, 4];
@@ -95,10 +88,8 @@
     }
   });
 
-  // Quantization: all trim and playhead writes round to the nearest frame
-  // boundary so preview and export agree on which exact frame is the
-  // first/last kept frame. Sub-frame trim values are the source of off-by-one
-  // mismatches between scrub preview and the rendered MP4.
+  // Trim/playhead writes round to the nearest frame so preview and export agree
+  // on the first/last kept frame; sub-frame values cause off-by-one mismatches.
   function effectiveFps(): number {
     return effFps(store.metadata?.fps);
   }
@@ -119,10 +110,7 @@
     );
   }
 
-  // Zoom so the entire clip fills the visible viewport, then scroll back
-  // to the head. timelineZoom=1 means "duration spans timelineWidth", so
-  // fit is just `1.0` modulo the rare case where the user has dragged the
-  // panel narrower than the rendered clip.
+  // timelineZoom=1 means "duration spans timelineWidth", so fit is just 1.0.
   function zoomToFit() {
     store.timelineZoom = 1;
     requestAnimationFrame(() => {
@@ -130,9 +118,7 @@
     });
   }
 
-  // Zoom so the selected region fills ~70% of the viewport and centers
-  // it horizontally. `0.7` leaves visual breathing room on both sides so
-  // neighbouring context isn't lost the moment the user clicks the icon.
+  // Selected region fills ~70% of the viewport (0.7 leaves context on both sides).
   function zoomToSelection() {
     if (!timelineEl || duration <= 0) return;
     const id = store.selectedZoomRegionId;
@@ -160,13 +146,11 @@
     const rect = timelineEl.getBoundingClientRect();
     const scrollLeft = timelineEl.scrollLeft;
     const x = clientX - rect.left + scrollLeft;
-    // x is in OUTPUT pixels → output seconds → back to original time (so the
-    // scrubber lands on kept content and skips over collapsed cuts).
+    // OUTPUT px → original time so the scrubber lands on kept content, skipping collapsed cuts.
     return Math.max(0, Math.min(duration, tOf(x)));
   }
 
-  // Shared trim-nudge for the global Alt+[ / Alt+] shortcuts. The trim
-  // handles use their own ArrowLeft/Right inside TimelineClipBar.
+  // For the global Alt+[ / Alt+] shortcuts (trim handles have their own arrows in TimelineClipBar).
   function nudgeTrim(which: "in" | "out", direction: 1 | -1, second = false) {
     if (duration <= 0) return;
     store.pushUndoStateCoalesced(`trim-${which}`, 500);
@@ -189,15 +173,9 @@
   }
 
   const duration = $derived(store.metadata?.duration ?? 0);
-  // Cuts collapse the timeline: the horizontal axis is OUTPUT (post-cut) time,
-  // not original-recording time. `originalToOutput` maps an original time onto
-  // the gapless output line (a time inside a cut lands on the cut's start), so
-  // removed ranges occupy zero width and everything after them slides left —
-  // exactly like a real NLE. With no cuts the mapping is the identity, so this
-  // is byte-for-byte the old original-time layout. Trim is preserved (it's not
-  // a cut), so the head/tail still show with their handles.
+  // The axis is OUTPUT (post-cut) time: `originalToOutput` collapses cuts to zero
+  // width so later content slides left (NLE ripple). Trim isn't a cut, so head/tail handles remain.
   const cuts = $derived(store.effectiveCuts);
-  // Output length of the whole recording = original duration minus all cuts.
   const outputDuration = $derived(originalToOutput(cuts, duration));
   const pixelsPerSecond = $derived(
     outputDuration > 0 ? (timelineWidth * store.timelineZoom) / outputDuration : 100,
@@ -205,8 +183,7 @@
   const totalWidth = $derived(
     Math.max(outputDuration * pixelsPerSecond, timelineWidth),
   );
-  // Canonical axis transforms. Every lane positions content with `xOf` and
-  // resolves a pointer back with `tOf`; keep them as the single source of truth.
+  // Canonical axis transforms — every lane positions with `xOf` and resolves pointers with `tOf`.
   const xOf = (t: number) => originalToOutput(cuts, t) * pixelsPerSecond;
   const tOf = (x: number) => outputToOriginal(cuts, x / pixelsPerSecond);
   const clipLeft = $derived(xOf(store.inPoint));
@@ -239,10 +216,7 @@
     const rect = timelineEl.getBoundingClientRect();
     const scrollLeft = timelineEl.scrollLeft;
     const x = clientX - rect.left + scrollLeft;
-    // x is in OUTPUT pixels — map back through the cut model to original time,
-    // exactly like `clientXToTime`. (Using the raw `x / pps` here treated an
-    // output position as original time, so the playhead trailed the cursor more
-    // and more past each cut.)
+    // OUTPUT px → original time via the cut model (raw `x / pps` would make the playhead trail past each cut).
     const time = Math.max(0, Math.min(duration, tOf(x)));
     store.currentTime = time;
     if (videoEl) videoEl.currentTime = time;
@@ -268,9 +242,7 @@
 
     const mod = event.ctrlKey || event.metaKey;
 
-    // Cmd/Ctrl + V pastes a previously-copied region at the playhead — the
-    // only modifier-combo this scope owns. Cards own copy/duplicate (those
-    // need a focused card), but paste works anywhere in the timeline.
+    // Paste works anywhere in the timeline (cards own copy/duplicate — they need focus).
     if (mod && (event.key === "v" || event.key === "V")) {
       if (zoomClipboard) {
         event.preventDefault();
@@ -279,10 +251,7 @@
       return;
     }
 
-    // Every remaining timeline shortcut is a plain (optionally Shift/Alt) key.
-    // Bail when Ctrl/Cmd is held so a global combo (⌘K command palette, ⌘J
-    // timeline toggle, ⌘S save, …) doesn't ALSO fire the matching
-    // single-letter transport (J/K/L) or marker (I/O/Home/End) action here.
+    // Bail on Ctrl/Cmd so a global combo (⌘K/⌘J/⌘S) doesn't also fire a single-letter transport here.
     if (mod) return;
 
     const step = event.shiftKey ? 1 : frameStep();
@@ -323,10 +292,8 @@
       }
     }
 
-    // Alt+[ trims the IN point one frame later (shrinks from the head);
-    // Alt+] trims the OUT point one frame earlier (shrinks from the tail).
-    // Shift+Alt switches the unit from one frame to one second. We match
-    // `event.code` because shifted brackets become "{"/"}" on some layouts.
+    // Alt+[ shrinks from head, Alt+] from tail (Shift = 1s). Match `event.code` —
+    // shifted brackets become "{"/"}" on some layouts.
     if (event.altKey && event.code === "BracketLeft") {
       event.preventDefault();
       nudgeTrim("in", 1, event.shiftKey);
@@ -356,9 +323,7 @@
       store.splitAt(store.currentTime);
     }
 
-    // Ripple-delete the selected clip (or the one under the playhead) and
-    // close the gap. The store returns the original-time join to land on a
-    // kept frame.
+    // Ripple-delete the selected clip (or the one under the playhead); store returns the join to land on a kept frame.
     if (event.key === "Delete" || event.key === "Backspace") {
       event.preventDefault();
       const target = store.selectedClipStart ?? store.currentTime;
@@ -369,10 +334,7 @@
       }
     }
 
-    // J/K/L transport. K parks playback. L plays forward; consecutive Ls
-    // step the playback rate up through SHUTTLE_SPEEDS. J does the same in
-    // reverse via a rAF-driven loop (browsers don't reliably support
-    // negative <video> playbackRate).
+    // J/K/L transport (see shuttle state above).
     if (event.key === "k" || event.key === "K") {
       event.preventDefault();
       shuttleDirection = 0;
@@ -426,8 +388,7 @@
       event.preventDefault();
       const rect = timelineEl.getBoundingClientRect();
       const anchorX = event.clientX - rect.left;
-      // Anchor in OUTPUT seconds (output px / output pps) so the point under the
-      // cursor stays put across the zoom — restored with the output pps below.
+      // Anchor in OUTPUT seconds so the point under the cursor stays put across the zoom.
       const anchorOut =
         duration > 0 ? (timelineEl.scrollLeft + anchorX) / pixelsPerSecond : 0;
       const delta = event.deltaY < 0 ? 0.2 : -0.2;
@@ -487,9 +448,7 @@
     syncVideoTime();
   }
 
-  // Internal clipboard for zoom regions. Plain object holding the editable
-  // fields of a region — id and source are regenerated on paste so a paste
-  // never collides with an existing region's identity.
+  // Editable fields only — id/source are regenerated on paste so it never collides with an existing region.
   type ZoomClipboard = Omit<ZoomRegion, "id" | "source">;
   let zoomClipboard = $state<ZoomClipboard | null>(null);
 
@@ -512,17 +471,13 @@
     zoomClipboard = snapshotForClipboard(r);
   }
 
-  // Place a region anchored at the supplied start time, copying everything
-  // else from `template`. Caller is responsible for clamping start so the
-  // span fits inside [0, duration].
+  // Place a region at `startAt`, copying the rest from `template`.
   function placeRegion(template: ZoomClipboard, startAt: number) {
     if (duration <= 0) return;
     const span = template.end - template.start;
     const start = Math.max(0, Math.min(duration - span, startAt));
     const end = start + span;
-    // store.addZoomRegion only seeds the geometry/scale; layer the rest of
-    // the template on with a single follow-up update so the new region
-    // is identical to the source modulo position.
+    // addZoomRegion only seeds geometry/scale; layer the rest on so the copy matches the source.
     const id = store.addZoomRegion(start, end, template.scale, {
       x: template.centerX,
       y: template.centerY,
@@ -538,15 +493,12 @@
 
   function duplicateRegion(r: ZoomRegion) {
     const span = r.end - r.start;
-    // Offset by 0.25s or one full span — whichever is smaller — so the new
-    // card sits visibly to the right without overshooting the timeline.
+    // Offset by min(0.25s, span) so the copy sits visibly right without overshooting.
     const offset = Math.min(0.25, span);
     placeRegion(snapshotForClipboard(r), r.start + offset);
   }
 
-  // Duplicate an annotation along with a +0.25s time offset so the copy
-  // sits visibly to the right of the source on the timeline. The store
-  // already nudges the geometry diagonally; we layer the time shift on top.
+  // Store nudges the geometry diagonally; we add a +0.25s time shift on top.
   function duplicateAnnotation(
     annotation: import("$lib/stores/editor-store.svelte").Annotation,
   ) {
@@ -583,7 +535,7 @@
   });
 </script>
 
-<!-- Track-header chip for the fixed left rail. Hue per lane, shape shared. -->
+<!-- Track-header chip for the fixed left rail. -->
 {#snippet railLabel(Icon: typeof Film, label: string, chipClass: string)}
   <span
     class="inline-flex items-center gap-1 rounded-sm px-1.5 py-px font-mono text-[8px] font-bold uppercase tracking-wider {chipClass}"
@@ -634,12 +586,8 @@
     onZoomToSelection={zoomToSelection}
   />
 
-  <!-- Track-header rail (fixed) + scrolling tracks. The rail lives OUTSIDE the
-       horizontal scroller so lane names never overlap a card sitting at t≈0
-       (the NLE convention). Row heights mirror the track side exactly —
-       h-7 ruler spacer, h-12 clip, mt-1.5 + min-h-9 per lane — so labels line
-       up with their lanes. The scroller's internal coordinate system is
-       unchanged, so playhead / snap / card math is untouched. -->
+  <!-- Rail lives OUTSIDE the scroller so lane names never overlap a card at t≈0.
+       Row heights mirror the track side (h-7 ruler, h-12 clip, mt-1.5+min-h-9 lanes) so labels align. -->
   <div
     class="relative flex overflow-hidden rounded-xl border border-border/60 bg-background/60 shadow-(--shadow-craft-inset)"
   >

--- a/apps/desktop/src/components/editor/VideoPlayerControls.svelte
+++ b/apps/desktop/src/components/editor/VideoPlayerControls.svelte
@@ -22,16 +22,9 @@
 		videoEl?: HTMLVideoElement | null;
 		/** Element to request fullscreen on (usually the preview container). */
 		fullscreenTargetEl?: HTMLElement | null;
-		/** Returns a PNG blob of the current preview composite (provided by
-		 *  VideoPreview via its `bind:captureFrame`). When undefined the
-		 *  Copy-frame button is disabled — typically the preview hasn't
-		 *  initialized its WebGL2 context yet. */
+		/** PNG blob of the current preview composite; undefined disables Copy-frame (WebGL2 not ready). */
 		captureFrame?: (() => Promise<Blob | null>) | undefined;
-		/** Bidirectional loop toggle. Lives in the editor page (not here)
-		 *  because the actual seek-and-replay has to coordinate with audio
-		 *  elements + the `ended` handler — both are out of scope for this
-		 *  controls component. Toggling here just flips the flag; the page
-		 *  reads it on `ended`/`timeupdate`. */
+		/** Loop toggle. Just flips the flag here; the editor page does the seek-and-replay (needs audio + `ended`). */
 		loopEnabled?: boolean;
 	}
 
@@ -45,16 +38,8 @@
 
 	let capturing = $state(false);
 
-	/**
-	 * Capture the current frame and write it to the system clipboard as
-	 * a PNG. The WebView's `navigator.clipboard.write` works on Tauri
-	 * because the WebView treats `tauri://localhost` as a secure context
-	 * — no Tauri plugin needed for image clipboard.
-	 *
-	 * Pauses playback first so the captured pixels match what the user
-	 * sees in the click moment; otherwise a frame drift of one rVFC tick
-	 * could change which pixel they actually got.
-	 */
+	// Copy the current frame to the clipboard as PNG. `navigator.clipboard.write`
+	// works on Tauri (tauri://localhost is a secure context). Pause first so the captured pixels match.
 	async function copyFrameToClipboard() {
 		if (capturing || !captureFrame) return;
 		capturing = true;
@@ -108,12 +93,8 @@
 		return `${mins}:${secs.toString().padStart(2, "0")}.${ms.toString().padStart(2, "0")}`;
 	}
 
-	// OUTPUT (post-cut) time — the same gapless axis the timeline uses. Cuts
-	// collapse out of the transport, so the duration readout, the scrubber range,
-	// and the played-region width all reflect the EDITED length, and the scrubber
-	// can't land inside a removed region. `store.currentTime` stays the single
-	// source of truth (original time); we only map to output for presentation +
-	// seek here. With no cuts these are identities, so this is the old behaviour.
+	// OUTPUT (post-cut) time: readout/scrubber reflect the edited length and can't land
+	// in a removed region. `store.currentTime` stays the source of truth (original time); we map to output only for display + seek.
 	const cuts = $derived(store.effectiveCuts);
 	const fullDuration = $derived(store.metadata?.duration ?? 0);
 	const outputDuration = $derived(originalToOutput(cuts, fullDuration));
@@ -163,7 +144,6 @@
 </script>
 
 <div class="flex h-10 w-full items-center gap-2 px-2">
-	<!-- Transport pill: play / step -->
 	<div
 		class="flex items-center gap-0.5 rounded-lg bg-muted/60 p-0.5 ring-1 ring-inset ring-border/40"
 	>
@@ -226,7 +206,6 @@
 		</Tooltip.Root>
 	</div>
 
-	<!-- Time readout -->
 	<div
 		class="flex items-center gap-1 font-mono tabular-nums text-[11px] font-semibold min-w-32"
 	>
@@ -235,7 +214,6 @@
 		<span class="text-muted-foreground">{durationFormatted}</span>
 	</div>
 
-	<!-- Scrubber: custom thin track with played overlay -->
 	<div class="relative flex h-7 flex-1 items-center">
 		<div
 			class="pointer-events-none absolute inset-x-0 top-1/2 h-1 -translate-y-1/2 rounded-full bg-muted/80 ring-1 ring-inset ring-border/40"
@@ -258,7 +236,6 @@
 		/>
 	</div>
 
-	<!-- Right: capture frame + loop + fullscreen -->
 	<div
 		class="flex items-center gap-0.5 rounded-lg bg-muted/60 p-0.5 ring-1 ring-inset ring-border/40"
 	>

--- a/apps/desktop/src/components/editor/VideoPreview.svelte
+++ b/apps/desktop/src/components/editor/VideoPreview.svelte
@@ -84,23 +84,17 @@
 		captureFrame = $bindable(),
 	}: Props = $props();
 
-	//  DOM refs & GL state 
 	let canvasEl: HTMLCanvasElement | null = $state(null);
-	// True once we've discovered the WebView doesn't expose WebGL2. The preview
-	// can't render without it (composite blends video + background + effects in
-	// a shader), so the user needs an actionable message — not a silently blank
-	// canvas. Surfaces on integrated GPUs old enough to predate WebGL2 (~2014)
-	// and on machines with broken/outdated graphics drivers.
+	// WebView doesn't expose WebGL2 — surface an actionable message rather than a
+	// silently blank canvas (old integrated GPUs, broken/outdated drivers).
 	let webgl2Unsupported = $state(false);
 	let containerEl: HTMLDivElement | null = $state(null);
 	/** Shrink-wrap around the WebGL canvas so the annotation overlay can sit
 	 * on top of it at the same rendered rect regardless of letterboxing. */
 	let previewRectEl: HTMLDivElement | null = $state(null);
 	let isReady = $state(false);
-	// Second, internal-only decoder used purely to pre-decode the first frame
-	// after a cut so the visible freeze (the primary element's seek latency) is
-	// masked. It is never played — only seeked once per cut — so it costs one
-	// extra decode per skip, not a continuous parallel stream.
+	// Internal decoder that pre-decodes the first post-cut frame to mask the
+	// primary element's seek latency. Only seeked once per cut, never played.
 	let scoutEl = $state<HTMLVideoElement | null>(null);
 
 	let gl: WebGL2RenderingContext | null = null;
@@ -111,35 +105,29 @@
 	let lastBgKey = "";
 
 	// WebCodecs preview engine (behind the `webcodecsPreview` experimental flag).
-	// When active, the composite samples a frame WE decode for the current time —
-	// not the <video> element's pixels — so jumping over a cut never waits on
-	// the element's native seek. The <video> element still drives the clock and
-	// audio sync (hybrid); the full clock swap comes later. Not $state — read
-	// only from the imperative draw loop.
+	// When active, the composite samples a frame WE decode — not the <video>
+	// element's pixels — so jumping over a cut never waits on the native seek.
+	// The <video> element still drives the clock and audio sync (hybrid). Not
+	// $state — read only from the imperative draw loop.
 	let wcSource: WebCodecsVideoSource | null = null;
 	let wcReady = false;
 	let loadedWcSrc = "";
-	// True once at least one frame is in videoTex. The GL context uses
-	// preserveDrawingBuffer:false, so returning early from draw() clears the
-	// canvas to BLACK instead of holding; when a fresh frame isn't ready we
-	// re-render the last frame already in videoTex, and this guards that.
+	// True once a frame is in videoTex. preserveDrawingBuffer:false means an early
+	// return from draw() clears to BLACK; we re-render the last frame instead, and
+	// this guards that.
 	let hasRenderedFrame = false;
-	// Last original time published to store.currentTime. We throttle that write
-	// (it fans out to overlays/timeline/waveform); slamming it every rAF frame
-	// congests the main thread and delays decoded-frame delivery → dropped frames.
+	// Last original time published to store.currentTime. Throttled — the write
+	// fans out to overlays/timeline/waveform; every-rAF writes starve frame delivery.
 	let lastPublishedTime = -1;
 	// Guards the end-of-timeline stop so it fires once per play session, not every
 	// frame while the clock sits clamped at the end. Reset when playback (re)starts.
 	let endHandled = false;
 
-	// Gapless OUTPUT-time clock that drives the PICTURE in the WebCodecs path.
-	// This is the actual fix for the cut hitch: a <video> element's currentTime
-	// STALLS during its own seek, so borrowing it as the clock freezes the
-	// picture at every cut. This clock is a free-running integrator — it never
-	// stalls — so playback runs over a continuous, gap-free output timeline
-	// (recording minus cuts), exactly like Cap's segment-walk. We map output →
-	// original time (outputToOriginal) for frame lookup, cursor, and zoom. The
-	// <video> element stays the audio/seek transport and is nudged to follow.
+	// Gapless OUTPUT-time clock that drives the PICTURE in the WebCodecs path. A
+	// <video> element's currentTime STALLS during its own seek, so borrowing it as
+	// the clock freezes the picture at every cut. This free-running integrator
+	// never stalls. Map output→original (outputToOriginal) for frame/cursor/zoom
+	// lookup; the <video> element stays the audio/seek transport and follows.
 	const picClock = new PlaybackClock();
 
 	// Uniform locations
@@ -165,10 +153,9 @@
 	let idlePeriods: IdlePeriodJS[] = [];
 	let loadedCursorPath = "";
 
-	// SVG cursor overlay state. Updated each draw() call when the user has
-	// picked a non-`dot` cursor style; consumed by the absolutely-positioned
-	// <img> at the bottom of the markup. Not a $derived — the data is pulled
-	// from the WebGL draw loop where the cursor sample is already evaluated.
+	// SVG cursor overlay state, updated each draw() for non-`dot` styles and
+	// consumed by the absolutely-positioned <img>. Not $derived — the data is
+	// pulled from the draw loop where the cursor sample is already evaluated.
 	let svgCursor = $state<{
 		visible: boolean;
 		alpha: number;
@@ -200,16 +187,13 @@
 	// changes keeps playback cheap even on long recordings.
 	let smoothingSignature = "";
 
-	// Press-event model — drives every aspect of click feedback.
+	// Press-event model — drives click feedback. One event per click
+	// ({downUs, upUs}) read from RAW samples, never the smoothed array:
+	// smoothing must NEVER nudge click timing, since the visual press has to
+	// land on the exact frame the audio click plays. Each event also carries the
+	// captured click position so the impact frame pins there (see clickAnchorAt).
 	//
-	// The captured cursor track tells us, per ~8 ms sample, whether the
-	// physical mouse button was held. We collapse that into one event per
-	// click ({downUs, upUs}) read straight from the RAW samples — never the
-	// smoothed array. Smoothing reshapes x/y for cinematic motion, but it
-	// must NEVER nudge click timing: the rendered video has to land its
-	// visual press on the exact frame the audio click sound plays.
-	//
-	// Around each event we run a deterministic, time-based animation:
+	// Per event we run a deterministic, time-based animation:
 	//
 	//   downUs - PREROLL ───── downUs ───── max(upUs, downUs+MIN_HOLD)
 	//        │ pointer sprite appears
@@ -220,12 +204,8 @@
 	//                                                            │ sprite returns to rest
 	//                                                            │ cursor fades back to idleAlpha
 	//
-	// The snap at downUs is intentional — it's the visual analogue of the
-	// audible click. Smooth crossfade through the click moment would feel
-	// mushy and desync from the audio.
-	// Each event carries the captured click position (downX, downY in source
-	// pixels) so the visualization can pin the cursor to that point during
-	// the impact frame — see `clickAnchorAt` below.
+	// The snap at downUs is the visual analogue of the audible click — a smooth
+	// crossfade there would feel mushy and desync from the audio.
 	let pressEvents: PressEvent[] = [];
 	//  Shaders
 	const VERT_SRC = `#version 300 es
@@ -566,11 +546,9 @@ void main() {
 			if (!wire || wire.startsWith("#")) return "";
 			return convertFileSrc(wire);
 		}
-		// Defensive: gradient/colour values must never reach convertFileSrc —
-		// the caller already gates on backgroundType, but a stray write that
-		// leaves a CSS gradient in backgroundValue while type briefly reads
-		// "image" would otherwise log "File does not exist at path: linear-
-		// gradient(...)" via the Tauri asset protocol.
+		// Defensive: keep gradient/colour values away from convertFileSrc — a
+		// stray write leaving a CSS gradient here while type briefly reads "image"
+		// would otherwise log a bogus "File does not exist" via the asset protocol.
 		if (value.includes("gradient(") || value.startsWith("#")) return "";
 		if (value.startsWith("asset:") && !value.startsWith("asset://")) {
 			const id = value.slice("asset:".length);
@@ -850,16 +828,9 @@ void main() {
 		return true;
 	}
 
-	// Smoothly-eased zoom scale at `timeSec`. Returns 1.0 outside every
-	// region; inside a region, ramps 1.0 → `region.scale` across `rampIn`
-	// seconds shaped by `easeIn`, holds at `region.scale`, then ramps back
-	// across `rampOut` shaped by `easeOut`. Matches the Rust
-	// `ZoomRegion::scale_at` logic 1:1 so preview and export stay aligned.
-	// Returns the current zoom state for `timeSec`:
-	//  - scale: eased scale value (1.0 outside any region)
-	//  - cx/cy: focus centre in video UV space (0.5/0.5 at rest), eased from
-	//           the region's target centre in lockstep with the scale ramp
-	//  - motionBlur: 0..1 strength multiplier of the active region (or 0)
+	// Zoom state for `timeSec`: eased scale (1.0 outside any region), focus
+	// centre in video UV, and motion-blur strength. Matches the Rust
+	// `ZoomRegion::scale_at` 1:1 so preview and export stay aligned.
 	function evaluateZoomAt(timeSec: number): {
 		scale: number;
 		cx: number;
@@ -893,16 +864,12 @@ void main() {
 			phase = Math.max(0, Math.min(1, phase));
 			const eased = atHold ? 1 : bezierY(curve, phase);
 			const scale = 1.0 + (r.scale - 1.0) * eased;
-			// Focus point is CONSTANT at the target for the whole region — only
-			// the scale eases. The zoom is an affine transform pinned at the
-			// focus: `(uv - c)/scale + c`. At scale≈1 that's the identity (so no
-			// visible offset on the first frame regardless of c), and as the
-			// scale ramps it dollies straight into the target. Easing the centre
-			// from 0.5→target instead (the old behaviour) made the frame grow at
-			// the centre first and then slide to the target — the "scale at
-			// centre, then snap" artifact. Keeping it constant also guarantees
-			// the cursor (which uses the same affine forward transform) stays
-			// glued to its content pixel through the whole ramp.
+			// Focus point is CONSTANT at the target for the whole region — only the
+			// scale eases. The affine zoom `(uv - c)/scale + c` is the identity at
+			// scale≈1 (no first-frame offset regardless of c) and dollies straight
+			// into the target as it ramps. Easing the centre from 0.5→target instead
+			// caused the "scale at centre, then slide" artifact, and a constant
+			// centre keeps the cursor (same forward transform) glued.
 			const cx = r.centerX ?? 0.5;
 			const cy = r.centerY ?? 0.5;
 			return { scale, cx, cy, motionBlur: r.motionBlur ?? 0 };
@@ -910,16 +877,12 @@ void main() {
 		return { scale: 1.0, cx: 0.5, cy: 0.5, motionBlur: 0 };
 	}
 
-	// Blur annotations are composited by AnnotationOverlay, which reads this
-	// canvas back via Canvas2D `drawImage` from its OWN rAF loop. With
-	// `preserveDrawingBuffer: false` the WebGL back buffer is only valid for a
-	// cross-canvas read within the SAME task that issued `draw()` — an
-	// out-of-task read (the overlay's separate loop) intermittently samples a
-	// cleared buffer, which is the blur "flicker" during playback. Fix: mirror
-	// the composite into a plain 2D canvas in-task right after each draw(); the
-	// overlay samples the mirror (whose pixels persist across tasks) instead of
-	// the live GL canvas. Maintained only while a blur exists, so the common
-	// path pays nothing.
+	// AnnotationOverlay reads this canvas back via drawImage from its OWN rAF
+	// loop. With preserveDrawingBuffer:false the GL buffer is only valid for a
+	// cross-canvas read within the SAME task as draw() — an out-of-task read
+	// samples a cleared buffer (the blur "flicker"). Fix: mirror the composite
+	// into a 2D canvas in-task after each draw() and have the overlay sample
+	// that. Maintained only while a blur exists, so the common path pays nothing.
 	let blurMirrorEl = $state<HTMLCanvasElement | null>(null);
 	const hasBlurAnnotation = $derived(
 		store.annotations.some((a) => a.kind.kind === "blur" && !a.hidden),
@@ -991,13 +954,10 @@ void main() {
 		// (one string compare) when nothing's changed.
 		ensureSmoothingCurrent();
 
-		// Picture time. In the WebCodecs path the gapless OUTPUT clock is the
-		// master: output time → original time (outputToOriginal) feeds frame
-		// lookup, cursor, and zoom. The <video>/audio transport is nudged to
-		// follow — advancing it past cut gaps for sound — but is never read for
-		// the picture, so its seek stalls can't freeze playback. In the legacy
-		// path the <video> element's currentTime is the clock, as before (it
-		// updates per-frame via rVFC, unlike store.currentTime's ~4×/sec tick).
+		// Picture time. WebCodecs path: the gapless OUTPUT clock is master
+		// (output→original feeds frame/cursor/zoom); the <video>/audio transport
+		// follows but is never read for the picture, so its seek stalls can't
+		// freeze playback. Legacy path: the <video> currentTime is the clock.
 		const usingPicClock = experimentalStore.webcodecsPreview && wcReady;
 		let playbackTime: number;
 		if (usingPicClock && store.isPlaying) {
@@ -1052,19 +1012,16 @@ void main() {
 			playbackTime = videoEl ? videoEl.currentTime : store.currentTime;
 		}
 
-		// Skip over removed cut ranges — manual split/delete AND accepted
-		// silence — during forward playback. Two decoders leapfrog the gap:
+		// Legacy-path cut skip: two decoders leapfrog the removed gap.
 		//   1. As the playhead nears a cut, the SCOUT pre-decodes the first
 		//      post-cut frame (cut.end), well ahead of the boundary.
 		//   2. At the boundary the PRIMARY jumps to cut.end (keeps store time &
-		//      audio correct) — but the primary's seek latency would freeze the
-		//      picture, so for the frames where the primary is still settling we
-		//      sample the scout's already-decoded frame instead. The swap is
-		//      seamless because both land on the same time/content.
-		// The seek is issued ONCE per cut: re-assigning currentTime every render
-		// frame while a seek is pending thrashes the decoder into a multi-second
-		// stall. Scrubbing into a cut is still allowed (gated on isPlaying) so the
-		// user can inspect what was removed; `cutsEnabled` off bypasses it.
+		//      audio correct); while it settles we sample the scout's already-
+		//      decoded frame, so there's no visible freeze. Both land on the same
+		//      time/content, so the swap is seamless.
+		// Seek issued ONCE per cut — re-assigning currentTime mid-seek thrashes the
+		// decoder into a multi-second stall. Scrubbing into a cut stays allowed
+		// (gated on isPlaying); `cutsEnabled` off bypasses it.
 		let frameEl: HTMLVideoElement | null = videoEl;
 		const activeCuts = store.effectiveCuts;
 		// Legacy <video> cut-skip (scout + primary seek). OFF for the WebCodecs
@@ -1472,20 +1429,14 @@ void main() {
 	}
 
 	/**
-	 * Capture the current preview frame (composite: video + background +
-	 * zoom + blur + cursor) as a PNG blob.
+	 * Capture the current preview frame as a PNG blob — the full composite
+	 * (video + background + zoom + blur + cursor), so the screenshot matches
+	 * what the user sees rather than the raw recording.
 	 *
-	 * Why this isn't just `videoEl` → `drawImage`: the WebGL pipeline
-	 * applies all the editor effects (zoom regions, motion blur, padded
-	 * background, cursor overlay), and the user expects the screenshot to
-	 * match what they see — not the raw recording. We pull from the canvas.
-	 *
-	 * preserveDrawingBuffer is `false` on the GL context (perf), which
-	 * means the back buffer is cleared after the JS task yields. Workaround:
-	 * call `draw()` synchronously, then immediately `drawImage` from the
-	 * WebGL canvas to a fresh 2D canvas — the browser preserves the buffer
-	 * for inter-canvas copies within the same task. `toBlob` then runs
-	 * against the 2D canvas, which has no such constraint.
+	 * preserveDrawingBuffer is false, so the back buffer is cleared once the JS
+	 * task yields. Workaround: draw() synchronously, then drawImage from the GL
+	 * canvas to a 2D canvas in the same task (inter-canvas copies preserve the
+	 * buffer); toBlob runs against the 2D canvas, which has no such constraint.
 	 */
 	$effect(() => {
 		captureFrame = async () => {
@@ -1758,10 +1709,8 @@ void main() {
 			class="block max-h-full max-w-full transition-opacity duration-200 ease-out motion-reduce:transition-none group-data-[annotations-active=true]/preview:opacity-90"
 		></canvas>
 		{#if webgl2Unsupported}
-			<!-- WebGL2 is required to composite the preview (background + zoom +
-			     cursor + effects all run in the fragment shader). Without it the
-			     canvas stays blank — surface an actionable message instead so the
-			     user knows it's a graphics-driver issue, not a broken app. -->
+			<!-- Actionable message instead of a blank canvas — reads as a
+			     graphics-driver issue, not a broken app. -->
 			<div
 				class="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 bg-background/95 p-6 text-center"
 				role="alert"
@@ -1775,9 +1724,8 @@ void main() {
 				</p>
 			</div>
 		{/if}
-		<!-- Annotation scrim: subtle primary-tinted darkening sits between the
-			 WebGL composite and the annotation overlay so shapes pop. Stays out
-			 of the way (opacity 0) on every other tab. -->
+		<!-- Annotation scrim: primary-tinted darkening between the composite and
+			 the overlay so shapes pop. Opacity 0 on every other tab. -->
 		<div
 			aria-hidden="true"
 			class="pointer-events-none absolute inset-0 bg-foreground/12 mix-blend-multiply opacity-0 transition-opacity duration-200 ease-out motion-reduce:transition-none group-data-[annotations-active=true]/preview:opacity-100"
@@ -1805,15 +1753,11 @@ void main() {
 			{@const hot = cursorSpriteHotspot(style, stateKey)}
 			{@const hotPctX = (hot.x / 64) * 100}
 			{@const hotPctY = (hot.y / 64) * 100}
-			<!-- Custom SVG cursor.
-			     - Wrapper owns `left/top/width/opacity` so cursor motion and the
-			       visibility ramp stay instantaneous frame-by-frame.
-			     - Inner img owns the press transform: `scale` is computed in JS
-			       per frame (anticipation lift → click-frame snap → recovery),
-			       NOT via a CSS transition. A CSS transition would lag the
-			       impact behind the captured click and desync from the audio.
-			     - `transform-origin` is set to the hotspot so the scale change
-			       keeps the cursor's tip pinned to the captured pointer. -->
+			<!-- Custom SVG cursor. Wrapper owns left/top/width/opacity (per-frame
+			     motion + visibility ramp). Inner img owns the press transform:
+			     `scale` is computed in JS per frame, NOT a CSS transition — a
+			     transition would lag the impact and desync from the audio.
+			     transform-origin = hotspot keeps the cursor tip pinned. -->
 			<div
 				class="pointer-events-none absolute"
 				style="
@@ -1837,10 +1781,8 @@ void main() {
 			</div>
 			{/if}
 		{/if}
-		<!-- Camera overlay sits ABOVE the cursor SVG so the bubble
-		     never gets visually clipped behind a cursor that wanders
-		     into its corner. The component owns its own video element
-		     and stays in sync with the screen video via store.currentTime.
+		<!-- Above the cursor SVG so the bubble isn't clipped behind a cursor in
+		     its corner. Owns its own video element, synced via store.currentTime.
 		     TODO(camera-recording): gated behind CAMERA_OVERLAY_UI_ENABLED. See
 		     apps/desktop/docs/camera-recording-todo.md. -->
 		{#if CAMERA_OVERLAY_UI_ENABLED}
@@ -1873,9 +1815,8 @@ void main() {
 			muted
 		></video>
 		<!-- Scout decoder: never played, only seeked to pre-decode the first
-		     post-cut frame so the primary's seek latency is masked (see draw()).
-		     Only mounted when the clip actually has active cuts to skip, so the
-		     default no-cut session never pays for a second decode pipeline. -->
+		     post-cut frame (see draw()). Mounted only when the clip has cuts to
+		     skip, so a no-cut session pays for no second decode pipeline. -->
 		{#if store.effectiveCuts.length > 0}
 			<!-- svelte-ignore a11y_media_has_caption -->
 			<video

--- a/apps/desktop/src/components/editor/VideoPreview.svelte
+++ b/apps/desktop/src/components/editor/VideoPreview.svelte
@@ -13,17 +13,22 @@
 	} from "$lib/registry";
 	import { bezierY } from "$lib/easing/cubic-bezier";
 	import { assetsStore } from "$lib/stores/assets-store.svelte";
-	import {
-		MAX_GRADIENT_STOPS,
-		parseGradient as parseGradientSpec,
-		type EditorStore,
-	} from "$lib/stores/editor-store.svelte";
+	import { type EditorStore } from "$lib/stores/editor-store.svelte";
 	import { Spinner } from "@recast/ui/spinner";
 	import { convertFileSrc } from "@tauri-apps/api/core";
 	import { onDestroy, onMount } from "svelte";
 	import { CAMERA_OVERLAY_UI_ENABLED } from "$lib/feature-flags";
 	import { experimentalStore } from "$lib/stores/experimental.svelte";
 	import { analytics } from "$lib/analytics/client";
+	import {
+		buildPressEvents,
+		clickAnchorAt,
+		clickHighlightAt,
+		pressStateAt,
+		type PressEvent,
+	} from "./cursor-animation.logic";
+	import { hexToRgba } from "./color.logic";
+	import { buildGradientUniforms } from "./gradient.logic";
 	import { WebCodecsVideoSource } from "$lib/playback/webcodecs-source";
 	import { PlaybackClock } from "$lib/playback/clock";
 	import { originalToOutput, outputToOriginal } from "$lib/timeline/cuts";
@@ -221,266 +226,8 @@
 	// Each event carries the captured click position (downX, downY in source
 	// pixels) so the visualization can pin the cursor to that point during
 	// the impact frame — see `clickAnchorAt` below.
-	type PressEvent = {
-		downUs: number;
-		upUs: number;
-		downX: number;
-		downY: number;
-		/** Right button initiated this press (selects the sprite slot only). */
-		right: boolean;
-		/** Cursor moved past DRAG_THRESHOLD_PX (source px) while held. */
-		dragged: boolean;
-	};
 	let pressEvents: PressEvent[] = [];
-	/** Cursor displacement (source px) during a hold beyond which it's a drag.
-	 *  MUST mirror DRAG_THRESHOLD_PX in cursor_anim.rs. */
-	const DRAG_THRESHOLD_PX = 8;
-
-	const PRESS_MIN_HOLD_US = 320_000; // minimum down-window from the click frame
-	const PRESS_LINGER_US = 320_000; // pressed sprite holds this long past release
-	const PRESS_PREROLL_US = 320_000; // pointer sprite visible this long before click
-	const PRESS_VIS_RAMP_US = 180_000; // cursor visibility ramp-in / ramp-out
-	const PRESS_POSTROLL_US = 320_000; // visibility holds this long after sprite settles
-	const PRESS_ANTICIP_US = 140_000; // anticipation lift duration
-	const PRESS_RECOVERY_US = 380_000; // recovery duration after click snap
-	const PRESS_LIFT = 0.04; // anticipation peak: scale = 1 + LIFT
-	const PRESS_PUNCH = 0.16; // click compression: scale = 1 - PUNCH
-	const PRESS_BOUNCE = 0.03; // recovery overshoot above 1
-	// Always-on click snap — cosine ramp pulls the rendered cursor x/y
-	// through the captured click anchor inside ±CLICK_SNAP_HALF_US so the
-	// impact frame ALWAYS lands on the click target, regardless of the
-	// user's smoothing strength or snap-to-clicks toggle. Outside the
-	// window the cursor follows the regular (raw or smoothed) path.
-	const CLICK_SNAP_HALF_US = 200_000;
-
-	function rebuildPressEvents() {
-		pressEvents = [];
-		// Source: raw samples. Smoothing only reshapes x/y — click timing
-		// AND click position stay anchored to what the OS captured.
-		const samples = cursorSamplesRaw;
-		if (samples.length === 0) return;
-		let inPress = false;
-		let downUs = 0;
-		let downX = 0;
-		let downY = 0;
-		let right = false;
-		let maxDisp = 0;
-		for (let i = 0; i < samples.length; i++) {
-			const s = samples[i];
-			const down = s.leftDown || s.rightDown;
-			if (down && !inPress) {
-				inPress = true;
-				downUs = s.timestampUs;
-				downX = s.x;
-				downY = s.y;
-				// Right-click only when right is the sole button down at the edge.
-				right = s.rightDown && !s.leftDown;
-				maxDisp = 0;
-			} else if (down && inPress) {
-				maxDisp = Math.max(maxDisp, Math.hypot(s.x - downX, s.y - downY));
-			} else if (!down && inPress) {
-				inPress = false;
-				pressEvents.push({
-					downUs,
-					upUs: s.timestampUs,
-					downX,
-					downY,
-					right,
-					dragged: maxDisp > DRAG_THRESHOLD_PX,
-				});
-			}
-		}
-		if (inPress) {
-			pressEvents.push({
-				downUs,
-				upUs: samples[samples.length - 1].timestampUs,
-				downX,
-				downY,
-				right,
-				dragged: maxDisp > DRAG_THRESHOLD_PX,
-			});
-		}
-	}
-
-	// Active click anchor + cosine falloff weight at tsUs, or null when
-	// outside any click-snap window. Linear scan; press events << 500
-	// typically. Picks the closest event when two snap windows overlap so
-	// double-clicks still snap cleanly to each successive target.
-	function clickAnchorAt(
-		tsUs: number,
-	): { x: number; y: number; weight: number } | null {
-		let bestEv: PressEvent | null = null;
-		let bestAbsDt = Infinity;
-		for (let i = 0; i < pressEvents.length; i++) {
-			const ev = pressEvents[i];
-			if (tsUs < ev.downUs - CLICK_SNAP_HALF_US) break;
-			if (tsUs > ev.downUs + CLICK_SNAP_HALF_US) continue;
-			const absDt = Math.abs(tsUs - ev.downUs);
-			if (absDt < bestAbsDt) {
-				bestAbsDt = absDt;
-				bestEv = ev;
-			}
-		}
-		if (!bestEv) return null;
-		// Cosine ramp: 1 at the click frame, 0 at the window edge.
-		const weight = 0.5 + 0.5 * Math.cos((bestAbsDt / CLICK_SNAP_HALF_US) * Math.PI);
-		return { x: bestEv.downX, y: bestEv.downY, weight };
-	}
-
-	// 3t² - 2t³ smoothstep — clamped, C1-continuous, cheap. Used for the
-	// visibility ramps and the easing inside each scale phase.
-	function smoothStep01(t: number): number {
-		if (t <= 0) return 0;
-		if (t >= 1) return 1;
-		return t * t * (3 - 2 * t);
-	}
-
-	// Pinned click-highlight envelope. Returns the CAPTURED click position
-	// (raw source px) and an alpha that rises the instant the click lands,
-	// holds through the press, then fades. Decoupling the ring from the
-	// (smoothed, possibly lagging) cursor is what makes it appear exactly
-	// where AND when the click happened — riding the cursor read as delayed,
-	// off-target feedback under smoothing. Mirrors `click_highlight_at` in
-	// cursor_anim.rs so preview and export agree frame-for-frame.
-	const HIGHLIGHT_FADE_IN_US = 40_000;
-	const HIGHLIGHT_FADE_OUT_US = 220_000;
-	function clickHighlightAt(
-		tsUs: number,
-	): { x: number; y: number; alpha: number } | null {
-		let best: PressEvent | null = null;
-		let bestDt = Infinity;
-		for (let i = 0; i < pressEvents.length; i++) {
-			const ev = pressEvents[i];
-			const holdEnd = Math.max(
-				ev.upUs + PRESS_LINGER_US,
-				ev.downUs + PRESS_MIN_HOLD_US,
-			);
-			if (tsUs < ev.downUs) continue;
-			if (tsUs > holdEnd + HIGHLIGHT_FADE_OUT_US) continue;
-			const dt = tsUs - ev.downUs;
-			if (dt < bestDt) {
-				bestDt = dt;
-				best = ev;
-			}
-		}
-		if (!best) return null;
-		const holdEnd = Math.max(
-			best.upUs + PRESS_LINGER_US,
-			best.downUs + PRESS_MIN_HOLD_US,
-		);
-		let alpha: number;
-		if (tsUs < best.downUs + HIGHLIGHT_FADE_IN_US) {
-			alpha = smoothStep01((tsUs - best.downUs) / HIGHLIGHT_FADE_IN_US);
-		} else if (tsUs <= holdEnd) {
-			alpha = 1;
-		} else {
-			alpha = smoothStep01(
-				(holdEnd + HIGHLIGHT_FADE_OUT_US - tsUs) / HIGHLIGHT_FADE_OUT_US,
-			);
-		}
-		return { x: best.downX, y: best.downY, alpha };
-	}
-
-	// All click-relative state for a given moment. Linear scan — recordings
-	// rarely carry more than a few hundred clicks, and the per-frame cost is
-	// dominated by WebGL state setup anyway. When two events' influence
-	// windows overlap (sub-300 ms double-clicks), we pick the one whose
-	// downUs is closest to tsUs — this hands the curve to the upcoming
-	// click as soon as we're nearer to it than to the previous one, so the
-	// pointer sprite, anticipation lift, and impact snap all track the
-	// click the viewer is actually about to perceive.
-	function pressStateAt(tsUs: number): {
-		pressedSprite: boolean; // swap to the press SVG sprite
-		visibleAlpha: number; // 0..1 boost on top of idleAlpha (overrides idle-hide)
-		scale: number; // applied directly to the sprite transform
-		right: boolean; // active press was a right-click (sprite slot)
-		dragging: boolean; // active press is a drag (sprite slot)
-	} {
-		let bestEv: PressEvent | null = null;
-		let bestHoldEnd = 0;
-		let bestVisStart = 0;
-		let bestVisEnd = 0;
-		let bestAbsDt = Infinity;
-		for (let i = 0; i < pressEvents.length; i++) {
-			const ev = pressEvents[i];
-			// holdEnd = the latest of:
-			//   - release + LINGER  → the pressed sprite tails the actual release
-			//                         so even long holds get a visible post-release dwell
-			//   - down + MIN_HOLD   → flash clicks (single-sample presses) still
-			//                         show the pressed sprite for a readable beat
-			const holdEnd = Math.max(
-				ev.upUs + PRESS_LINGER_US,
-				ev.downUs + PRESS_MIN_HOLD_US,
-			);
-			const visStart = ev.downUs - PRESS_PREROLL_US - PRESS_VIS_RAMP_US;
-			const visEnd = holdEnd + PRESS_POSTROLL_US + PRESS_VIS_RAMP_US;
-			// Events are sorted by downUs ascending, so once we're before
-			// an event's window we're before every later event's window too.
-			if (tsUs < visStart) break;
-			if (tsUs > visEnd) continue;
-			const absDt = Math.abs(tsUs - ev.downUs);
-			if (absDt < bestAbsDt) {
-				bestEv = ev;
-				bestHoldEnd = holdEnd;
-				bestVisStart = visStart;
-				bestVisEnd = visEnd;
-				bestAbsDt = absDt;
-			}
-		}
-		if (!bestEv)
-			return {
-				pressedSprite: false,
-				visibleAlpha: 0,
-				scale: 1,
-				right: false,
-				dragging: false,
-			};
-
-		// Visibility: smooth ramp in, hold full, smooth ramp out.
-		let visibleAlpha = 1;
-		if (tsUs < bestEv.downUs - PRESS_PREROLL_US) {
-			visibleAlpha = smoothStep01((tsUs - bestVisStart) / PRESS_VIS_RAMP_US);
-		} else if (tsUs > bestHoldEnd + PRESS_POSTROLL_US) {
-			visibleAlpha = smoothStep01((bestVisEnd - tsUs) / PRESS_VIS_RAMP_US);
-		}
-
-		// Pressed sprite: from preroll start through the held window.
-		const pressedSprite =
-			tsUs >= bestEv.downUs - PRESS_PREROLL_US && tsUs <= bestHoldEnd;
-
-		// Scale curve — three phases keyed on `dt = tsUs - downUs`.
-		//   dt ∈ [-ANTICIP, 0):  1 → 1+LIFT (smooth lift)
-		//   dt = 0:              snap to 1-PUNCH (click frame — sync point)
-		//   dt ∈ [0, RECOVERY]:  1-PUNCH → 1+BOUNCE → 1
-		let scale = 1;
-		const dt = tsUs - bestEv.downUs;
-		if (dt >= -PRESS_ANTICIP_US && dt < 0) {
-			const u = (dt + PRESS_ANTICIP_US) / PRESS_ANTICIP_US;
-			scale = 1 + PRESS_LIFT * smoothStep01(u);
-		} else if (dt >= 0 && dt < PRESS_RECOVERY_US) {
-			const u = dt / PRESS_RECOVERY_US;
-			if (u < 0.6) {
-				// 1-PUNCH → 1+BOUNCE
-				const v = u / 0.6;
-				scale =
-					1 - PRESS_PUNCH + (PRESS_PUNCH + PRESS_BOUNCE) * smoothStep01(v);
-			} else {
-				// 1+BOUNCE → 1
-				const v = (u - 0.6) / 0.4;
-				scale = 1 + PRESS_BOUNCE - PRESS_BOUNCE * smoothStep01(v);
-			}
-		}
-
-		return {
-			pressedSprite,
-			visibleAlpha,
-			scale,
-			right: bestEv.right,
-			dragging: bestEv.dragged,
-		};
-	}
-
-	//  Shaders 
+	//  Shaders
 	const VERT_SRC = `#version 300 es
 in vec2 a_pos;
 out vec2 v_uv;
@@ -920,7 +667,7 @@ void main() {
 			// Press events come from raw samples — smoothing-independent.
 			// Rebuild once per track load; the result is keyed by sample
 			// timestamps, which never move regardless of smoothing settings.
-			rebuildPressEvents();
+			pressEvents = buildPressEvents(cursorSamplesRaw);
 			ensureSmoothingCurrent();
 		} catch (err) {
 			console.warn("Cursor track load failed:", err);
@@ -1007,39 +754,6 @@ void main() {
 	}
 
 	//  Color parsing 
-	function hexToRgba(hex: string, alpha = 1): [number, number, number, number] {
-		const s = hex.trim().replace(/^#/, "");
-		if (s.length < 6) return [17 / 255, 17 / 255, 17 / 255, alpha];
-		const r = parseInt(s.slice(0, 2), 16) / 255;
-		const g = parseInt(s.slice(2, 4), 16) / 255;
-		const b = parseInt(s.slice(4, 6), 16) / 255;
-		const a = s.length >= 8 ? parseInt(s.slice(6, 8), 16) / 255 : alpha;
-		return [r, g, b, a];
-	}
-
-	// Pack the store's gradient string into the flat uniform arrays the shader
-	// consumes. Stops are sorted, padded to MAX_GRADIENT_STOPS (extra slots
-	// repeat the last stop so the shader's clamp is a no-op), and the angle is
-	// converted CSS-degrees → radians. Shares the store parser with the picker
-	// and the Rust rasteriser so preview === export.
-	function buildGradientUniforms(value: string) {
-		const spec = parseGradientSpec(value || "");
-		const sorted = [...spec.stops].sort((a, b) => a.pos - b.pos);
-		const count = Math.min(Math.max(sorted.length, 2), MAX_GRADIENT_STOPS);
-		const colors = new Float32Array(MAX_GRADIENT_STOPS * 4);
-		const positions = new Float32Array(MAX_GRADIENT_STOPS);
-		for (let i = 0; i < MAX_GRADIENT_STOPS; i++) {
-			const stop = sorted[Math.min(i, sorted.length - 1)];
-			const [r, g, b, a] = hexToRgba(stop.color);
-			colors[i * 4] = r;
-			colors[i * 4 + 1] = g;
-			colors[i * 4 + 2] = b;
-			colors[i * 4 + 3] = a;
-			positions[i] = Math.min(1, Math.max(0, stop.pos / 100));
-		}
-		return { colors, positions, count, angleRad: (spec.angle * Math.PI) / 180 };
-	}
-
 	//  Sizing
 	function resizeCanvas() {
 		if (!canvasEl || !containerEl || !store.metadata) return false;
@@ -1571,7 +1285,7 @@ void main() {
 			// fades back in around an upcoming click so the viewer sees
 			// "intent → click → release" rather than a cursor materialising
 			// out of nowhere on the frame the click sound plays.
-			const press = pressStateAt(ts);
+			const press = pressStateAt(pressEvents, ts);
 			const baseAlpha = Math.max(idleA, press.visibleAlpha);
 
 			if (baseAlpha > 0) {
@@ -1588,7 +1302,7 @@ void main() {
 					// the cursor moves on.
 					let posX = pos.x;
 					let posY = pos.y;
-					const anchor = clickAnchorAt(ts);
+					const anchor = clickAnchorAt(pressEvents, ts);
 					if (anchor) {
 						posX = posX * (1 - anchor.weight) + anchor.x * anchor.weight;
 						posY = posY * (1 - anchor.weight) + anchor.y * anchor.weight;
@@ -1608,7 +1322,7 @@ void main() {
 			// it lag behind, reading as delayed/off-target feedback). Uses the
 			// same affine zoom as the cursor so it tracks the zoomed video.
 			if (cs.highlightClicks) {
-				const hl = clickHighlightAt(ts);
+				const hl = clickHighlightAt(pressEvents, ts);
 				if (hl) {
 					highlightAlpha = (cs.highlightOpacity / 100) * hl.alpha;
 					let hlUvX = hl.x / meta.width;

--- a/apps/desktop/src/components/editor/ZoomSuggestionsPopover.svelte
+++ b/apps/desktop/src/components/editor/ZoomSuggestionsPopover.svelte
@@ -24,8 +24,7 @@
   type Status = "idle" | "loading" | "ready" | "error" | "empty";
   let status = $state<Status>("idle");
   let errorMsg = $state<string | null>(null);
-  // Suggestions the user hasn't yet accepted or dismissed. Each refresh
-  // discards the previous set so we don't keep stale suggestions around.
+  // Suggestions not yet accepted or dismissed; each refresh replaces the set.
   let pending = $state<ZoomSuggestion[]>([]);
 
   $effect(() => {
@@ -82,9 +81,7 @@
     return { start: store.trimStart, end: store.trimEnd || duration };
   }
 
-  // Derive per-suggestion placement (or null) so blocked rows can be greyed
-  // out before the user tries to accept them. Re-plans whenever zoom regions
-  // or trim change.
+  // Per-suggestion placement (null = blocked) so blocked rows can be greyed out.
   const placements = $derived.by(() => {
     const bounds = clipBounds();
     if (!bounds) return new Map<string, Interval | null>();
@@ -132,9 +129,7 @@
   function acceptAll() {
     const bounds = clipBounds();
     if (!bounds) return;
-    // Re-plan after each placement so two adjacent suggestions don't both claim
-    // the same slot — a click + settle 400 ms apart would otherwise produce
-    // overlapping windows. We sort by timestamp so earlier triggers win.
+    // Re-plan after each placement (sorted by timestamp) so adjacent suggestions don't claim the same slot.
     const occupied = currentOccupied();
     const sorted = [...pending].sort((a, b) => a.timestampUs - b.timestampUs);
     const skipped: ZoomSuggestion[] = [];

--- a/apps/desktop/src/components/editor/_components/AnnotationOverlay.svelte
+++ b/apps/desktop/src/components/editor/_components/AnnotationOverlay.svelte
@@ -19,6 +19,11 @@
     type Rect,
   } from "$lib/annotations/uv";
   import { FRAME_ANCHORS, snap, type SnapAnchor } from "$lib/annotations/snap";
+  import {
+    arrowGeometry,
+    blurTint,
+    strokeDashPattern,
+  } from "./annotation-draw.logic";
   import type {
     Annotation,
     AnnotationKind,
@@ -246,16 +251,7 @@
           ctx.filter = "none";
           // Variant tint sits on top of the blurred copy so it reads
           // as a deliberate privacy treatment rather than just a smudge.
-          let tint: string | null = null;
-          if (k.variant === "white") tint = "rgba(255,255,255,0.30)";
-          else if (k.variant === "black") tint = "rgba(0,0,0,0.30)";
-          else if (k.variant === "color") {
-            const m = /^#?([0-9a-fA-F]{6})$/.exec(k.tintColor.trim());
-            if (m) {
-              const v = parseInt(m[1], 16);
-              tint = `rgba(${(v >> 16) & 0xff},${(v >> 8) & 0xff},${v & 0xff},0.30)`;
-            }
-          }
+          const tint = blurTint(k.variant, k.tintColor);
           if (tint) {
             ctx.fillStyle = tint;
             ctx.fillRect(x, y, w, h);
@@ -290,20 +286,9 @@
     const r = rectPx();
     const p1 = projectUV(k.x1, k.y1, t);
     const p2 = projectUV(k.x2, k.y2, t);
-    const dx = p2.x - p1.x;
-    const dy = p2.y - p1.y;
-    const len = Math.hypot(dx, dy);
-    if (len < 1) return;
-
     const strokePx = Math.max(2, a.stroke.width * r.w);
-    const headLen = Math.max(strokePx * 2, k.headSize * len);
-    const headWidth = headLen * 0.7;
-    const ux = dx / len;
-    const uy = dy / len;
-    const lineEndX = p2.x - ux * headLen;
-    const lineEndY = p2.y - uy * headLen;
-    const nx = -uy;
-    const ny = ux;
+    const geo = arrowGeometry(p1, p2, strokePx, k.headSize);
+    if (!geo) return;
 
     ctx.save();
     ctx.globalAlpha = opacity;
@@ -315,16 +300,16 @@
 
     ctx.beginPath();
     ctx.moveTo(p1.x, p1.y);
-    ctx.lineTo(lineEndX, lineEndY);
+    ctx.lineTo(geo.lineEnd.x, geo.lineEnd.y);
     ctx.stroke();
 
     // Reset dash before the head fill so it isn't striped.
     ctx.setLineDash([]);
 
     ctx.beginPath();
-    ctx.moveTo(p2.x, p2.y);
-    ctx.lineTo(lineEndX + nx * headWidth * 0.5, lineEndY + ny * headWidth * 0.5);
-    ctx.lineTo(lineEndX - nx * headWidth * 0.5, lineEndY - ny * headWidth * 0.5);
+    ctx.moveTo(geo.tip.x, geo.tip.y);
+    ctx.lineTo(geo.left.x, geo.left.y);
+    ctx.lineTo(geo.right.x, geo.right.y);
     ctx.closePath();
     ctx.fill();
 
@@ -339,14 +324,8 @@
   ) {
     ctx.lineWidth = strokePx;
     const style = a.stroke.style ?? "solid";
-    if (style === "dashed") {
-      ctx.setLineDash([8 * strokePx, 6 * strokePx]);
-    } else if (style === "dotted") {
-      ctx.setLineDash([2 * strokePx, 4 * strokePx]);
-      ctx.lineCap = "round";
-    } else {
-      ctx.setLineDash([]);
-    }
+    ctx.setLineDash(strokeDashPattern(style, strokePx));
+    if (style === "dotted") ctx.lineCap = "round";
   }
 
   /** Apply the optional preview-only glow (rendered before fill/stroke). */

--- a/apps/desktop/src/components/editor/_components/AnnotationOverlay.svelte
+++ b/apps/desktop/src/components/editor/_components/AnnotationOverlay.svelte
@@ -86,9 +86,8 @@
   const HOVER_FLASH_COLOUR = "rgba(59,130,246,0.85)";
   const SNAP_GUIDE_COLOUR = "rgba(59,130,246,0.7)";
 
-  //  Helpers — thin wrappers around shared modules so this file just owns
-  //  rendering + interaction state, not geometry math.
-
+  // Thin wrappers around shared geometry modules; this file owns rendering +
+  // interaction state, not the math.
   function getDpr(): number {
     return window.devicePixelRatio || 1;
   }
@@ -139,20 +138,12 @@
     opacity: number,
     t: number,
   ) {
-    // Blur annotations bypass the fade-in/out ramps in preview because:
-    //   1. A fresh blur has start ≈ currentTime, so the linear ramp puts
-    //      opacity at 0 → drawAnnotation would early-return → user sees
-    //      nothing right after creating the blur.
-    //   2. A partially-transparent blur copy mixed over the unblurred
-    //      WebGL canvas reads as flicker, not a smooth fade — Canvas2D's
-    //      globalAlpha applies to drawImage too.
-    // Plus: while a blur is the *selected* annotation, always render it
-    // even outside its [start, end] window. The user is actively editing
-    // it; floating-point drift between `a.start` (captured at creation
-    // time from `store.currentTime`) and `t` (from `videoEl.currentTime`
-    // on the next animation frame) was making fresh blurs flicker on the
-    // first few frames after placement. The export pipeline still honours
-    // `start`/`end` exactly.
+    // Blur bypasses the fade ramps in preview: a fresh blur (start ≈ currentTime)
+    // would ramp from opacity 0 and early-return, and a half-transparent blur
+    // copy over the unblurred canvas reads as flicker (globalAlpha applies to
+    // drawImage). When a blur is selected, render it even outside [start, end] —
+    // float drift between a.start and t flickered fresh blurs on placement.
+    // Export still honours start/end exactly.
     const isBlur = a.kind.kind === "blur";
     const isSelected = a.id === store.selectedAnnotationId;
     if (isBlur) {
@@ -195,19 +186,15 @@
     } else if (a.kind.kind === "image") {
       ctx.rect(x, y, w, h);
     } else if (a.kind.kind === "blur") {
-      // Real blur preview: copy the WebGL composite (full background +
-      // padding + video) into the overlay canvas, blurred with the 2D
-      // context's native `filter`. This is reliable across WebView
-      // backends, unlike `backdrop-filter` against a GPU-promoted canvas.
-      // Strength 0..1 maps to 0..32 px to match the export-side cap.
+      // Copy the WebGL composite into the overlay canvas, blurred via the 2D
+      // context's native `filter` — reliable across WebView backends, unlike
+      // backdrop-filter on a GPU-promoted canvas. Strength 0..1 → 0..32 px,
+      // matching the export-side cap.
       const k = a.kind;
       if (compositeCanvasEl && w > 1 && h > 1) {
         const blurPx = Math.max(0.001, Math.min(32, k.strength * 32));
-        // Source rect: same UV → canvas-px mapping, but in the WebGL
-        // canvas's own backing-store coordinates. Both canvases share the
-        // same DPR + size factor here because they both stretch to the
-        // same `targetEl`, so we can read `compositeCanvasEl.width/height`
-        // and treat its pixel space as proportional to ours.
+        // Source rect in the WebGL canvas's backing-store coords. Both canvases
+        // stretch to the same targetEl, so its pixel space is proportional to ours.
         const srcW = compositeCanvasEl.width;
         const srcH = compositeCanvasEl.height;
         const dstW = canvasEl?.width ?? 0;
@@ -226,10 +213,8 @@
             ctx.rect(x, y, w, h);
           }
           ctx.clip();
-          // Setting `filter` on the 2D context applies to subsequent draws
-          // — including `drawImage` from another canvas. Browser
-          // implementations promote this to a GPU shader, so the cost is
-          // negligible per blur region.
+          // `filter` applies to the following drawImage; browsers promote this
+          // to a GPU shader, so it's cheap per blur region.
           ctx.filter = `blur(${blurPx.toFixed(2)}px)`;
           try {
             ctx.drawImage(

--- a/apps/desktop/src/components/editor/_components/AnnotationStatusRail.svelte
+++ b/apps/desktop/src/components/editor/_components/AnnotationStatusRail.svelte
@@ -10,9 +10,7 @@
 
   let { store }: Props = $props();
 
-  // Auto-hide when there are zero annotations so non-annotation users never see
-  // the rail. Visible whenever any annotation exists, regardless of which tab
-  // the user is on — that's the whole point of a global status rail.
+  // Global rail: visible whenever any annotation exists, regardless of active tab.
   const visible = $derived(store.annotations.length > 0);
   const onAnnotationsTab = $derived(store.activePanel === "annotations");
   const hidden = $derived(store.annotationsGloballyHidden);

--- a/apps/desktop/src/components/editor/_components/BezierEditor.svelte
+++ b/apps/desktop/src/components/editor/_components/BezierEditor.svelte
@@ -30,9 +30,8 @@
     disabled = false,
   }: Props = $props();
 
-  // The SVG viewBox is the unit square `0..1`, with `overshoot` units of
-  // padding on each side so handles whose y exits [0,1] (bounce / spring)
-  // remain grabbable. We flip y at render time because SVG y grows down.
+  // viewBox is the unit square plus OVERSHOOT padding so bounce/spring handles
+  // (y outside [0,1]) stay grabbable. y is flipped at render time (SVG y grows down).
   const OVERSHOOT = 0.6;
   const VB_MIN = -OVERSHOOT;
   const VB_SPAN = 1 + OVERSHOOT * 2;
@@ -140,12 +139,7 @@
     )}
     style:padding="6px"
   >
-    <!--
-      The SVG surface receives pointermove/up to continue a drag started on a
-      handle (standard drag UX). It has no role of its own — the semantics
-      live on the two handle circles below, which expose slider roles so AT
-      users can identify and value-read each control point.
-    -->
+    <!-- Surface only receives pointermove/up to continue a drag; the slider roles live on the handle circles. -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <svg
       bind:this={svgEl}

--- a/apps/desktop/src/components/editor/_components/BlurAnnotationLayer.svelte
+++ b/apps/desktop/src/components/editor/_components/BlurAnnotationLayer.svelte
@@ -7,16 +7,9 @@
   } from "$lib/stores/editor-store.svelte";
   import { onDestroy, onMount } from "svelte";
 
-  // HTML layer for blur annotations. Sits between the WebGL composite and
-  // the 2D AnnotationOverlay canvas so the canvas can still draw selection
-  // handles ON TOP of the blur, while the blur itself runs as native
-  // `backdrop-filter: blur(Npx)` against the live video pixels underneath.
-  //
-  // The 2D canvas can't backdrop-blur its own pixels (and Canvas2D's `filter`
-  // only blurs what you draw, not what's behind it), so we delegate the
-  // visual to compositor-accelerated CSS. At export time, FFmpeg's `boxblur`
-  // filter (see `commands/ffmpeg.rs::build_annotation_blur_complex`) does
-  // the equivalent in a deterministic offline pass.
+  // Blur via native `backdrop-filter` against the video underneath — Canvas2D can't
+  // blur what's behind it, so this layer sits below the 2D overlay (which draws handles on top).
+  // PARITY: export side uses FFmpeg boxblur (commands/ffmpeg.rs::build_annotation_blur_complex).
 
   interface Props {
     store: EditorStore;
@@ -31,8 +24,7 @@
   let layerSize = $state({ w: 0, h: 0 });
   let resizeObserver: ResizeObserver | null = null;
   let rafHandle: number | null = null;
-  // rAF tick so positions track playback (the store doesn't dispatch on every
-  // video frame). Same pattern as TextAnnotationLayer.
+  // rAF tick so positions track playback (store doesn't dispatch per video frame).
   let _frame = $state(0);
 
   function videoRectCss() {
@@ -75,13 +67,7 @@
     resizeObserver?.disconnect();
   });
 
-  /**
-   * Build the per-annotation positioning + tint style. Strength 0..1 maps to
-   * 0..32 px of `backdrop-filter: blur(Npx)`, which mirrors the export-side
-   * boxblur radius cap of 5% of the shorter canvas edge — the two pipelines
-   * stay close enough that what users see in preview matches what they get
-   * in the exported file.
-   */
+  // Per-annotation positioning + tint style; blur radius tuned to match export-side boxblur.
   function styleFor(a: Annotation): string {
     if (a.kind.kind !== "blur") return "display: none;";
     void _frame;
@@ -99,10 +85,7 @@
     const h = Math.abs(br.y - tl.y);
     if (w < 1 || h < 1) return "display: none;";
 
-    // 0..1 → 0..96 px (CSS), with an ease-in curve so the bottom of the
-    // slider stays subtle while the top reaches redaction-grade. CSS
-    // backdrop-filter is roughly Gaussian, so 96px ≈ σ40 — comparable to
-    // FFmpeg boxblur(127, power=3) used at export.
+    // 0..1 → 0..96px, ease-in. 96px ≈ σ40, comparable to export's FFmpeg boxblur(127, power=3).
     const t01 = Math.max(0, Math.min(1, k.strength));
     const blurPx = Math.pow(t01, 0.7) * 96;
     const radiusPx = Math.max(
@@ -110,19 +93,14 @@
       k.radius * Math.min(layerSize.w, layerSize.h),
     );
 
-    // Variant tint scales with strength so the slider doubles as a
-    // legibility cut: at strength=0 the tint disappears, at strength=1 it
-    // covers ~95% (effectively a redaction box). Browsers also clamp very
-    // large backdrop-filter radii internally, so the rising tint is what
-    // actually guarantees redaction at the high end of the slider.
+    // Tint scales with strength: browsers clamp huge backdrop-filter radii, so the
+    // rising tint is what actually guarantees redaction at the top of the slider.
     const tintAlpha = 0.15 + 0.80 * t01;
     let tint = "transparent";
     if (k.variant === "white") tint = `rgba(255,255,255,${tintAlpha.toFixed(3)})`;
     else if (k.variant === "black") tint = `rgba(0,0,0,${tintAlpha.toFixed(3)})`;
     else if (k.variant === "color") tint = hexToRgba(k.tintColor, tintAlpha);
-    // glass = blur only. Add a faint mid-grey wash that grows past
-    // strength=0.6 so the glass variant also redacts when pushed hard,
-    // while staying invisible at low strengths.
+    // glass = blur only, plus a faint grey wash past strength 0.6 so it still redacts when pushed hard.
     else if (k.variant === "glass" && t01 > 0.6) {
       tint = `rgba(128,128,128,${((t01 - 0.6) * 0.6).toFixed(3)})`;
     }

--- a/apps/desktop/src/components/editor/_components/CameraOverlay.svelte
+++ b/apps/desktop/src/components/editor/_components/CameraOverlay.svelte
@@ -6,11 +6,9 @@
     store: EditorStore;
     /** The screen video element, used as the time-base for camera sync. */
     videoEl: HTMLVideoElement | null;
-    /** The preview rectangle (canvas-sized div) — used as the positioning
-     *  parent and the drag-coord reference. */
+    /** Preview rectangle (canvas-sized div) — positioning parent and drag-coord reference. */
     targetEl: HTMLDivElement | null;
-    /** `convertFileSrc(camera.mp4)` for this project, or empty when no
-     *  camera was recorded. The component renders nothing when empty. */
+    /** `convertFileSrc(camera.mp4)`, or empty when no camera was recorded (renders nothing). */
     cameraSrc: string;
   }
 
@@ -18,10 +16,8 @@
 
   let cameraVideoEl: HTMLVideoElement | null = $state(null);
 
-  // Final-canvas geometry. Drives the bubble's absolute placement inside
-  // `targetEl`. The bubble's UV is in *video* space (so the user picks
-  // "bottom-right of the video" not "of the canvas-with-padding"), and we
-  // transform that into canvas-pixel offsets here.
+  // Bubble UV is in *video* space (so "bottom-right of the video", not of the padded
+  // canvas); transformed into canvas-pixel offsets here.
   const geom = $derived.by(() => {
     const m = store.metadata;
     if (!m || !m.width || !m.height) return null;
@@ -33,15 +29,8 @@
     );
   });
 
-  /**
-   * Bubble CSS position. The wrapper sits inside `targetEl` (which fills
-   * the canvas), so we express x/y/width as percentages of the canvas.
-   *
-   * Height is omitted on purpose — we use `aspect-ratio: 1` to keep the
-   * bubble square on screen regardless of video aspect (a 1:1 placement
-   * in UV coords would render rectangular on a 16:9 video, which is not
-   * what users picking "rounded square" expect).
-   */
+  // x/y/width as canvas percentages. Height is omitted; `aspect-ratio: 1` keeps
+  // the bubble square regardless of video aspect (UV 1:1 would render rectangular on 16:9).
   const bubbleStyle = $derived.by(() => {
     if (!geom) return "display:none;";
     const p = store.cameraOverlay.defaultPlacement;
@@ -51,9 +40,7 @@
     return `left:${left}%;top:${top}%;width:${width}%;`;
   });
 
-  /** border-radius derived from the saved shape. Square → 0; rounded uses
-   *  the saved corner-radius (16% default); circle is 50% (with the
-   *  enforced 1:1 aspect this gives a true circle). */
+  // square → 0; rounded → saved corner-radius (16% default); circle → 50% (true circle with the 1:1 aspect).
   const borderRadius = $derived.by(() => {
     const s = store.cameraOverlay.shape;
     if (s === "circle") return "50%";
@@ -61,12 +48,8 @@
     return `${(store.cameraOverlay.cornerRadius ?? 0.16) * 100}%`;
   });
 
-  // Drift correction: keep the camera <video> within ~150 ms of the screen
-  // video at all times. Re-runs whenever `store.currentTime` ticks (set by
-  // the screen video's `timeupdate`) and on user scrubs (handled via the
-  // route's onSeeked → store.currentTime path). The 150 ms tolerance keeps
-  // micro-jitter between two HTMLVideoElement clocks from triggering
-  // unnecessary seeks during normal playback.
+  // Keep the camera <video> within ~150ms of the screen video; the tolerance avoids
+  // re-seeking on micro-jitter between the two HTMLVideoElement clocks.
   $effect(() => {
     void store.currentTime;
     if (!cameraVideoEl || !videoEl) return;
@@ -76,19 +59,15 @@
     }
   });
 
-  // Play/pause the camera in lockstep with the screen video. Mirrors the
-  // existing audio-element sync in the editor route — set currentTime to
-  // the screen's instant before starting playback so the first frame is
-  // the right one even after a long pause.
+  // Play/pause in lockstep; set currentTime to the screen's instant before play so
+  // the first frame is correct even after a long pause.
   $effect(() => {
     const playing = store.isPlaying;
     if (!cameraVideoEl) return;
     if (playing) {
       if (videoEl) cameraVideoEl.currentTime = videoEl.currentTime;
       void cameraVideoEl.play().catch((err) => {
-        // Autoplay restrictions don't apply because we're muted, but
-        // network/decoder hiccups can still throw — keep the screen video
-        // playing in that case.
+        // Network/decoder hiccups can still throw; keep the screen video playing.
         console.warn("camera overlay play failed:", err);
       });
     } else {
@@ -96,13 +75,8 @@
     }
   });
 
-  //  Drag-to-reposition
-  //
-  // Pointer-captured drag in the preview. `dragStartUv` snapshots the
-  // placement at pointerdown and we accumulate UV-space deltas relative to
-  // the rendered video rect (NOT the canvas, so padding doesn't bias the
-  // motion). The single `pushUndoState` lives at pointerdown so the entire
-  // drag collapses to one undo entry.
+  // Drag-to-reposition. UV deltas are relative to the rendered video rect (not the
+  // canvas, so padding doesn't bias motion); pushUndoState at pointerdown = one undo entry.
   let isDragging = $state(false);
   let dragStartClient = { x: 0, y: 0 };
   let dragStartUv = { x: 0, y: 0 };
@@ -122,10 +96,7 @@
     if (!isDragging || !targetEl || !geom) return;
     const rect = targetEl.getBoundingClientRect();
     if (rect.width <= 0 || rect.height <= 0) return;
-    // Convert CSS-pixel drag deltas into video-UV deltas. The canvas spans
-    // the full rect; the video is at (videoX, videoY) with size
-    // (videoW, videoH) inside it. Drag distance / video CSS size =
-    // UV delta.
+    // CSS-pixel drag deltas → video-UV deltas (drag distance / video CSS size).
     const videoCssW = rect.width * (geom.videoW / geom.canvasW);
     const videoCssH = rect.height * (geom.videoH / geom.canvasH);
     if (videoCssW <= 0 || videoCssH <= 0) return;
@@ -151,9 +122,7 @@
 </script>
 
 {#if cameraSrc && store.cameraOverlay.enabled && geom}
-  <!-- Bubble wrapper — owns position, shape, shadow, and drag pointers. The
-       <video> inside fills the wrapper with object-fit:cover so the camera
-       feed fills the bubble cleanly regardless of camera resolution. -->
+  <!-- Bubble wrapper owns position, shape, shadow, and drag pointers; the <video> fills it via object-fit:cover. -->
   <div
     role="presentation"
     class="absolute select-none"

--- a/apps/desktop/src/components/editor/_components/FocusOverlay.svelte
+++ b/apps/desktop/src/components/editor/_components/FocusOverlay.svelte
@@ -4,6 +4,14 @@
     type EditorStore,
     type ZoomRegion,
   } from "$lib/stores/editor-store.svelte";
+  import {
+    cursorForHandle,
+    HANDLE_RADIUS_PX,
+    handlePositions,
+    hitTestHandle,
+    regionBox,
+    type HandleName,
+  } from "./focus-overlay.logic";
   import { onDestroy, onMount } from "svelte";
 
   interface Props {
@@ -19,7 +27,6 @@
   let rafHandle: number | null = null;
   let resizeObserver: ResizeObserver | null = null;
 
-  type HandleName = "nw" | "n" | "ne" | "e" | "se" | "s" | "sw" | "w" | "body";
   type DragState =
     | null
     | {
@@ -39,7 +46,6 @@
       };
   let drag: DragState = null;
 
-  const HANDLE_RADIUS_PX = 6;
   const SELECTION_COLOUR = "#3b82f6";
   const MIN_SCALE = 1.05;
   const MAX_SCALE = 3;
@@ -86,54 +92,6 @@
       x: (e.clientX - rect.left) * dpr,
       y: (e.clientY - rect.top) * dpr,
     };
-  }
-
-  /** The UV-space box the focus rectangle occupies on the source frame. */
-  function regionBox(r: ZoomRegion): { x: number; y: number; w: number; h: number } {
-    const s = Math.max(1.001, r.scale);
-    const w = 1 / s;
-    const h = 1 / s;
-    // Clamp so the rect stays inside [0,1]².
-    const cx = Math.min(Math.max(r.centerX, w / 2), 1 - w / 2);
-    const cy = Math.min(Math.max(r.centerY, h / 2), 1 - h / 2);
-    return { x: cx - w / 2, y: cy - h / 2, w, h };
-  }
-
-  function handlePositions(
-    x: number,
-    y: number,
-    w: number,
-    h: number,
-  ): Record<Exclude<HandleName, "body">, { x: number; y: number }> {
-    return {
-      nw: { x, y },
-      n: { x: x + w / 2, y },
-      ne: { x: x + w, y },
-      e: { x: x + w, y: y + h / 2 },
-      se: { x: x + w, y: y + h },
-      s: { x: x + w / 2, y: y + h },
-      sw: { x, y: y + h },
-      w: { x, y: y + h / 2 },
-    };
-  }
-
-  function hitTestHandle(
-    pt: { x: number; y: number },
-    x: number,
-    y: number,
-    w: number,
-    h: number,
-  ): HandleName | null {
-    const dpr = getDpr();
-    const slop = HANDLE_RADIUS_PX * dpr + 2 * dpr;
-    const handles = handlePositions(x, y, w, h);
-    for (const [name, p] of Object.entries(handles)) {
-      if (Math.abs(pt.x - p.x) <= slop && Math.abs(pt.y - p.y) <= slop) {
-        return name as HandleName;
-      }
-    }
-    if (pt.x >= x && pt.x <= x + w && pt.y >= y && pt.y <= y + h) return "body";
-    return null;
   }
 
   function selectedRegion(): ZoomRegion | null {
@@ -212,27 +170,6 @@
     rafHandle = requestAnimationFrame(tick);
   }
 
-  function cursorForHandle(h: HandleName | null): string {
-    switch (h) {
-      case "nw":
-      case "se":
-        return "nwse-resize";
-      case "ne":
-      case "sw":
-        return "nesw-resize";
-      case "n":
-      case "s":
-        return "ns-resize";
-      case "e":
-      case "w":
-        return "ew-resize";
-      case "body":
-        return "move";
-      default:
-        return "";
-    }
-  }
-
   function handlePointerDown(e: PointerEvent) {
     const r = selectedRegion();
     if (!r || !canvasEl) return;
@@ -243,7 +180,7 @@
     const w = br.x - tl.x;
     const h = br.y - tl.y;
 
-    const hit = hitTestHandle(pt, tl.x, tl.y, w, h);
+    const hit = hitTestHandle(pt, tl.x, tl.y, w, h, getDpr());
     if (!hit) return;
 
     (e.currentTarget as Element).setPointerCapture(e.pointerId);
@@ -285,7 +222,7 @@
       const box = regionBox(r);
       const tl = uvToCanvas(box.x, box.y);
       const br = uvToCanvas(box.x + box.w, box.y + box.h);
-      const hit = hitTestHandle(pt, tl.x, tl.y, br.x - tl.x, br.y - tl.y);
+      const hit = hitTestHandle(pt, tl.x, tl.y, br.x - tl.x, br.y - tl.y, getDpr());
       canvasEl.style.cursor = cursorForHandle(hit);
       return;
     }

--- a/apps/desktop/src/components/editor/_components/FocusOverlay.svelte
+++ b/apps/desktop/src/components/editor/_components/FocusOverlay.svelte
@@ -303,18 +303,16 @@
     resizeObserver?.disconnect();
   });
 
-  // Reactive triggers — the RAF loop already picks up store changes each
-  // frame, but touching them here keeps the effect graph wired for Svelte 5.
+  // The RAF loop already reads the store each frame; touching these keeps the
+  // Svelte 5 effect graph wired.
   $effect(() => {
     void store.selectedZoomRegionId;
     void store.zoomRegions;
     void store.padding;
   });
 
-  // Editing chrome (dashed rect, handles, crosshair) is only meaningful while
-  // the user is on the Focus tab — otherwise the overlay both hides itself and
-  // stops swallowing pointer events so clicks reach the AnnotationOverlay or
-  // the preview underneath.
+  // Off the Focus tab the overlay hides and stops swallowing pointer events so
+  // clicks reach the AnnotationOverlay / preview underneath.
   const isActive = $derived(
     store.activePanel === "focus" && store.selectedZoomRegionId !== null,
   );

--- a/apps/desktop/src/components/editor/_components/TextAnnotationLayer.svelte
+++ b/apps/desktop/src/components/editor/_components/TextAnnotationLayer.svelte
@@ -8,16 +8,10 @@
   } from "$lib/stores/editor-store.svelte";
   import { onDestroy, onMount, tick } from "svelte";
 
-  // HTML layer for text annotations only. Lives as a sibling to
-  // AnnotationOverlay (the 2D canvas) so that:
-  //   - text uses the WebView's full glyph rendering (kerning, ligatures)
-  //   - inline editing via `contenteditable` is trivial
-  //   - inert canvas-side draw code stays simple (just a `kind === "text"`
-  //     skip)
-  //
-  // At export time, `lib/export/rasterize-text.ts` walks every text annotation
-  // and rasterizes it to a PNG that's then fed to the Rust pipeline as an
-  // image-kind annotation. Rust never sees fonts.
+  // HTML layer (sibling to the 2D AnnotationOverlay) so text gets the WebView's
+  // full glyph rendering and contenteditable inline editing.
+  // PARITY: export rasterizes each text annotation to a PNG (lib/export/rasterize-text.ts);
+  // Rust never sees fonts.
 
   interface Props {
     store: EditorStore;
@@ -33,13 +27,10 @@
   let editingId = $state<string | null>(null);
   let resizeObserver: ResizeObserver | null = null;
   let rafHandle: number | null = null;
-  // Track time/zoom changes via rAF; the store doesn't fire on every video
-  // tick so the cheapest correct path is to rebuild positions per frame.
+  // rAF tick to rebuild positions per frame (store doesn't fire on every video tick).
   let _frame = $state(0);
 
-  // Drag state for text annotations. Text is a sibling HTML element so we
-  // can't piggyback on AnnotationOverlay's pointer flow — we run our own
-  // here, using the same UV math + snap engine so behavior matches.
+  // Own pointer flow (text is a sibling HTML element), using the same UV math + snap engine as the canvas.
   type TextDrag = {
     id: string;
     startX: number; // UV
@@ -48,8 +39,7 @@
     moved: boolean; // true once we cross the click vs drag threshold
   } | null;
   let drag: TextDrag = $state(null);
-  // Click-vs-drag threshold in CSS px. Below this the gesture is treated as a
-  // click (select); above it, the gesture commits a move.
+  // Below this (CSS px) the gesture is a click (select); above it, a move.
   const CLICK_DRAG_THRESHOLD_PX = 3;
 
   function videoRectCss() {
@@ -109,9 +99,7 @@
     resizeObserver?.disconnect();
   });
 
-  // Per-annotation reactive style derived from the box, the playhead, and
-  // the layer dims. The `_frame` dependency forces re-derive on rAF ticks
-  // so the position tracks playback / zoom animations.
+  // `_frame` dependency forces re-derive on rAF ticks so position tracks playback/zoom.
   function styleFor(a: Annotation): string {
     if (a.kind.kind !== "text") return "";
     void _frame;
@@ -184,9 +172,7 @@
     }
   }
 
-  /** Build snap anchors from frame edges + every other annotation's box.
-   *  Mirrors the anchor set used by AnnotationOverlay for canvas-rendered
-   *  shapes so dragging text feels identical to dragging a rectangle. */
+  // Frame edges + every other annotation's box; mirrors AnnotationOverlay's anchor set.
   function buildSnapAnchors(excludeId: string | null): SnapAnchor[] {
     const anchors: SnapAnchor[] = [...FRAME_ANCHORS];
     for (const a of store.annotations) {
@@ -225,9 +211,7 @@
     if (editingId === a.id) return; // let contenteditable take the gesture
     if (a.locked || a.kind.kind !== "text") return;
     if (e.button !== 0) return;
-    // Don't fight the WebGL canvas / focus overlay — text dragging is only
-    // available on the Annotations tab (matches the rest of the editor's
-    // pointer gating).
+    // Text dragging only on the Annotations tab so it doesn't fight the canvas/focus overlay.
     if (store.activePanel !== "annotations") return;
 
     e.stopPropagation();
@@ -340,9 +324,7 @@
         onclick={(e) => {
           if (!interactive) return;
           if (isEditing) return;
-          // Suppress the click that tails a successful drag — otherwise the
-          // selection would be reasserted but the gesture would also re-emit
-          // a stray select. The drag is already over by `click` time.
+          // Suppress the click that tails a successful drag.
           if (drag?.id === a.id && drag?.moved) {
             e.stopPropagation();
             return;

--- a/apps/desktop/src/components/editor/_components/annotation-draw.logic.test.ts
+++ b/apps/desktop/src/components/editor/_components/annotation-draw.logic.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+	arrowGeometry,
+	blurTint,
+	strokeDashPattern,
+} from "./annotation-draw.logic";
+
+describe("strokeDashPattern", () => {
+	it("scales dash arrays by stroke width; solid is empty", () => {
+		expect(strokeDashPattern("solid", 2)).toEqual([]);
+		expect(strokeDashPattern(undefined, 2)).toEqual([]);
+		expect(strokeDashPattern("dashed", 2)).toEqual([16, 12]);
+		expect(strokeDashPattern("dotted", 3)).toEqual([6, 12]);
+	});
+});
+
+describe("blurTint", () => {
+	it("returns fixed tints for white/black", () => {
+		expect(blurTint("white", "")).toBe("rgba(255,255,255,0.30)");
+		expect(blurTint("black", "")).toBe("rgba(0,0,0,0.30)");
+	});
+	it("parses a #rrggbb colour variant", () => {
+		expect(blurTint("color", "#ff8000")).toBe("rgba(255,128,0,0.30)");
+		expect(blurTint("color", "00ff00")).toBe("rgba(0,255,0,0.30)");
+	});
+	it("returns null for no-tint or invalid colour", () => {
+		expect(blurTint("none", "")).toBeNull();
+		expect(blurTint("color", "nope")).toBeNull();
+	});
+});
+
+describe("arrowGeometry", () => {
+	it("is null for a degenerate arrow", () => {
+		expect(arrowGeometry({ x: 0, y: 0 }, { x: 0.5, y: 0 }, 2, 0.2)).toBeNull();
+	});
+	it("computes shaft end and symmetric head corners", () => {
+		const g = arrowGeometry({ x: 0, y: 0 }, { x: 100, y: 0 }, 2, 0.2)!;
+		// len 100, headLen max(4, 20)=20, headWidth 14
+		expect(g.tip).toEqual({ x: 100, y: 0 });
+		expect(g.lineEnd.x).toBeCloseTo(80, 5);
+		expect(g.left.y).toBeCloseTo(7, 5);
+		expect(g.right.y).toBeCloseTo(-7, 5);
+	});
+	it("respects the stroke-width floor on head length", () => {
+		// tiny headSize → headLen floored at strokePx*2 = 20
+		const g = arrowGeometry({ x: 0, y: 0 }, { x: 100, y: 0 }, 10, 0.01)!;
+		expect(g.lineEnd.x).toBeCloseTo(80, 5);
+	});
+});

--- a/apps/desktop/src/components/editor/_components/annotation-draw.logic.ts
+++ b/apps/desktop/src/components/editor/_components/annotation-draw.logic.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure, testable bits of the annotation canvas rendering: arrow head geometry,
+ * stroke dash patterns, and blur-variant tint colours. The imperative drawing
+ * (ctx.fill/stroke/clip etc.) stays in AnnotationOverlay — it's view-bound to
+ * the component's canvas/project helpers and isn't meaningfully unit-testable;
+ * these helpers are the maths it builds on.
+ */
+
+export type StrokeStyle = "solid" | "dashed" | "dotted";
+
+/** Canvas dash array for a stroke style, scaled by stroke width. Empty = solid. */
+export function strokeDashPattern(
+	style: StrokeStyle | undefined,
+	strokePx: number,
+): number[] {
+	if (style === "dashed") return [8 * strokePx, 6 * strokePx];
+	if (style === "dotted") return [2 * strokePx, 4 * strokePx];
+	return [];
+}
+
+/**
+ * Tint overlay for a blur annotation variant, or null when there's no tint.
+ * `color` variant parses a `#rrggbb` (with/without `#`); invalid colour → null.
+ */
+export function blurTint(variant: string, tintColor: string): string | null {
+	if (variant === "white") return "rgba(255,255,255,0.30)";
+	if (variant === "black") return "rgba(0,0,0,0.30)";
+	if (variant === "color") {
+		const m = /^#?([0-9a-fA-F]{6})$/.exec(tintColor.trim());
+		if (m) {
+			const v = parseInt(m[1], 16);
+			return `rgba(${(v >> 16) & 0xff},${(v >> 8) & 0xff},${v & 0xff},0.30)`;
+		}
+	}
+	return null;
+}
+
+export interface Point {
+	x: number;
+	y: number;
+}
+
+export interface ArrowGeometry {
+	/** Where the shaft ends (base of the head). */
+	lineEnd: Point;
+	/** The arrow tip (p2). */
+	tip: Point;
+	/** The two base corners of the head triangle. */
+	left: Point;
+	right: Point;
+}
+
+/**
+ * Arrow shaft + head triangle geometry from endpoints, stroke width, and head
+ * size (fraction of length). Returns null for a degenerate (sub-pixel) arrow.
+ */
+export function arrowGeometry(
+	p1: Point,
+	p2: Point,
+	strokePx: number,
+	headSize: number,
+): ArrowGeometry | null {
+	const dx = p2.x - p1.x;
+	const dy = p2.y - p1.y;
+	const len = Math.hypot(dx, dy);
+	if (len < 1) return null;
+	const headLen = Math.max(strokePx * 2, headSize * len);
+	const headWidth = headLen * 0.7;
+	const ux = dx / len;
+	const uy = dy / len;
+	const lineEndX = p2.x - ux * headLen;
+	const lineEndY = p2.y - uy * headLen;
+	const nx = -uy;
+	const ny = ux;
+	return {
+		lineEnd: { x: lineEndX, y: lineEndY },
+		tip: { x: p2.x, y: p2.y },
+		left: { x: lineEndX + nx * headWidth * 0.5, y: lineEndY + ny * headWidth * 0.5 },
+		right: { x: lineEndX - nx * headWidth * 0.5, y: lineEndY - ny * headWidth * 0.5 },
+	};
+}

--- a/apps/desktop/src/components/editor/_components/annotation-draw.logic.ts
+++ b/apps/desktop/src/components/editor/_components/annotation-draw.logic.ts
@@ -1,9 +1,6 @@
 /**
- * Pure, testable bits of the annotation canvas rendering: arrow head geometry,
- * stroke dash patterns, and blur-variant tint colours. The imperative drawing
- * (ctx.fill/stroke/clip etc.) stays in AnnotationOverlay — it's view-bound to
- * the component's canvas/project helpers and isn't meaningfully unit-testable;
- * these helpers are the maths it builds on.
+ * Annotation rendering maths: arrow-head geometry, stroke dash patterns, and
+ * blur-variant tint colours. The imperative drawing stays in AnnotationOverlay.
  */
 
 export type StrokeStyle = "solid" | "dashed" | "dotted";

--- a/apps/desktop/src/components/editor/_components/focus-overlay.logic.test.ts
+++ b/apps/desktop/src/components/editor/_components/focus-overlay.logic.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+	cursorForHandle,
+	handlePositions,
+	hitTestHandle,
+	regionBox,
+} from "./focus-overlay.logic";
+
+describe("regionBox", () => {
+	it("centres a 1/scale square and clamps inside the frame", () => {
+		// scale 2 → side 0.5, centred → [0.25, 0.75]
+		expect(regionBox({ scale: 2, centerX: 0.5, centerY: 0.5 })).toEqual({
+			x: 0.25,
+			y: 0.25,
+			w: 0.5,
+			h: 0.5,
+		});
+	});
+	it("pushes an off-frame centre back inside", () => {
+		const b = regionBox({ scale: 2, centerX: 0, centerY: 1 });
+		expect(b.x).toBeCloseTo(0); // clamped to w/2 - w/2
+		expect(b.y).toBeCloseTo(0.5);
+	});
+});
+
+describe("handlePositions", () => {
+	it("places the 8 anchors around the rect", () => {
+		const h = handlePositions(0, 0, 10, 20);
+		expect(h.nw).toEqual({ x: 0, y: 0 });
+		expect(h.se).toEqual({ x: 10, y: 20 });
+		expect(h.n).toEqual({ x: 5, y: 0 });
+		expect(h.e).toEqual({ x: 10, y: 10 });
+	});
+});
+
+describe("hitTestHandle", () => {
+	it("detects a corner handle within slop", () => {
+		expect(hitTestHandle({ x: 0, y: 0 }, 0, 0, 100, 100, 1)).toBe("nw");
+	});
+	it("returns body for an interior point", () => {
+		expect(hitTestHandle({ x: 50, y: 50 }, 0, 0, 100, 100, 1)).toBe("body");
+	});
+	it("returns null outside the rect", () => {
+		expect(hitTestHandle({ x: 200, y: 200 }, 0, 0, 100, 100, 1)).toBeNull();
+	});
+});
+
+describe("cursorForHandle", () => {
+	it("maps handles to resize cursors", () => {
+		expect(cursorForHandle("nw")).toBe("nwse-resize");
+		expect(cursorForHandle("e")).toBe("ew-resize");
+		expect(cursorForHandle("body")).toBe("move");
+		expect(cursorForHandle(null)).toBe("");
+	});
+});

--- a/apps/desktop/src/components/editor/_components/focus-overlay.logic.ts
+++ b/apps/desktop/src/components/editor/_components/focus-overlay.logic.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure geometry for the focus/zoom-region editing overlay: the UV-space box a
+ * region occupies, its resize-handle positions, hit-testing, and the cursor for
+ * a handle. Extracted from FocusOverlay so the maths is testable; the component
+ * keeps the canvas/store wiring and the drawing.
+ *
+ * NOTE: this is the zoom-region editor's own source-space geometry — it does NOT
+ * use the zoom-aware/aspect-aware helpers in `$lib/annotations/uv.ts` (those are
+ * for annotations, which live in zoomed space). Keep the two separate.
+ */
+
+export type HandleName =
+	| "nw"
+	| "n"
+	| "ne"
+	| "e"
+	| "se"
+	| "s"
+	| "sw"
+	| "w"
+	| "body";
+
+export interface Box {
+	x: number;
+	y: number;
+	w: number;
+	h: number;
+}
+
+/** Half-size (px, pre-DPR) of a resize handle; also the draw size. */
+export const HANDLE_RADIUS_PX = 6;
+
+/**
+ * The UV-space box a zoom region occupies on the source frame: a square of side
+ * `1/scale` centred on (centerX, centerY), clamped so it stays inside [0,1]².
+ */
+export function regionBox(r: {
+	scale: number;
+	centerX: number;
+	centerY: number;
+}): Box {
+	const s = Math.max(1.001, r.scale);
+	const w = 1 / s;
+	const h = 1 / s;
+	const cx = Math.min(Math.max(r.centerX, w / 2), 1 - w / 2);
+	const cy = Math.min(Math.max(r.centerY, h / 2), 1 - h / 2);
+	return { x: cx - w / 2, y: cy - h / 2, w, h };
+}
+
+/** The eight resize-handle anchor points around a px-space rect. */
+export function handlePositions(
+	x: number,
+	y: number,
+	w: number,
+	h: number,
+): Record<Exclude<HandleName, "body">, { x: number; y: number }> {
+	return {
+		nw: { x, y },
+		n: { x: x + w / 2, y },
+		ne: { x: x + w, y },
+		e: { x: x + w, y: y + h / 2 },
+		se: { x: x + w, y: y + h },
+		s: { x: x + w / 2, y: y + h },
+		sw: { x, y: y + h },
+		w: { x, y: y + h / 2 },
+	};
+}
+
+/**
+ * Which handle (or "body") a point hits within a px-space rect, or null. `dpr`
+ * scales the hit slop so the grab radius is consistent across displays.
+ */
+export function hitTestHandle(
+	pt: { x: number; y: number },
+	x: number,
+	y: number,
+	w: number,
+	h: number,
+	dpr: number,
+): HandleName | null {
+	const slop = HANDLE_RADIUS_PX * dpr + 2 * dpr;
+	const handles = handlePositions(x, y, w, h);
+	for (const [name, p] of Object.entries(handles)) {
+		if (Math.abs(pt.x - p.x) <= slop && Math.abs(pt.y - p.y) <= slop) {
+			return name as HandleName;
+		}
+	}
+	if (pt.x >= x && pt.x <= x + w && pt.y >= y && pt.y <= y + h) return "body";
+	return null;
+}
+
+/** CSS cursor for a hovered handle. */
+export function cursorForHandle(h: HandleName | null): string {
+	switch (h) {
+		case "nw":
+		case "se":
+			return "nwse-resize";
+		case "ne":
+		case "sw":
+			return "nesw-resize";
+		case "n":
+		case "s":
+			return "ns-resize";
+		case "e":
+		case "w":
+			return "ew-resize";
+		case "body":
+			return "move";
+		default:
+			return "";
+	}
+}

--- a/apps/desktop/src/components/editor/_components/focus-overlay.logic.ts
+++ b/apps/desktop/src/components/editor/_components/focus-overlay.logic.ts
@@ -1,8 +1,6 @@
 /**
- * Pure geometry for the focus/zoom-region editing overlay: the UV-space box a
- * region occupies, its resize-handle positions, hit-testing, and the cursor for
- * a handle. Extracted from FocusOverlay so the maths is testable; the component
- * keeps the canvas/store wiring and the drawing.
+ * Focus/zoom-region overlay geometry: the UV-space box a region occupies, its
+ * resize-handle positions, hit-testing, and the cursor for a handle.
  *
  * NOTE: this is the zoom-region editor's own source-space geometry — it does NOT
  * use the zoom-aware/aspect-aware helpers in `$lib/annotations/uv.ts` (those are
@@ -30,10 +28,7 @@ export interface Box {
 /** Half-size (px, pre-DPR) of a resize handle; also the draw size. */
 export const HANDLE_RADIUS_PX = 6;
 
-/**
- * The UV-space box a zoom region occupies on the source frame: a square of side
- * `1/scale` centred on (centerX, centerY), clamped so it stays inside [0,1]².
- */
+/** UV-space box for a zoom region: a `1/scale`-side square centred on (centerX, centerY), clamped inside [0,1]². */
 export function regionBox(r: {
 	scale: number;
 	centerX: number;
@@ -66,10 +61,7 @@ export function handlePositions(
 	};
 }
 
-/**
- * Which handle (or "body") a point hits within a px-space rect, or null. `dpr`
- * scales the hit slop so the grab radius is consistent across displays.
- */
+/** Which handle (or "body") a point hits in a px-space rect, or null. `dpr` scales the grab slop per display. */
 export function hitTestHandle(
 	pt: { x: number; y: number },
 	x: number,

--- a/apps/desktop/src/components/editor/_components/timeline/AnnotationLayerCard.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/AnnotationLayerCard.svelte
@@ -15,11 +15,8 @@
   } from "./timeline-helpers";
   import { snapTime, type SnapResult, type SnapTarget } from "./timeline-snap";
 
-  // Annotation timeline card. Mirrors ZoomLayerCard's drag/resize/snap
-  // behaviour but operates on annotations (visible via store.annotations,
-  // mutated through store.updateAnnotation). Visual treatment is
-  // deliberately distinct — outline only, no sparkline — so the two lanes
-  // are distinguishable at a glance.
+  // Mirrors ZoomLayerCard's drag/resize/snap on annotations; outline-only
+  // (no sparkline) so the two lanes are distinguishable at a glance.
 
   interface Props {
     store: EditorStore;
@@ -69,9 +66,7 @@
   const tOf = (xPx: number) =>
     outputToOriginal(store.effectiveCuts, xPx / pixelsPerSecond);
   const left = $derived(xOf(annotation.start));
-  // 28px lets a single icon stay grabbable even on a one-frame annotation.
-  // Subtitle (start time) appears once the card is wide enough to fit it
-  // alongside the kind label.
+  // 28px keeps a one-frame annotation grabbable.
   const width = $derived(
     Math.max(xOf(annotation.end) - xOf(annotation.start), 28),
   );

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineAnnotationLane.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineAnnotationLane.svelte
@@ -5,9 +5,7 @@
   import { buildSnapTargets, snapLabel, type SnapTarget } from "./timeline-snap";
   import AnnotationLayerCard from "./AnnotationLayerCard.svelte";
 
-  // Annotation lane — sister of TimelineZoomLane. Same lifted-state pattern
-  // for the snap guide so visual feedback during a drag is consistent
-  // between lanes.
+  // Sister of TimelineZoomLane; same lifted snap-guide pattern.
 
   interface Props {
     store: EditorStore;

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineClipBar.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineClipBar.svelte
@@ -13,10 +13,8 @@
     type TimeMode,
   } from "./timeline-helpers";
 
-  // Clip bar with thumbnails and the in/out trim handles. Owns its own
-  // drag state — the parent only supplies `clientXToTime` so the
-  // pointermove/up handlers can resolve absolute pointer X (already
-  // including timeline scroll offset) into a clip time.
+  // Clip bar with thumbnails and in/out trim handles. Owns its drag state;
+  // the parent only supplies `clientXToTime` (handles scroll offset) to resolve pointer X.
 
   interface Props {
     store: EditorStore;
@@ -44,17 +42,11 @@
     clientXToTime,
   }: Props = $props();
 
-  // The clip lane renders one block per kept segment (split by the user or
-  // carved out by cuts), so a split visibly produces two adjacent clips. The
-  // horizontal axis is OUTPUT (post-cut) time: a cut occupies zero width and
-  // the clips after it slide left to close the gap, exactly like a real NLE.
-  // `xOf` maps an original time onto that gapless axis. With no cuts it's the
-  // identity, so this is the old layout untouched.
+  // One block per kept segment on the OUTPUT (post-cut) axis: a cut occupies zero
+  // width and later clips slide left to close the gap. `xOf` maps original time onto that axis.
   const pps = $derived(pixelsPerSecond);
   const xOf = (t: number) => originalToOutput(store.effectiveCuts, t) * pps;
-  // Original clip span at output px — the thumbnail strip is laid out across
-  // this (each kept block is internally cut-free, i.e. locally linear, so a
-  // block shows its slice via a plain margin offset, same as before).
+  // Thumbnail strip is laid across this; each block is internally cut-free, so it shows its slice via a margin offset.
   const clipDuration = $derived(Math.max(0.0001, store.outPoint - store.inPoint));
   const stripFullWidth = $derived(clipDuration * pps);
   const thumbW = $derived(
@@ -79,11 +71,8 @@
       .filter((p) => p > store.inPoint && p < store.outPoint)
       .map((p) => ({ time: p, x: xOf(p) })),
   );
-  // Seam markers: where a removed cut sits BETWEEN two kept segments, the gap
-  // is collapsed to a single seam. Hover to see how much was removed, click to
-  // restore it (the non-destructive replacement for the old in-place red band).
-  // Derivation is a pure, unit-tested helper (`deriveSeams`); here we only add
-  // the output-axis x position.
+  // Where a removed cut sits between two kept segments, collapsed to one seam.
+  // deriveSeams is the pure unit-tested helper; here we only add the output-axis x.
   const seamMarkers = $derived(
     deriveSeams(store.segments).map((s) => ({ ...s, x: xOf(s.gapStart) })),
   );
@@ -98,9 +87,7 @@
   const inHandleLeft = $derived(clipLeft);
   const outHandleLeft = $derived(clipLeft + clipWidth);
 
-  // Ripple-delete the clip block spanning [start, end]: its midpoint is always
-  // inside it, so `deleteSegmentAt` targets exactly this segment. Park the
-  // playhead on the join so the preview lands on a kept frame.
+  // Midpoint is always inside the block, so deleteSegmentAt targets exactly it; park playhead on the join.
   function deleteSegment(start: number, end: number) {
     const joinAt = store.deleteSegmentAt((start + end) / 2);
     if (joinAt === null) return;
@@ -110,9 +97,7 @@
 
   let activeTrimHandle = $state<"in" | "out" | null>(null);
 
-  // Live drag context for the in/out trim handles. `originalAt` is the value
-  // the handle had at pointer-down — used to display a delta in the tooltip
-  // so users see exactly how many frames they've shaved off.
+  // `originalAt` = the handle value at pointer-down, for the frames-delta tooltip.
   let trimDragContext = $state<{
     which: "in" | "out";
     originalAt: number;
@@ -122,8 +107,7 @@
     if (duration <= 0) return;
     event.preventDefault();
     event.stopPropagation();
-    // Single undo entry per drag, regardless of how many pointermove events
-    // fire while the user holds the handle.
+    // Single undo entry per drag.
     store.pushUndoState();
     activeTrimHandle = which;
     trimDragContext = {
@@ -165,8 +149,7 @@
     if (which === "in") {
       const next = Math.max(0, Math.min(t, store.outPoint - min));
       store.trimStart = next;
-      // Scrub-while-trim: park playback at the in point so the preview
-      // shows the first kept frame as the user drags.
+      // Park playback at the in point so the preview shows the first kept frame while dragging.
       if (scrub) {
         store.currentTime = next;
         if (videoEl) videoEl.currentTime = next;
@@ -175,8 +158,7 @@
       const next = Math.min(duration, Math.max(t, store.inPoint + min));
       store.trimEnd = next;
       if (scrub) {
-        // Show one frame before the cut (the last kept frame) — that's the
-        // frame the user is actually deciding to keep or discard.
+        // Show the last kept frame (one before the cut) — the frame being decided on.
         const previewAt = Math.max(store.inPoint, next - frameStep(fps));
         store.currentTime = previewAt;
         if (videoEl) videoEl.currentTime = previewAt;
@@ -214,9 +196,6 @@
 </script>
 
 <div class="relative h-12">
-  <!-- One block per kept segment. Splitting divides the clip into two adjacent
-       blocks; deleting a block ripple-closes the gap. Each block shows its own
-       slice of the shared thumbnail strip (shifted via stripOffset). -->
   {#each clipBlocks as block (block.key)}
     {@const selected =
       store.selectedClipStart !== null &&
@@ -255,8 +234,7 @@
         </div>
       {/if}
 
-      <!-- Per-clip ripple delete (only when there's more than one clip — the
-           trim handles, not this, remove the whole recording). -->
+      <!-- Per-clip ripple delete, only with >1 clip (trim handles remove the whole recording). -->
       {#if clipBlocks.length > 1}
         <!-- svelte-ignore a11y_consider_explicit_label -->
         <button
@@ -272,10 +250,7 @@
     </div>
   {/each}
 
-  <!-- Seam markers: a removed section collapses to a single seam between the two
-       kept clips. The content disappears and the timeline closes up (NLE ripple);
-       the seam stays as a restorable handle — hover shows how much was removed,
-       click restores it. -->
+  <!-- Removed section collapsed to a restorable seam (click to restore). -->
   {#each seamMarkers as seam (seam.gapStart)}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <button

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineCutLane.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineCutLane.svelte
@@ -7,10 +7,7 @@
   } from "$lib/timeline/cuts";
   import { X } from "@lucide/svelte";
 
-  // Lane that hosts cut bands — the ranges removed from the timeline.
-  // Drag empty lane space to carve a new cut; drag a band's edges to
-  // fine-tune it, or its body to slide it. Mirrors the zoom/annotation
-  // lanes structurally so the timeline reads consistently.
+  // Hosts cut bands. Drag empty lane space to carve a cut; drag a band's edges or body to adjust it.
 
   interface Props {
     store: EditorStore;
@@ -20,16 +17,13 @@
 
   let { store, pixelsPerSecond, duration }: Props = $props();
 
-  // Cuts shorter than this are dropped — a sub-100ms removal reads as a
-  // glitch, not an edit.
+  // Cuts shorter than this are dropped — a sub-100ms removal reads as a glitch.
   const MIN_CUT = 0.1;
 
   let laneEl = $state<HTMLDivElement | null>(null);
 
-  // Output (post-cut) axis, shared with every other lane. An APPLIED cut
-  // collapses to zero width here (its start and end map to the same output x),
-  // so we render it as a seam; an unapplied cut (flag/lane off → not in
-  // effectiveCuts, identity mapping) keeps its width and stays an editable band.
+  // Output (post-cut) axis. An applied cut collapses to zero width (rendered as a
+  // seam); an unapplied cut (lane off → not in effectiveCuts) keeps its width as an editable band.
   const cuts = $derived(store.effectiveCuts);
   const xOf = (t: number) => originalToOutput(cuts, t) * pixelsPerSecond;
   const axisWidth = $derived(xOf(duration));
@@ -147,10 +141,8 @@
     store.removeCut(id);
   }
 
-  // Filled peak envelope, drawn behind the cut bands so the user can see the
-  // audio they're cutting against. Built in PIXEL space on the output axis: each
-  // bucket sits at `xOf(bucketTime)`, so buckets inside an applied cut collapse
-  // onto the seam and the envelope closes up exactly like the clips above it.
+  // Peak envelope behind the bands. Built in output-pixel space (each bucket at
+  // `xOf(bucketTime)`) so buckets inside an applied cut collapse onto the seam.
   const waveformPath = $derived.by(() => {
     const w = store.waveform;
     const n = w.length;
@@ -201,10 +193,8 @@
     {@const cutLeft = xOf(cut.start)}
     {@const cutW = xOf(cut.end) - cutLeft}
     {#if cutW < 2}
-      <!-- APPLIED cut: the section is collapsed out of the timeline, so it shows
-           as a seam. Hover to see the removed length; click to restore. (Move /
-           resize need width to grab, so they only apply to the unapplied band
-           below — restore, then re-cut, to adjust an applied section.) -->
+      <!-- Applied cut collapsed to a seam (click to restore). Move/resize need
+           width, so they only work on the unapplied band below. -->
       <button
         type="button"
         onpointerdown={(e) => e.stopPropagation()}

--- a/apps/desktop/src/components/editor/_components/timeline/TimelinePlayhead.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelinePlayhead.svelte
@@ -1,22 +1,17 @@
 <script lang="ts">
   import { formatTimeByMode, type TimeMode } from "./timeline-helpers";
 
-  // Vertical playhead column with timecode pill on top and a thin guide line
-  // running the height of the timeline. While the user actively drags, the
-  // [left] transition is suppressed so the head pins under the cursor.
+  // While dragging, the [left] transition is suppressed so the head pins under the cursor.
 
   interface Props {
     currentTime: number;
-    /** Horizontal position in px, already mapped onto the output (post-cut)
-     *  axis by the parent. The label still shows `currentTime` (original time,
-     *  what the rest of the app uses); only the position is output-mapped. */
+    /** px on the output (post-cut) axis. The label still shows `currentTime`
+     *  (original time); only the position is output-mapped. */
     leftPx: number;
     fps: number;
     isDragging: boolean;
     timeMode: TimeMode;
-    /** When false (cut lane hidden), the playhead guide line is shortened
-     *  so it stops at the bottom of the annotation lane instead of dangling
-     *  into empty space. */
+    /** When false (cut lane hidden), the guide line stops at the annotation lane. */
     tall?: boolean;
   }
 

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineRuler.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineRuler.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
   import { buildMinorTicks, buildTimeMarkers } from "./timeline-helpers";
 
-  // Pure render: top ruler with major labels and minor ticks. Recomputes
-  // markers from `duration` × `pixelsPerSecond` so the parent doesn't need
-  // to thread them through.
-
   interface Props {
     duration: number;
     pixelsPerSecond: number;

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineToolbar.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineToolbar.svelte
@@ -27,14 +27,8 @@
   import ZoomSuggestionsPopover from "../../ZoomSuggestionsPopover.svelte";
   import { formatTimeByMode, type TimeMode } from "./timeline-helpers";
 
-  // Top control bar. Left cluster = edit actions (trim / focus / suggest /
-  // reset). Right cluster = view controls: playback speed + timeline zoom
-  // inline (high frequency), with low-frequency display options (time format,
-  // clip stats, shortcut hints) folded into a "View" menu.
-  //
-  // Popovers (Suggest, Remove-silence, Speed) use the portalled Popover
-  // component on purpose — the timeline sits inside an `overflow-hidden`
-  // slide wrapper, so an in-DOM popover anchored above the bar gets clipped.
+  // Popovers (Suggest, Remove-silence, Speed) must be portalled: the timeline
+  // sits in an `overflow-hidden` slide wrapper that would clip an in-DOM popover.
 
   interface Props {
     store: EditorStore;
@@ -80,12 +74,10 @@
 
   const trimHint = `Set trim points to exclude parts of the clip from export, or add focus regions to highlight important moments. You can also ask Trace to suggest focus regions based on where you moved the cursor.`;
 
-  // Popover open state — local to the toolbar; nothing upstream depends on it.
   let suggestOpen = $state(false);
   let showSilence = $state(false);
 
-  // Badge on the silence button counts ONLY silence-detected cuts. Manual
-  // ripple deletes are a separate concept and shouldn't inflate this number.
+  // Counts only silence-detected cuts; manual ripple deletes shouldn't inflate this.
   const silenceCutCount = $derived(
     store.cuts.filter((c) => c.source === "silence").length,
   );
@@ -109,11 +101,9 @@
 </script>
 
 <div class="mb-2 flex flex-wrap items-center justify-between gap-2 text-[11px]">
-  <!-- Edit actions -->
   <div class="flex items-center gap-1">
     <InspectorHint content={trimHint} />
 
-    <!-- Trim -->
     <div class={GROUP}>
       <button
         type="button"
@@ -137,7 +127,6 @@
       </button>
     </div>
 
-    <!-- Split the clip at the playhead into two independently-deletable clips. -->
     <button
       type="button"
       onclick={onSplit}
@@ -149,7 +138,6 @@
       <Kbd class="ml-0.5">S</Kbd>
     </button>
 
-    <!-- Focus / Suggest -->
     <div class={GROUP}>
       <button type="button" onclick={onAddFocusRegion} class={SEG}>
         <Search class="size-3" />
@@ -182,9 +170,7 @@
       </Popover.Root>
     </div>
 
-    <!-- Remove-silence: scans audio + screen motion for dead air. Gated
-         behind the experimental flag so first-run users don't see the
-         in-progress UI; opt-in lives in Settings → Experimental. -->
+    <!-- Gated behind the experimental flag (Settings → Experimental) — in-progress UI. -->
     {#if experimentalStore.silenceDetection}
       <Popover.Root open={showSilence} onOpenChange={(v) => (showSilence = v)}>
         <Popover.Trigger>
@@ -243,9 +229,7 @@
     </span>
   </div>
 
-  <!-- View controls -->
   <div class="flex items-center gap-1.5 text-muted-foreground">
-    <!-- Playback speed: continuous slider + quick presets -->
     <Popover.Root>
       <Popover.Trigger>
         {#snippet child({ props })}
@@ -293,7 +277,6 @@
       </Popover.Content>
     </Popover.Root>
 
-    <!-- Timeline zoom: out / level / in / fit-to-clip / fit-to-selection -->
     <div class={GROUP}>
       <button
         type="button"
@@ -339,7 +322,6 @@
       </button>
     </div>
 
-    <!-- Active-trim feedback. Stays inline (transient, only while trimmed). -->
     {#if hasTrim}
       <span
         class="inline-flex h-6 items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-2 font-mono text-[10px] font-semibold tabular-nums text-primary"
@@ -350,7 +332,6 @@
       </span>
     {/if}
 
-    <!-- View menu: low-frequency display options -->
     <DropdownMenu.Root>
       <DropdownMenu.Trigger>
         <button type="button" aria-label="View options" class={SOLO}>

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineZoomLane.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineZoomLane.svelte
@@ -5,9 +5,8 @@
   import { buildSnapTargets, snapLabel, type SnapTarget } from "./timeline-snap";
   import ZoomLayerCard from "./ZoomLayerCard.svelte";
 
-  // Lane that hosts zoom-region cards. The lane builds the snap target list
-  // (playhead + in/out + duration + neighbours) and renders a vertical
-  // guide whenever any card reports an active snap during drag/resize.
+  // Hosts zoom-region cards: builds the shared snap target list and paints
+  // the guide line when a card reports an active snap during drag/resize.
 
   interface Props {
     store: EditorStore;
@@ -29,8 +28,7 @@
     onDuplicate,
   }: Props = $props();
 
-  // Lifted from each card so the lane can paint a single guide line at the
-  // active target. Last writer wins — only one card drags at a time.
+  // Last writer wins — only one card drags at a time.
   let activeSnap = $state<SnapTarget | null>(null);
   // Snap targets are original times; place the guide on the output axis.
   const snapX = $derived(
@@ -81,10 +79,7 @@
   {/if}
 
   {#if activeSnap}
-    <!-- Snap guide. Anchored to the lane container, but drawn full-height
-         using a tall element with negative offsets so it visually crosses
-         the clip bar above too — the same affordance Premiere/Final Cut
-         use to confirm a snap. -->
+    <!-- Drawn tall with negative offsets so the guide crosses the clip bar above too. -->
     <div
       class="pointer-events-none absolute -top-14 z-40 h-42.5 w-px bg-primary/80"
       style="left: {snapX + 6}px;"

--- a/apps/desktop/src/components/editor/_components/timeline/ZoomLayerCard.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/ZoomLayerCard.svelte
@@ -12,15 +12,9 @@
   } from "./timeline-helpers";
   import { snapTime, type SnapResult, type SnapTarget } from "./timeline-snap";
 
-  // Single zoom-region card. Three drag modes share one pointer-handler
-  // because they all read the same pixels-per-second translation:
-  //   - body drag      → translate the whole region (start AND end shift)
-  //   - resize-start   → only `start` moves, `end` stays
-  //   - resize-end     → only `end` moves, `start` stays
-  //
-  // A drag captures `pushUndoState()` once at pointer-down so the entire
-  // gesture collapses to a single undo entry, then commits on every move.
-  // Snap targets come from the lane (playhead, in/out, neighbours).
+  // Three drag modes through one pointer-handler: move (shift both edges),
+  // resize-start (move `start`), resize-end (move `end`).
+  // pushUndoState() fires once at pointer-down so the whole gesture is one undo entry.
 
   interface Props {
     store: EditorStore;
@@ -50,9 +44,7 @@
     onDuplicate,
   }: Props = $props();
 
-  // Pick a frame from the clip-wide thumbnail strip closest to this region's
-  // start. Cheap visual identifier — the strip is already loaded for the
-  // clip bar, so this is a free reuse (no extra ffmpeg call).
+  // Reuse the clip bar's thumbnail strip (already loaded) for the frame nearest this region's start.
   const cardThumb = $derived.by(() => {
     const strip = store.thumbnailStrip;
     if (!strip.length || duration <= 0) return null;
@@ -63,12 +55,9 @@
     return strip[idx] ?? null;
   });
 
-  // Hard floor so a card can't be dragged into a degenerate zero-width state.
-  // 0.1s ≈ 6 frames at 60fps — still tight enough to be intentional.
+  // Floor so a card can't collapse to zero width (0.1s ≈ 6 frames at 60fps).
   const MIN_DURATION = 0.1;
 
-  // ~6 px in time-space. The lane re-renders the snap guide whenever the
-  // active target changes, so this also drives the user-visible feedback.
   const SNAP_TOLERANCE_PX = 6;
 
   type DragMode = "move" | "resize-start" | "resize-end";
@@ -84,16 +73,14 @@
   let drag = $state<DragContext | null>(null);
 
   const isSelected = $derived(region.id === store.selectedZoomRegionId);
-  // Output (post-cut) axis: position via originalToOutput so a region sits on
-  // the same gapless line as the clips. A region overlapping a cut renders
-  // narrower (the cut portion collapses) — correct NLE behaviour.
+  // Output (post-cut) axis so regions sit on the same gapless line as clips;
+  // a region overlapping a cut renders narrower (correct NLE behaviour).
   const xOf = (t: number) =>
     originalToOutput(store.effectiveCuts, t) * pixelsPerSecond;
   const tOf = (xPx: number) =>
     outputToOriginal(store.effectiveCuts, xPx / pixelsPerSecond);
   const left = $derived(xOf(region.start));
-  // Hard floor of 32px keeps even sub-frame regions clickable. Below 80px
-  // the card collapses to icon+label only; below 56px to icon only.
+  // 32px floor keeps even sub-frame regions clickable.
   const width = $derived(Math.max(xOf(region.end) - xOf(region.start), 32));
   const showThumb = $derived(width >= 110);
   const showSubtitle = $derived(width >= 130);
@@ -121,10 +108,8 @@
 
   function onPointerMove(event: PointerEvent) {
     if (!drag) return;
-    // The pointer moves in OUTPUT pixels; convert that to an output-time delta,
-    // then map an original anchor through output space and back so dragging
-    // tracks the cursor on the collapsed axis. With no cuts this reduces to the
-    // old `anchor + deltaPx/pps`.
+    // Pointer moves in OUTPUT pixels; map the original anchor through output space
+    // and back so dragging tracks the cursor on the collapsed axis.
     const outDelta = (event.clientX - drag.startClientX) / pixelsPerSecond;
     const movedFrom = (orig: number) => tOf(xOf(orig) + outDelta);
     const tolerance = SNAP_TOLERANCE_PX / pixelsPerSecond;
@@ -134,9 +119,7 @@
       const span = drag.originalEnd - drag.originalStart;
       const proposed = movedFrom(drag.originalStart);
 
-      // Snap whichever edge is closer to a target — this lets the user
-      // butt the card up against the playhead from either side without
-      // having to think about which edge is leading.
+      // Snap whichever edge is closer so the card butts against a target from either side.
       const startSnap = snapTime(proposed, snapTargets, tolerance, fps);
       const endSnap = snapTime(proposed + span, snapTargets, tolerance, fps);
       const startDist = startSnap.target
@@ -193,14 +176,10 @@
     onSnapChange(null);
   }
 
-  // Keyboard nudge / shortcut handler for the focused card. Coalesces
-  // sequential nudges into one undo entry so holding ArrowRight feels like
-  // one continuous edit rather than dozens of stack frames.
+  // Coalesces sequential nudges into one undo entry so a held arrow is one edit.
   function onCardKeydown(event: KeyboardEvent) {
     if (duration <= 0) return;
 
-    // Delete / Backspace removes. Plain key — no modifier required —
-    // because the card itself is focused, not a text input.
     if (event.key === "Delete" || event.key === "Backspace") {
       event.preventDefault();
       event.stopPropagation();
@@ -208,8 +187,7 @@
       return;
     }
 
-    // Cmd/Ctrl + D duplicates. Cmd/Ctrl + C copies. Paste happens at the
-    // timeline scope so users can land regions wherever the playhead is.
+    // Paste lives at timeline scope so regions land at the playhead, not here.
     const isMod = event.ctrlKey || event.metaKey;
     if (isMod && (event.key === "d" || event.key === "D")) {
       event.preventDefault();
@@ -229,15 +207,12 @@
     event.stopPropagation();
 
     const direction = event.key === "ArrowLeft" ? -1 : 1;
-    // Shift = 1 second nudges, plain = single frame. Mirrors the playhead
-    // arrow-step convention in Timeline.svelte.
+    // Shift = 1s, plain = one frame. Mirrors the playhead step in Timeline.svelte.
     const delta = direction * (event.shiftKey ? 1 : frameStep(fps));
 
     store.pushUndoStateCoalesced(`nudge-zoom-${region.id}`, 600);
 
-    // Alt = resize the trailing edge instead of translating the card. Lets
-    // users tighten/loosen a region from the keyboard without aiming at
-    // the edge handles.
+    // Alt = resize the trailing edge instead of translating the card.
     if (event.altKey) {
       const next = Math.min(
         duration,
@@ -257,9 +232,7 @@
   }
 
   function onCardClick(event: MouseEvent) {
-    // Click selects only when no drag occurred. Pointer handlers live on
-    // window so a real drag never fires this — but a static click without
-    // motion still reaches us via the body's `onclick`.
+    // A real drag never fires this (window-level pointer handlers); only a static click does.
     event.stopPropagation();
     store.selectedZoomRegionId = region.id;
   }
@@ -285,10 +258,8 @@
     height: 30px;
   "
 >
-  <!-- Card body. We split the visual rectangle from the move hit-target
-       so the resize edges can sit on top with their own cursor.
-       Selected state earns a 2-px left accent bar via box-shadow inset
-       so it reads as "this is the active layer" without jiggling layout. -->
+  <!-- Body split from the resize edges so each gets its own cursor; selected state
+       uses a box-shadow inset accent bar to avoid layout shift. -->
   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
   <button
     type="button"
@@ -296,8 +267,7 @@
     onclick={onCardClick}
     onkeydown={onCardKeydown}
     onpointerdown={(e) => {
-      // Resizing has priority — those handlers stop propagation, so any
-      // pointerdown that reaches here is intended as a body drag.
+      // Resize handlers stop propagation, so anything reaching here is a body drag.
       if (e.button !== 0) return;
       beginDrag("move", e);
     }}
@@ -360,8 +330,7 @@
     </div>
   </button>
 
-  <!-- Resize handles. 8px wide hit zone, 2px visible bar at the inner edge.
-       z-index above the body so pointer events land here first. -->
+  <!-- Resize handles: 8px hit zone above the body so pointer events land here first. -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     role="slider"

--- a/apps/desktop/src/components/editor/_components/timeline/timeline-helpers.ts
+++ b/apps/desktop/src/components/editor/_components/timeline/timeline-helpers.ts
@@ -1,9 +1,7 @@
 import type { Easing } from "$lib/easing/cubic-bezier";
 import type { ZoomRegion } from "$lib/stores/editor-store.svelte";
 
-// Pure helpers extracted from Timeline.svelte. Keeping these out of the
-// Svelte component lets the timeline subviews share them without re-importing
-// the orchestrator, and makes them unit-testable in isolation.
+// Pure helpers extracted from Timeline.svelte so subviews share them and they stay unit-testable.
 
 export function effectiveFps(metadataFps: number | undefined): number {
 	const f = metadataFps ?? 0;
@@ -18,14 +16,12 @@ export function frameStep(fps: number): number {
 	return 1 / fps;
 }
 
-// Floor on the clip length: at least 2 frames so the trimmed range is never
-// sub-frame. Scales naturally with fps (60fps → ~33ms; 30fps → ~66ms).
+// At least 2 frames so a trimmed range is never sub-frame.
 export function minClipDuration(fps: number): number {
 	return 2 * frameStep(fps);
 }
 
-// SMPTE-style HH:MM:SS:FF (or MM:SS:FF for clips < 1 hour). Frame component
-// is zero-padded so the readout has constant width.
+// SMPTE-style HH:MM:SS:FF (MM:SS:FF for clips < 1 hour).
 export function formatTimecode(time: number, fps: number): string {
 	const t = Math.max(0, time);
 	const totalFrames = Math.round(t * fps);
@@ -42,11 +38,7 @@ export function formatTimecode(time: number, fps: number): string {
 		: `${mm}:${ss}:${ff}`;
 }
 
-// Display modes the timeline supports. Stored as a discriminated string so
-// it round-trips cleanly through component props.
-//   smpte   — HH:MM:SS:FF (full editorial timecode)
-//   seconds — M:SS.cs   (decimal seconds, useful at low zoom)
-//   frames  — Nf        (raw frame count, useful for frame-precision work)
+// smpte: HH:MM:SS:FF · seconds: M:SS.cs · frames: Nf
 export type TimeMode = "smpte" | "seconds" | "frames";
 
 export function formatFrames(time: number, fps: number): string {
@@ -54,8 +46,6 @@ export function formatFrames(time: number, fps: number): string {
 	return `${frames}f`;
 }
 
-// Single entry-point for all timeline labels. Sub-views call this with the
-// active TimeMode so the format flips everywhere at once.
 export function formatTimeByMode(
 	time: number,
 	mode: TimeMode,
@@ -91,8 +81,7 @@ export function greatestCommonDivisor(a: number, b: number): number {
 	return left || 1;
 }
 
-// Approximate polynomial-in-t eval; indistinguishable from the real
-// Newton-Raphson solve at sparkline resolution.
+// Polynomial-in-t approximation; indistinguishable from the real Newton-Raphson solve at sparkline resolution.
 export function approxEaseY(easing: Easing, x: number): number {
 	const a = 1 - 3 * easing.y2 + 3 * easing.y1;
 	const b = 3 * easing.y2 - 6 * easing.y1;
@@ -100,9 +89,7 @@ export function approxEaseY(easing: Easing, x: number): number {
 	return ((a * x + b) * x + c) * x;
 }
 
-// Path drawing 0..100 × 0..18 viewBox: the region's scale curve, normalised
-// so peak scale reaches the top of the box. Shows the rampIn/hold/rampOut
-// shape at a glance.
+// SVG path (100×18 viewBox) of the region's scale curve, normalised so peak scale hits the top.
 export function zoomSparklinePath(r: ZoomRegion): string {
 	const duration = Math.max(0.001, r.end - r.start);
 	const half = duration * 0.5;

--- a/apps/desktop/src/components/editor/_components/timeline/timeline-snap.ts
+++ b/apps/desktop/src/components/editor/_components/timeline/timeline-snap.ts
@@ -1,8 +1,7 @@
 import { quantizeToFrame } from "./timeline-helpers";
 
-// Snap resolver shared by drag/resize on zoom region cards. Pure module —
-// returns both the snapped value and which target produced it, so callers
-// can render a guide line at the active snap.
+// Snap resolver for drag/resize on region cards. Returns both the snapped
+// value and which target produced it so callers can draw a guide at the snap.
 
 export type SnapKind =
 	| "playhead"
@@ -21,8 +20,6 @@ export interface SnapTarget {
 	kind: SnapKind;
 }
 
-// User-facing label for the snap guide badge. Shared by every lane so the
-// wording stays identical no matter which lane reports the active snap.
 export function snapLabel(kind: SnapKind): string {
 	switch (kind) {
 		case "playhead":
@@ -53,12 +50,9 @@ export interface SnapResult {
 	target: SnapTarget | null;
 }
 
-// Resolve a candidate time against the supplied targets. Within `toleranceTime`
-// of any target we lock to that target; otherwise we fall through to the
-// frame grid so writes never land at sub-frame fractions.
-//
-// Targets are checked in array order — pass them with the most "intentful"
-// first (playhead, in/out) so they win ties against neighbour edges.
+// Lock to the nearest target within `toleranceTime`, else fall through to the
+// frame grid so writes never land sub-frame. Targets are checked in array order;
+// pass the most intentful first (playhead, in/out) so they win ties.
 export function snapTime(
 	candidate: number,
 	targets: SnapTarget[],
@@ -78,9 +72,6 @@ export function snapTime(
 	return { time: quantizeToFrame(candidate, fps), target: null };
 }
 
-// Convenience: produce the standard target list a zoom-card drag wants to
-// snap against. Pass `excludeRegionId` to keep a card from snapping to its
-// own edges while it's being moved.
 export interface BuildTargetsArgs {
 	playhead: number;
 	inPoint: number;
@@ -88,11 +79,7 @@ export interface BuildTargetsArgs {
 	duration: number;
 	regions: ReadonlyArray<{ id: string; start: number; end: number }>;
 	annotations?: ReadonlyArray<{ id: string; start: number; end: number }>;
-	/**
-	 * Range identifier(s) to omit from the target list — pass the moving
-	 * card's id so it doesn't snap to its own edges. Accepts either a
-	 * single id (zoom case) or a structured exclude (annotation case).
-	 */
+	/** Id of the moving card so it doesn't snap to its own edges. */
 	excludeRegionId?: string | null;
 	excludeAnnotationId?: string | null;
 }

--- a/apps/desktop/src/components/editor/color.logic.test.ts
+++ b/apps/desktop/src/components/editor/color.logic.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { hexToRgba } from "./color.logic";
+
+describe("hexToRgba", () => {
+	it("parses #rrggbb to normalised channels with default alpha", () => {
+		expect(hexToRgba("#ffffff")).toEqual([1, 1, 1, 1]);
+		expect(hexToRgba("#000000")).toEqual([0, 0, 0, 1]);
+		const [r, g, b] = hexToRgba("#ff8000");
+		expect(r).toBe(1);
+		expect(g).toBeCloseTo(128 / 255, 5);
+		expect(b).toBe(0);
+	});
+	it("reads the alpha byte from #rrggbbaa", () => {
+		expect(hexToRgba("#00000080")[3]).toBeCloseTo(128 / 255, 5);
+	});
+	it("honours the alpha argument for 6-digit hex", () => {
+		expect(hexToRgba("#ffffff", 0.5)).toEqual([1, 1, 1, 0.5]);
+	});
+	it("falls back to #111111 on malformed input", () => {
+		expect(hexToRgba("nope", 0.3)).toEqual([17 / 255, 17 / 255, 17 / 255, 0.3]);
+	});
+});

--- a/apps/desktop/src/components/editor/color.logic.ts
+++ b/apps/desktop/src/components/editor/color.logic.ts
@@ -1,8 +1,4 @@
-/**
- * Pure colour parsing for the WebGL preview. Kept free of any store/Svelte
- * import so it stays unit-testable (the gradient packer, which needs the store's
- * parser, lives in `gradient.logic.ts`).
- */
+/** Colour parsing for the WebGL preview. Store-free (gradient packing lives in `gradient.logic.ts`). */
 
 /**
  * `#rrggbb`/`#rrggbbaa` → normalised `[r, g, b, a]` (0..1). Falls back to the

--- a/apps/desktop/src/components/editor/color.logic.ts
+++ b/apps/desktop/src/components/editor/color.logic.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure colour parsing for the WebGL preview. Kept free of any store/Svelte
+ * import so it stays unit-testable (the gradient packer, which needs the store's
+ * parser, lives in `gradient.logic.ts`).
+ */
+
+/**
+ * `#rrggbb`/`#rrggbbaa` → normalised `[r, g, b, a]` (0..1). Falls back to the
+ * `#111111` background colour (with `alpha`) on malformed input.
+ */
+export function hexToRgba(
+	hex: string,
+	alpha = 1,
+): [number, number, number, number] {
+	const s = hex.trim().replace(/^#/, "");
+	if (s.length < 6) return [17 / 255, 17 / 255, 17 / 255, alpha];
+	const r = parseInt(s.slice(0, 2), 16) / 255;
+	const g = parseInt(s.slice(2, 4), 16) / 255;
+	const b = parseInt(s.slice(4, 6), 16) / 255;
+	const a = s.length >= 8 ? parseInt(s.slice(6, 8), 16) / 255 : alpha;
+	return [r, g, b, a];
+}

--- a/apps/desktop/src/components/editor/cursor-animation.logic.test.ts
+++ b/apps/desktop/src/components/editor/cursor-animation.logic.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildPressEvents,
+	clickAnchorAt,
+	clickHighlightAt,
+	pressStateAt,
+	smoothStep01,
+	type PressSample,
+} from "./cursor-animation.logic";
+
+function sample(over: Partial<PressSample> & { timestampUs: number }): PressSample {
+	return { x: 0, y: 0, leftDown: false, rightDown: false, ...over };
+}
+
+describe("smoothStep01", () => {
+	it("clamps and is symmetric at the midpoint", () => {
+		expect(smoothStep01(-1)).toBe(0);
+		expect(smoothStep01(0)).toBe(0);
+		expect(smoothStep01(1)).toBe(1);
+		expect(smoothStep01(2)).toBe(1);
+		expect(smoothStep01(0.5)).toBe(0.5);
+	});
+});
+
+describe("buildPressEvents", () => {
+	it("collapses a held button into one event with position", () => {
+		const events = buildPressEvents([
+			sample({ timestampUs: 0 }),
+			sample({ timestampUs: 1000, x: 10, y: 20, leftDown: true }),
+			sample({ timestampUs: 2000, x: 10, y: 20, leftDown: true }),
+			sample({ timestampUs: 3000 }),
+		]);
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({
+			downUs: 1000,
+			upUs: 3000,
+			downX: 10,
+			downY: 20,
+			right: false,
+			dragged: false,
+		});
+	});
+	it("flags a drag past the threshold and right-clicks", () => {
+		const events = buildPressEvents([
+			sample({ timestampUs: 0, x: 0, y: 0, rightDown: true }),
+			sample({ timestampUs: 1000, x: 50, y: 0, rightDown: true }),
+			sample({ timestampUs: 2000 }),
+		]);
+		expect(events[0].right).toBe(true);
+		expect(events[0].dragged).toBe(true);
+	});
+	it("closes an open press at the last sample", () => {
+		const events = buildPressEvents([
+			sample({ timestampUs: 1000, leftDown: true }),
+			sample({ timestampUs: 2000, leftDown: true }),
+		]);
+		expect(events).toHaveLength(1);
+		expect(events[0].upUs).toBe(2000);
+	});
+});
+
+describe("clickAnchorAt / clickHighlightAt", () => {
+	const events = buildPressEvents([
+		sample({ timestampUs: 1_000_000, x: 100, y: 200, leftDown: true }),
+		sample({ timestampUs: 1_010_000 }),
+	]);
+	it("snaps to the anchor at the click frame with full weight", () => {
+		const a = clickAnchorAt(events, 1_000_000);
+		expect(a).not.toBeNull();
+		expect(a!.x).toBe(100);
+		expect(a!.weight).toBeCloseTo(1, 5);
+	});
+	it("returns null far from any click", () => {
+		expect(clickAnchorAt(events, 5_000_000)).toBeNull();
+	});
+	it("highlights at full alpha during the hold", () => {
+		const hl = clickHighlightAt(events, 1_050_000);
+		expect(hl).not.toBeNull();
+		expect(hl!.alpha).toBe(1);
+	});
+});
+
+describe("pressStateAt", () => {
+	const events = buildPressEvents([
+		sample({ timestampUs: 1_000_000, x: 0, y: 0, leftDown: true }),
+		sample({ timestampUs: 1_010_000 }),
+	]);
+	it("is idle far from any press", () => {
+		expect(pressStateAt(events, 5_000_000)).toMatchObject({
+			pressedSprite: false,
+			visibleAlpha: 0,
+			scale: 1,
+		});
+	});
+	it("shows the pressed sprite during the hold", () => {
+		expect(pressStateAt(events, 1_000_000).pressedSprite).toBe(true);
+	});
+	it("snaps scale below 1 right at the click frame (punch)", () => {
+		expect(pressStateAt(events, 1_000_000).scale).toBeLessThan(1);
+	});
+});

--- a/apps/desktop/src/components/editor/cursor-animation.logic.ts
+++ b/apps/desktop/src/components/editor/cursor-animation.logic.ts
@@ -1,0 +1,275 @@
+/**
+ * Pure click/press animation maths for the cursor overlay, extracted from
+ * VideoPreview. The captured cursor track (per ~8ms sample, with button state)
+ * is collapsed into one `PressEvent` per click, and the press/click visuals are
+ * deterministic functions of time around those events. Mirrors `cursor_anim.rs`
+ * so the editor preview and the export agree frame-for-frame.
+ *
+ * Everything here is pure: feed it the press events (built once via
+ * `buildPressEvents`) and a timestamp. The component keeps the cursor-sample
+ * state and the WebGL drawing.
+ */
+
+/** One collapsed click: down/up time + the captured click position. */
+export type PressEvent = {
+	downUs: number;
+	upUs: number;
+	downX: number;
+	downY: number;
+	/** Right button initiated this press (selects the sprite slot only). */
+	right: boolean;
+	/** Cursor moved past DRAG_THRESHOLD_PX (source px) while held. */
+	dragged: boolean;
+};
+
+/** The subset of a captured cursor sample that press detection needs. */
+export interface PressSample {
+	timestampUs: number;
+	x: number;
+	y: number;
+	leftDown: boolean;
+	rightDown: boolean;
+}
+
+/** Cursor displacement (source px) during a hold beyond which it's a drag.
+ *  MUST mirror DRAG_THRESHOLD_PX in cursor_anim.rs. */
+const DRAG_THRESHOLD_PX = 8;
+
+const PRESS_MIN_HOLD_US = 320_000; // minimum down-window from the click frame
+const PRESS_LINGER_US = 320_000; // pressed sprite holds this long past release
+const PRESS_PREROLL_US = 320_000; // pointer sprite visible this long before click
+const PRESS_VIS_RAMP_US = 180_000; // cursor visibility ramp-in / ramp-out
+const PRESS_POSTROLL_US = 320_000; // visibility holds this long after sprite settles
+const PRESS_ANTICIP_US = 140_000; // anticipation lift duration
+const PRESS_RECOVERY_US = 380_000; // recovery duration after click snap
+const PRESS_LIFT = 0.04; // anticipation peak: scale = 1 + LIFT
+const PRESS_PUNCH = 0.16; // click compression: scale = 1 - PUNCH
+const PRESS_BOUNCE = 0.03; // recovery overshoot above 1
+// Always-on click snap — cosine ramp pulls the rendered cursor x/y through the
+// captured click anchor inside ±CLICK_SNAP_HALF_US so the impact frame ALWAYS
+// lands on the click target, regardless of smoothing strength / snap toggle.
+const CLICK_SNAP_HALF_US = 200_000;
+const HIGHLIGHT_FADE_IN_US = 40_000;
+const HIGHLIGHT_FADE_OUT_US = 220_000;
+
+/** 3t² − 2t³ smoothstep — clamped, C1-continuous, cheap. */
+export function smoothStep01(t: number): number {
+	if (t <= 0) return 0;
+	if (t >= 1) return 1;
+	return t * t * (3 - 2 * t);
+}
+
+/**
+ * Collapse raw cursor samples into one press event per click. Reads button
+ * state from the RAW samples — smoothing reshapes x/y but must never move click
+ * timing/position.
+ */
+export function buildPressEvents(samples: PressSample[]): PressEvent[] {
+	const events: PressEvent[] = [];
+	if (samples.length === 0) return events;
+	let inPress = false;
+	let downUs = 0;
+	let downX = 0;
+	let downY = 0;
+	let right = false;
+	let maxDisp = 0;
+	for (let i = 0; i < samples.length; i++) {
+		const s = samples[i];
+		const down = s.leftDown || s.rightDown;
+		if (down && !inPress) {
+			inPress = true;
+			downUs = s.timestampUs;
+			downX = s.x;
+			downY = s.y;
+			// Right-click only when right is the sole button down at the edge.
+			right = s.rightDown && !s.leftDown;
+			maxDisp = 0;
+		} else if (down && inPress) {
+			maxDisp = Math.max(maxDisp, Math.hypot(s.x - downX, s.y - downY));
+		} else if (!down && inPress) {
+			inPress = false;
+			events.push({
+				downUs,
+				upUs: s.timestampUs,
+				downX,
+				downY,
+				right,
+				dragged: maxDisp > DRAG_THRESHOLD_PX,
+			});
+		}
+	}
+	if (inPress) {
+		events.push({
+			downUs,
+			upUs: samples[samples.length - 1].timestampUs,
+			downX,
+			downY,
+			right,
+			dragged: maxDisp > DRAG_THRESHOLD_PX,
+		});
+	}
+	return events;
+}
+
+/**
+ * Active click anchor + cosine falloff weight at `tsUs`, or null outside any
+ * click-snap window. Picks the closest event when two windows overlap so
+ * double-clicks snap cleanly to each successive target.
+ */
+export function clickAnchorAt(
+	events: PressEvent[],
+	tsUs: number,
+): { x: number; y: number; weight: number } | null {
+	let bestEv: PressEvent | null = null;
+	let bestAbsDt = Infinity;
+	for (let i = 0; i < events.length; i++) {
+		const ev = events[i];
+		if (tsUs < ev.downUs - CLICK_SNAP_HALF_US) break;
+		if (tsUs > ev.downUs + CLICK_SNAP_HALF_US) continue;
+		const absDt = Math.abs(tsUs - ev.downUs);
+		if (absDt < bestAbsDt) {
+			bestAbsDt = absDt;
+			bestEv = ev;
+		}
+	}
+	if (!bestEv) return null;
+	// Cosine ramp: 1 at the click frame, 0 at the window edge.
+	const weight = 0.5 + 0.5 * Math.cos((bestAbsDt / CLICK_SNAP_HALF_US) * Math.PI);
+	return { x: bestEv.downX, y: bestEv.downY, weight };
+}
+
+/**
+ * Pinned click-highlight envelope: the CAPTURED click position and an alpha
+ * that rises the instant the click lands, holds through the press, then fades.
+ */
+export function clickHighlightAt(
+	events: PressEvent[],
+	tsUs: number,
+): { x: number; y: number; alpha: number } | null {
+	let best: PressEvent | null = null;
+	let bestDt = Infinity;
+	for (let i = 0; i < events.length; i++) {
+		const ev = events[i];
+		const holdEnd = Math.max(
+			ev.upUs + PRESS_LINGER_US,
+			ev.downUs + PRESS_MIN_HOLD_US,
+		);
+		if (tsUs < ev.downUs) continue;
+		if (tsUs > holdEnd + HIGHLIGHT_FADE_OUT_US) continue;
+		const dt = tsUs - ev.downUs;
+		if (dt < bestDt) {
+			bestDt = dt;
+			best = ev;
+		}
+	}
+	if (!best) return null;
+	const holdEnd = Math.max(
+		best.upUs + PRESS_LINGER_US,
+		best.downUs + PRESS_MIN_HOLD_US,
+	);
+	let alpha: number;
+	if (tsUs < best.downUs + HIGHLIGHT_FADE_IN_US) {
+		alpha = smoothStep01((tsUs - best.downUs) / HIGHLIGHT_FADE_IN_US);
+	} else if (tsUs <= holdEnd) {
+		alpha = 1;
+	} else {
+		alpha = smoothStep01(
+			(holdEnd + HIGHLIGHT_FADE_OUT_US - tsUs) / HIGHLIGHT_FADE_OUT_US,
+		);
+	}
+	return { x: best.downX, y: best.downY, alpha };
+}
+
+/** All click-relative sprite/scale/visibility state for a moment in time. */
+export interface PressState {
+	pressedSprite: boolean; // swap to the press SVG sprite
+	visibleAlpha: number; // 0..1 boost on top of idleAlpha (overrides idle-hide)
+	scale: number; // applied directly to the sprite transform
+	right: boolean; // active press was a right-click (sprite slot)
+	dragging: boolean; // active press is a drag (sprite slot)
+}
+
+/**
+ * Press animation state at `tsUs`. When two events' influence windows overlap
+ * (sub-300ms double-clicks) the one whose `downUs` is closest to `tsUs` wins, so
+ * the sprite, anticipation lift, and impact snap all track the click the viewer
+ * is about to perceive.
+ */
+export function pressStateAt(events: PressEvent[], tsUs: number): PressState {
+	let bestEv: PressEvent | null = null;
+	let bestHoldEnd = 0;
+	let bestVisStart = 0;
+	let bestVisEnd = 0;
+	let bestAbsDt = Infinity;
+	for (let i = 0; i < events.length; i++) {
+		const ev = events[i];
+		const holdEnd = Math.max(
+			ev.upUs + PRESS_LINGER_US,
+			ev.downUs + PRESS_MIN_HOLD_US,
+		);
+		const visStart = ev.downUs - PRESS_PREROLL_US - PRESS_VIS_RAMP_US;
+		const visEnd = holdEnd + PRESS_POSTROLL_US + PRESS_VIS_RAMP_US;
+		// Events are sorted by downUs ascending, so once we're before an event's
+		// window we're before every later event's window too.
+		if (tsUs < visStart) break;
+		if (tsUs > visEnd) continue;
+		const absDt = Math.abs(tsUs - ev.downUs);
+		if (absDt < bestAbsDt) {
+			bestEv = ev;
+			bestHoldEnd = holdEnd;
+			bestVisStart = visStart;
+			bestVisEnd = visEnd;
+			bestAbsDt = absDt;
+		}
+	}
+	if (!bestEv)
+		return {
+			pressedSprite: false,
+			visibleAlpha: 0,
+			scale: 1,
+			right: false,
+			dragging: false,
+		};
+
+	// Visibility: smooth ramp in, hold full, smooth ramp out.
+	let visibleAlpha = 1;
+	if (tsUs < bestEv.downUs - PRESS_PREROLL_US) {
+		visibleAlpha = smoothStep01((tsUs - bestVisStart) / PRESS_VIS_RAMP_US);
+	} else if (tsUs > bestHoldEnd + PRESS_POSTROLL_US) {
+		visibleAlpha = smoothStep01((bestVisEnd - tsUs) / PRESS_VIS_RAMP_US);
+	}
+
+	// Pressed sprite: from preroll start through the held window.
+	const pressedSprite =
+		tsUs >= bestEv.downUs - PRESS_PREROLL_US && tsUs <= bestHoldEnd;
+
+	// Scale curve — three phases keyed on `dt = tsUs - downUs`.
+	//   dt ∈ [-ANTICIP, 0):  1 → 1+LIFT (smooth lift)
+	//   dt = 0:              snap to 1-PUNCH (click frame — sync point)
+	//   dt ∈ [0, RECOVERY]:  1-PUNCH → 1+BOUNCE → 1
+	let scale = 1;
+	const dt = tsUs - bestEv.downUs;
+	if (dt >= -PRESS_ANTICIP_US && dt < 0) {
+		const u = (dt + PRESS_ANTICIP_US) / PRESS_ANTICIP_US;
+		scale = 1 + PRESS_LIFT * smoothStep01(u);
+	} else if (dt >= 0 && dt < PRESS_RECOVERY_US) {
+		const u = dt / PRESS_RECOVERY_US;
+		if (u < 0.6) {
+			// 1-PUNCH → 1+BOUNCE
+			const v = u / 0.6;
+			scale = 1 - PRESS_PUNCH + (PRESS_PUNCH + PRESS_BOUNCE) * smoothStep01(v);
+		} else {
+			// 1+BOUNCE → 1
+			const v = (u - 0.6) / 0.4;
+			scale = 1 + PRESS_BOUNCE - PRESS_BOUNCE * smoothStep01(v);
+		}
+	}
+
+	return {
+		pressedSprite,
+		visibleAlpha,
+		scale,
+		right: bestEv.right,
+		dragging: bestEv.dragged,
+	};
+}

--- a/apps/desktop/src/components/editor/cursor-animation.logic.ts
+++ b/apps/desktop/src/components/editor/cursor-animation.logic.ts
@@ -1,13 +1,8 @@
 /**
- * Pure click/press animation maths for the cursor overlay, extracted from
- * VideoPreview. The captured cursor track (per ~8ms sample, with button state)
- * is collapsed into one `PressEvent` per click, and the press/click visuals are
+ * Click/press animation maths for the cursor overlay. The captured cursor track
+ * is collapsed into one `PressEvent` per click; the press/click visuals are
  * deterministic functions of time around those events. Mirrors `cursor_anim.rs`
- * so the editor preview and the export agree frame-for-frame.
- *
- * Everything here is pure: feed it the press events (built once via
- * `buildPressEvents`) and a timestamp. The component keeps the cursor-sample
- * state and the WebGL drawing.
+ * so editor preview and export agree frame-for-frame.
  */
 
 /** One collapsed click: down/up time + the captured click position. */
@@ -60,9 +55,8 @@ export function smoothStep01(t: number): number {
 }
 
 /**
- * Collapse raw cursor samples into one press event per click. Reads button
- * state from the RAW samples — smoothing reshapes x/y but must never move click
- * timing/position.
+ * Collapse raw cursor samples into one press event per click. Button state is
+ * read from RAW samples — smoothing reshapes x/y but must never move click timing/position.
  */
 export function buildPressEvents(samples: PressSample[]): PressEvent[] {
 	const events: PressEvent[] = [];

--- a/apps/desktop/src/components/editor/gradient.logic.ts
+++ b/apps/desktop/src/components/editor/gradient.logic.ts
@@ -2,10 +2,6 @@
  * Packs the store's gradient string into the flat uniform arrays the WebGL
  * preview shader consumes. Shares the store's gradient parser with the picker
  * and the Rust rasteriser so preview === export.
- *
- * This imports the store (for `parseGradient`/`MAX_GRADIENT_STOPS`), so it isn't
- * unit-tested under the pure-logic vitest setup; the pure colour parsing it
- * builds on lives in `color.logic.ts` (which is tested).
  */
 
 import {

--- a/apps/desktop/src/components/editor/gradient.logic.ts
+++ b/apps/desktop/src/components/editor/gradient.logic.ts
@@ -1,0 +1,44 @@
+/**
+ * Packs the store's gradient string into the flat uniform arrays the WebGL
+ * preview shader consumes. Shares the store's gradient parser with the picker
+ * and the Rust rasteriser so preview === export.
+ *
+ * This imports the store (for `parseGradient`/`MAX_GRADIENT_STOPS`), so it isn't
+ * unit-tested under the pure-logic vitest setup; the pure colour parsing it
+ * builds on lives in `color.logic.ts` (which is tested).
+ */
+
+import {
+	MAX_GRADIENT_STOPS,
+	parseGradient,
+} from "$lib/stores/editor-store.svelte";
+import { hexToRgba } from "./color.logic";
+
+/**
+ * Pack a gradient string into the shader's flat uniform arrays. Stops are
+ * sorted, padded to MAX_GRADIENT_STOPS (extra slots repeat the last stop so the
+ * shader's clamp is a no-op), positions normalised to 0..1, and the CSS-degree
+ * angle converted to radians.
+ */
+export function buildGradientUniforms(value: string): {
+	colors: Float32Array;
+	positions: Float32Array;
+	count: number;
+	angleRad: number;
+} {
+	const spec = parseGradient(value || "");
+	const sorted = [...spec.stops].sort((a, b) => a.pos - b.pos);
+	const count = Math.min(Math.max(sorted.length, 2), MAX_GRADIENT_STOPS);
+	const colors = new Float32Array(MAX_GRADIENT_STOPS * 4);
+	const positions = new Float32Array(MAX_GRADIENT_STOPS);
+	for (let i = 0; i < MAX_GRADIENT_STOPS; i++) {
+		const stop = sorted[Math.min(i, sorted.length - 1)];
+		const [r, g, b, a] = hexToRgba(stop.color);
+		colors[i * 4] = r;
+		colors[i * 4 + 1] = g;
+		colors[i * 4 + 2] = b;
+		colors[i * 4 + 3] = a;
+		positions[i] = Math.min(1, Math.max(0, stop.pos / 100));
+	}
+	return { colors, positions, count, angleRad: (spec.angle * Math.PI) / 180 };
+}

--- a/apps/desktop/src/components/editor/preset-picker.logic.test.ts
+++ b/apps/desktop/src/components/editor/preset-picker.logic.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
 	aspectClass,
 	bgPreviewStyle,
+	buildModel,
+	clampIndex,
+	filterPresets,
 	frameInsetPct,
+	groupPresets,
+	rowMoveIndex,
 	score,
 	wallpaperId,
 } from "./preset-picker.logic";
@@ -70,5 +75,75 @@ describe("bgPreviewStyle", () => {
 		expect(bgPreviewStyle({ ...preset, bg: "wallpaper" })).toBe(
 			"background:var(--color-muted)",
 		);
+	});
+});
+
+// ── Navigation model ──
+const P = (label: string, category: string) => ({
+	label,
+	category,
+	aspect: "16:9",
+});
+
+describe("filterPresets", () => {
+	const presets = [P("Studio", "Studio"), P("Reel", "Social"), P("Story", "Social")];
+	it("returns all in order for an empty query", () => {
+		expect(filterPresets(presets, "").map((p) => p.label)).toEqual([
+			"Studio",
+			"Reel",
+			"Story",
+		]);
+	});
+	it("filters and ranks by score", () => {
+		expect(filterPresets(presets, "st").map((p) => p.label)).toEqual([
+			"Studio",
+			"Story",
+		]);
+	});
+});
+
+describe("groupPresets", () => {
+	const filtered = [P("Studio", "Studio"), P("Reel", "Instagram")];
+	it("flattens to a single Results group while searching", () => {
+		const g = groupPresets(filtered, "x", null);
+		expect(g).toHaveLength(1);
+		expect(g[0][0]).toBe("Results");
+	});
+	it("groups by category and pins Current on top", () => {
+		const current = P("Studio", "Studio");
+		const g = groupPresets(filtered, "", current);
+		expect(g[0][0]).toBe("Current");
+		expect(g.map(([c]) => c)).toEqual(["Current", "Studio", "Instagram"]);
+	});
+});
+
+describe("buildModel + rowMoveIndex", () => {
+	// 3 presets in one category, 2 cols → rows [[0,1],[2]]
+	const grouped: [string, ReturnType<typeof P>[]][] = [
+		["Studio", [P("a", "Studio"), P("b", "Studio"), P("c", "Studio")]],
+	];
+	const model = buildModel(grouped, 2);
+
+	it("chunks into rows with unique running indices", () => {
+		expect(model.flat.map((p) => p.label)).toEqual(["a", "b", "c"]);
+		expect(model.rows.map((r) => r.map((c) => c.index))).toEqual([[0, 1], [2]]);
+	});
+	it("moves down preserving column, clamped on a short row", () => {
+		// from index 1 (row0 col1) down → row1 has only col0 → index 2
+		expect(rowMoveIndex(model, 1, 1)).toBe(2);
+		// from index 0 (row0 col0) down → row1 col0 → index 2
+		expect(rowMoveIndex(model, 0, 1)).toBe(2);
+	});
+	it("returns null past the edges", () => {
+		expect(rowMoveIndex(model, 0, -1)).toBeNull();
+		expect(rowMoveIndex(model, 2, 1)).toBeNull();
+	});
+});
+
+describe("clampIndex", () => {
+	it("clamps into range", () => {
+		expect(clampIndex(-2, 5)).toBe(0);
+		expect(clampIndex(9, 5)).toBe(4);
+		expect(clampIndex(3, 5)).toBe(3);
 	});
 });

--- a/apps/desktop/src/components/editor/preset-picker.logic.test.ts
+++ b/apps/desktop/src/components/editor/preset-picker.logic.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+	aspectClass,
+	bgPreviewStyle,
+	frameInsetPct,
+	score,
+	wallpaperId,
+} from "./preset-picker.logic";
+
+const preset = {
+	label: "Studio",
+	category: "Studio",
+	aspect: "16:9",
+	description: "Soft blue gradient",
+	keywords: ["clean", "demo"],
+	bg: "gradient",
+	value: "linear-gradient(#000,#fff)",
+};
+
+describe("score", () => {
+	it("matches everything on an empty query", () => {
+		expect(score(preset, "")).toBe(1);
+	});
+	it("ranks label prefix above substring and keyword", () => {
+		expect(score(preset, "stu")).toBe(100);
+		// label substring (90/category-prefix excluded by a non-matching category)
+		expect(
+			score({ ...preset, label: "My Studio", category: "Other" }, "studio"),
+		).toBe(80);
+		expect(score({ ...preset, label: "X", category: "Y" }, "demo")).toBe(30);
+	});
+	it("returns 0 for no match", () => {
+		expect(score({ ...preset, keywords: [], description: "" }, "zzz")).toBe(0);
+	});
+});
+
+describe("frameInsetPct", () => {
+	it("is 0 at no padding and capped at 20", () => {
+		expect(frameInsetPct(0)).toBe(0);
+		expect(frameInsetPct(10_000)).toBe(20);
+	});
+	it("mirrors video occupancy 1/(1+2p)", () => {
+		// padding 50% → p=0.5 → 0.5/2 = 25% → capped to 20
+		expect(frameInsetPct(50)).toBe(20);
+		// padding 10% → p=0.1 → 0.1/1.2 ≈ 8.33%
+		expect(frameInsetPct(10)).toBeCloseTo(8.333, 2);
+	});
+});
+
+describe("aspectClass", () => {
+	it("maps known aspects, defaults to video", () => {
+		expect(aspectClass("1:1")).toBe("aspect-square");
+		expect(aspectClass("9:16")).toBe("aspect-[9/16]");
+		expect(aspectClass("weird")).toBe("aspect-video");
+	});
+});
+
+describe("wallpaperId", () => {
+	it("strips asset prefixes", () => {
+		expect(wallpaperId({ ...preset, value: "asset://abc" })).toBe("abc");
+		expect(wallpaperId({ ...preset, value: "asset:xyz" })).toBe("xyz");
+	});
+});
+
+describe("bgPreviewStyle", () => {
+	it("uses the value for gradient/color, muted otherwise", () => {
+		expect(bgPreviewStyle(preset)).toBe(
+			"background:linear-gradient(#000,#fff)",
+		);
+		expect(bgPreviewStyle({ ...preset, bg: "wallpaper" })).toBe(
+			"background:var(--color-muted)",
+		);
+	});
+});

--- a/apps/desktop/src/components/editor/preset-picker.logic.ts
+++ b/apps/desktop/src/components/editor/preset-picker.logic.ts
@@ -76,3 +76,114 @@ export function aspectClass(aspect: string): string {
 			return "aspect-video";
 	}
 }
+
+// ── Keyboard-grid navigation model ──────────────────────────────────────────
+// The picker is a search box over a grid grouped by category. The pure pieces
+// below build the layout model and compute cursor moves; the component keeps the
+// reactive state (query/selectedIndex), the DOM refs, and focus/scroll effects.
+// Generic over `T extends PresetLike` so callers pass their own `Preset` type
+// without this module importing it.
+
+export interface Cell<T> {
+	preset: T;
+	index: number;
+}
+
+export interface PresetModel<T> {
+	groups: { category: string; rows: Cell<T>[][] }[];
+	flat: T[];
+	rows: Cell<T>[][];
+}
+
+/** Presets matching `query`, best-first; all presets (in input order) if empty. */
+export function filterPresets<T extends PresetLike>(
+	presets: T[],
+	query: string,
+): T[] {
+	return presets
+		.map((p) => ({ p, s: score(p, query) }))
+		.filter((x) => x.s > 0)
+		.sort((a, b) => b.s - a.s)
+		.map((x) => x.p);
+}
+
+/**
+ * Group filtered presets by category (a single "Results" group while searching),
+ * pinning the currently-applied preset to a "Current" group on top.
+ */
+export function groupPresets<T extends PresetLike>(
+	filtered: T[],
+	query: string,
+	current: T | null,
+): [string, T[]][] {
+	if (query.trim()) return [["Results", filtered]];
+	const map = new Map<string, T[]>();
+	for (const p of filtered) {
+		if (!map.has(p.category)) map.set(p.category, []);
+		map.get(p.category)!.push(p);
+	}
+	const entries = [...map.entries()];
+	// Pin the currently-applied preset to the top for instant re-apply.
+	if (current) entries.unshift(["Current", [current]]);
+	return entries;
+}
+
+/**
+ * Chunk grouped presets into rows of `cols`, assigning each cell a unique running
+ * `index`. Indices stay unique even though the pinned "Current" preset also
+ * appears in its own category, so navigation never relies on `indexOf`.
+ */
+export function buildModel<T>(
+	grouped: [string, T[]][],
+	cols: number,
+): PresetModel<T> {
+	const groups: PresetModel<T>["groups"] = [];
+	const flat: T[] = [];
+	const rows: Cell<T>[][] = [];
+	let counter = 0;
+	for (const [category, items] of grouped) {
+		const groupRows: Cell<T>[][] = [];
+		for (let i = 0; i < items.length; i += cols) {
+			const cells: Cell<T>[] = [];
+			for (let j = i; j < Math.min(i + cols, items.length); j++) {
+				const cell = { preset: items[j], index: counter++ };
+				cells.push(cell);
+				flat.push(items[j]);
+			}
+			groupRows.push(cells);
+			rows.push(cells);
+		}
+		groups.push({ category, rows: groupRows });
+	}
+	return { groups, flat, rows };
+}
+
+/** [rowPos, col] of `index` within the global row list; [0,0] if not found. */
+export function locateCell<T>(rows: Cell<T>[][], index: number): [number, number] {
+	for (let r = 0; r < rows.length; r++) {
+		const c = rows[r].findIndex((cell) => cell.index === index);
+		if (c !== -1) return [r, c];
+	}
+	return [0, 0];
+}
+
+/**
+ * New cursor index after a vertical move (jump a whole row, preserving the
+ * column, clamped when the target row is shorter), or null if there's no row in
+ * that direction.
+ */
+export function rowMoveIndex<T>(
+	model: PresetModel<T>,
+	index: number,
+	dir: 1 | -1,
+): number | null {
+	const [row, col] = locateCell(model.rows, index);
+	const target = model.rows[row + dir];
+	if (!target) return null;
+	return target[Math.min(col, target.length - 1)].index;
+}
+
+/** Clamp an index into [0, len-1] (len 0 → 0). */
+export function clampIndex(index: number, len: number): number {
+	return Math.max(0, Math.min(len - 1, index));
+}

--- a/apps/desktop/src/components/editor/preset-picker.logic.ts
+++ b/apps/desktop/src/components/editor/preset-picker.logic.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure helpers for PresetPicker — fuzzy search scoring, thumbnail styling, and
+ * aspect/wallpaper string mapping. Extracted from the component so the search
+ * ranking and frame maths are testable. The keyboard-nav state machine stays in
+ * the component (it owns reactive cursor state).
+ *
+ * Functions take a structural `PresetLike` (the subset of `Preset` they read)
+ * so this module doesn't depend on the component's exported `Preset` type.
+ */
+
+export interface PresetLike {
+	label: string;
+	category: string;
+	aspect: string;
+	description?: string;
+	keywords?: string[];
+	bg?: string;
+	value?: string;
+}
+
+/**
+ * Relevance of a preset to query `q` (higher = better, 0 = no match). Ranks
+ * label/category prefix highest, then substring matches, then description,
+ * keywords, and aspect. Empty query matches everything (returns 1).
+ */
+export function score(p: PresetLike, q: string): number {
+	if (!q) return 1;
+	const n = q.toLowerCase();
+	const label = p.label.toLowerCase();
+	const cat = p.category.toLowerCase();
+	if (label.startsWith(n)) return 100;
+	if (cat.startsWith(n)) return 90;
+	if (label.includes(n)) return 80;
+	if (cat.includes(n)) return 60;
+	if ((p.description ?? "").toLowerCase().includes(n)) return 40;
+	if ((p.keywords ?? []).some((k) => k.toLowerCase().includes(n))) return 30;
+	if (p.aspect.toLowerCase().includes(n)) return 20;
+	return 0;
+}
+
+/** Inline style for a preset's thumbnail background. */
+export function bgPreviewStyle(p: PresetLike): string {
+	if ((p.bg === "gradient" || p.bg === "color") && p.value)
+		return `background:${p.value}`;
+	return "background:var(--color-muted)";
+}
+
+/**
+ * WYSIWYG frame inset percent. `padding` is a percent of the shorter source
+ * edge and the canvas is source+padding on each side, so the video occupies
+ * `1/(1+2p)` of that edge — this mirrors that so the thumbnail frames like the
+ * real export. Capped at 20%.
+ */
+export function frameInsetPct(padding: number): number {
+	const p = Math.max(0, padding) / 100;
+	return Math.min(20, (p / (1 + 2 * p)) * 100);
+}
+
+/** The registry id for a wallpaper preset (strips the `asset:`/`asset://`). */
+export function wallpaperId(p: PresetLike): string {
+	return (p.value ?? "").replace(/^asset:\/\/?/, "").replace(/^asset:/, "");
+}
+
+/** Tailwind aspect class for a preset aspect string. */
+export function aspectClass(aspect: string): string {
+	switch (aspect) {
+		case "1:1":
+			return "aspect-square";
+		case "9:16":
+			return "aspect-[9/16]";
+		case "16:9":
+			return "aspect-video";
+		case "1.91:1":
+			return "aspect-[1.91/1]";
+		default:
+			return "aspect-video";
+	}
+}

--- a/apps/desktop/src/components/editor/preset-picker.logic.ts
+++ b/apps/desktop/src/components/editor/preset-picker.logic.ts
@@ -1,11 +1,7 @@
 /**
- * Pure helpers for PresetPicker — fuzzy search scoring, thumbnail styling, and
- * aspect/wallpaper string mapping. Extracted from the component so the search
- * ranking and frame maths are testable. The keyboard-nav state machine stays in
- * the component (it owns reactive cursor state).
- *
- * Functions take a structural `PresetLike` (the subset of `Preset` they read)
- * so this module doesn't depend on the component's exported `Preset` type.
+ * PresetPicker helpers: fuzzy search scoring, thumbnail styling, aspect/wallpaper
+ * mapping, and the keyboard-grid navigation model. Functions take a structural
+ * `PresetLike` so this module doesn't depend on the component's `Preset` type.
  */
 
 export interface PresetLike {
@@ -46,10 +42,9 @@ export function bgPreviewStyle(p: PresetLike): string {
 }
 
 /**
- * WYSIWYG frame inset percent. `padding` is a percent of the shorter source
- * edge and the canvas is source+padding on each side, so the video occupies
- * `1/(1+2p)` of that edge — this mirrors that so the thumbnail frames like the
- * real export. Capped at 20%.
+ * WYSIWYG frame inset percent. `padding` is a percent of the shorter source edge
+ * applied each side, so the video occupies `1/(1+2p)` of that edge — mirrored
+ * here so the thumbnail frames like the real export. Capped at 20%.
  */
 export function frameInsetPct(padding: number): number {
 	const p = Math.max(0, padding) / 100;
@@ -78,11 +73,8 @@ export function aspectClass(aspect: string): string {
 }
 
 // ── Keyboard-grid navigation model ──────────────────────────────────────────
-// The picker is a search box over a grid grouped by category. The pure pieces
-// below build the layout model and compute cursor moves; the component keeps the
-// reactive state (query/selectedIndex), the DOM refs, and focus/scroll effects.
-// Generic over `T extends PresetLike` so callers pass their own `Preset` type
-// without this module importing it.
+// Builds the per-category grid layout and computes cursor moves; the component
+// keeps the reactive state, DOM refs, and focus/scroll effects.
 
 export interface Cell<T> {
 	preset: T;

--- a/apps/desktop/src/components/editor/properity-panel/AnnotationsPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/AnnotationsPanel.svelte
@@ -60,8 +60,7 @@
     store.annotations.find((a) => a.id === store.selectedAnnotationId) ?? null,
   );
 
-  // Which ramp the Fade-curves editor targets — one large graph at a time
-  // (matches the Focus panel) instead of two cramped side-by-side editors.
+  // Which ramp the Fade-curves editor targets (one graph at a time).
   let customCurve = $state<"in" | "out">("in");
 
   type ToolDef = {
@@ -71,8 +70,7 @@
     hotkey: string;
   };
 
-  // Working tools only. (Image/polygon roadmap entries were removed — a
-  // disabled, locked tile is clutter, not discovery.)
+  // Working tools only — disabled/locked roadmap tiles are clutter.
   const tools: ToolDef[] = [
     { id: "select", label: "Select", icon: MousePointer2, hotkey: "V" },
     { id: "rect", label: "Rectangle", icon: Square, hotkey: "R" },
@@ -150,12 +148,10 @@
   });
 </script>
 
-<!-- Local, focus-aware tool hotkeys (V/R/O/A/T/B — documented in the central
-     shortcut registry). `<svelte:window>` so HMR can't leak the listener. -->
+<!-- Tool hotkeys (V/R/O/A/T/B). `<svelte:window>` so HMR can't leak the listener. -->
 <svelte:window onkeydown={handleHotkey} />
 
 <div class="flex flex-col gap-4 animate-in fade-in duration-200">
-  <!-- Tools — the "create" surface, at the top (the way you add annotations). -->
   <PanelSection
     title="Tools"
     hint="Pick a tool, then drag on the preview. Annotations are anchored in video-space so they follow zoom and crop. Press Esc to cancel placement; hold Alt while dragging to bypass snap."
@@ -207,7 +203,6 @@
     {/if}
   </PanelSection>
 
-  <!-- Layers -->
   {#if store.annotations.length === 0}
     <div
       class="flex flex-col items-center gap-2 rounded-xl border border-dashed border-border/70 bg-card/40 px-3 py-6 text-center"
@@ -226,13 +221,12 @@
     <AnnotationLayerPanel {store} />
   {/if}
 
-  <!-- Selected annotation editor — appearance & content lead; timing, fade
-       curves, and geometry collapse below (what you reach for after drawing). -->
+  <!-- Selected annotation editor — appearance/content lead; timing, fade
+       curves, geometry collapse below. -->
   {#if selected}
     {@const a = selected}
     {@const Icon = kindIcon(a)}
     <div class="flex flex-col gap-3 border-t border-border/50 pt-3">
-      <!-- Orientation header + delete -->
       <div class="flex items-center justify-between gap-2">
         <div class="flex min-w-0 items-center gap-1.5">
           <span
@@ -262,7 +256,6 @@
         </Button>
       </div>
 
-      <!-- Text content + typography (text's primary edit surface) -->
       {#if a.kind.kind === "text"}
         {@const k = a.kind}
         {@const currentFont =
@@ -405,7 +398,6 @@
         </PanelSection>
       {/if}
 
-      <!-- Blur is its own primary edit surface -->
       {#if a.kind.kind === "blur"}
         {@const k = a.kind}
         <PanelSection title="Blur">
@@ -480,10 +472,8 @@
         </PanelSection>
       {/if}
 
-      <!-- Appearance: stroke / fill / opacity / glow (adapts per kind) -->
       <AnnotationAppearance {store} annotation={a} />
 
-      <!-- Shape-specific finishing -->
       {#if a.kind.kind === "rect"}
         {@const k = a.kind}
         <PanelSection title="Shape">
@@ -525,7 +515,6 @@
         </PanelSection>
       {/if}
 
-      <!-- Timing -->
       <PanelSection title="Timing" collapsible defaultOpen>
         <SliderControl
           label="Start"
@@ -573,7 +562,6 @@
         />
       </PanelSection>
 
-      <!-- Fade curves: one large editor, switched in/out (matches Focus). -->
       <PanelSection title="Fade curves" collapsible defaultOpen={false}>
         {#snippet action()}
           <Button variant="ghost" size="xs" onclick={resetCurves}>Reset</Button>
@@ -605,7 +593,6 @@
         </div>
       </PanelSection>
 
-      <!-- Geometry: numeric box + frame alignment (power-user, collapsed). -->
       <AnnotationGeometry {store} annotation={a} />
     </div>
   {:else if store.annotations.length > 0}

--- a/apps/desktop/src/components/editor/properity-panel/AnnotationsPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/AnnotationsPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { kindIcon, kindLabel } from "$lib/annotations/kind-label";
+  import { clockCentis as fmtTime } from "$lib/format/time";
   import {
     FONT_FAMILIES,
     FONT_WEIGHTS,
@@ -109,12 +110,6 @@
   }
 
 
-  function fmtTime(sec: number): string {
-    const s = Math.max(0, sec);
-    const m = Math.floor(s / 60);
-    const rem = s - m * 60;
-    return `${m}:${rem.toFixed(2).padStart(5, "0")}`;
-  }
 
   function updateSelected(updates: Partial<Annotation>, trackUndo = false) {
     if (!selected) return;

--- a/apps/desktop/src/components/editor/properity-panel/AudioPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/AudioPanel.svelte
@@ -45,8 +45,7 @@
     updateAudioSettings({ volume: 100 }, true);
   }
 
-  // M keyboard shortcut. Suppressed inside text inputs and contenteditable
-  // (e.g. text annotations) so it doesn't fire while the user is typing.
+  // Suppress the M shortcut while typing in an input/contenteditable.
   function isEditableTarget(target: EventTarget | null): boolean {
     if (!(target instanceof HTMLElement)) return false;
     if (target.isContentEditable) return true;
@@ -62,8 +61,8 @@
     }
   }
 
-  // Volume zones for the slider readout. Above 100% the export pipeline
-  // applies straight gain, which can clip — surface that as a warning.
+  // Volume zones for the readout. Above 100% the export applies straight gain,
+  // which can clip — surfaced as a warning.
   type Zone = "muted" | "low" | "nominal" | "boost" | "hot";
   const volumeZone = $derived.by<Zone>(() => {
     if (store.audioSettings.muted) return "muted";
@@ -87,8 +86,8 @@
     );
   }
 
-  // The currently matching preset (if any) drives the Segmented selection;
-  // dragging the sliders to a custom value leaves nothing selected.
+  // Matching preset drives the Segmented selection; a custom slider value
+  // leaves nothing selected.
   const activePreset = $derived(
     FADE_PRESETS.find((p) => isPresetActive(p))?.label ?? "",
   );
@@ -96,21 +95,19 @@
     FADE_PRESETS.map((p) => ({ value: p.label, label: p.label })),
   );
 
-  // Wrappers: read the reactive store, defer the maths to the shared helpers.
+  // Wrappers: read the reactive store, defer maths to the shared helpers.
   const envelopePath = (fadeIn: number, fadeOut: number): string =>
     envelopePathBase(fadeIn, fadeOut, store.clipDuration || 1);
   const formatClipDuration = (): string => clock(store.clipDuration || 0);
 </script>
 
-<!-- Local, focus-aware: `M` toggles mute (documented in the central shortcut
-     registry). `<svelte:window>` so Svelte rebinds it on every HMR patch. -->
+<!-- `M` toggles mute. `<svelte:window>` so Svelte rebinds it on each HMR patch. -->
 <svelte:window onkeydown={handleKey} />
 
 <div
   class="flex flex-col gap-4"
   in:fly={{ y: 8, duration: 260, delay: 40, easing: cubicOut }}
 >
-  <!-- Output: master gain readout sits directly above the slider that drives it -->
   <PanelSection
     title="Output"
     hint="Volume affects editor playback and export. Press M to toggle mute."
@@ -143,7 +140,6 @@
     {/snippet}
 
     <div class="flex flex-col gap-2.5">
-      <!-- Hero meter: gain % + dB + clipping warning + linear gain bar -->
       <div
         class="rounded-md border border-border bg-card/60 px-3 py-2.5"
         class:opacity-50={store.audioSettings.muted}
@@ -189,7 +185,6 @@
           {/if}
         </div>
 
-        <!-- Linear gain bar with 100% reference mark -->
         <div class="relative mt-2 h-1.5 overflow-hidden rounded-full bg-background">
           <div
             class="absolute inset-y-0 left-0 transition-all duration-300 {volumeZone ===
@@ -211,7 +206,6 @@
         </div>
       </div>
 
-      <!-- The control for the readout above -->
       <SliderControl
         label="Output volume"
         value={store.audioSettings.volume}
@@ -246,7 +240,6 @@
       </span>
     {/snippet}
 
-    <!-- Envelope visualization -->
     <div class="rounded-md border border-border bg-background/60 p-2">
       <svg
         viewBox="0 0 100 24"
@@ -283,7 +276,6 @@
       </div>
     </div>
 
-    <!-- Presets -->
     <div class="mt-2">
       <Segmented
         size="xs"

--- a/apps/desktop/src/components/editor/properity-panel/AudioPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/AudioPanel.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
   import type { EditorStore } from "$lib/stores/editor-store.svelte";
+  import { clock } from "$lib/format/time";
+  import {
+    dbForVolume,
+    envelopePath as envelopePathBase,
+    FADE_PRESETS,
+    type FadePreset,
+  } from "./audio-panel.logic";
   import {
     AudioLines,
     AudioWaveform,
@@ -68,28 +75,11 @@
     return "hot";
   });
 
-  // dB-ish display ("0 dB" at 100%, calibrated as 20·log10(volume/100)). Not
-  // strictly the same as the Rust ffmpeg `volume=` filter (which is a
-  // multiplier on the linear sample value) but matches user intuition.
-  function dbForVolume(v: number): string {
-    if (v <= 0) return "−∞ dB";
-    const db = 20 * Math.log10(v / 100);
-    if (Math.abs(db) < 0.05) return "0.0 dB";
-    return `${db > 0 ? "+" : ""}${db.toFixed(1)} dB`;
-  }
-
-  const FADE_PRESETS: Array<{ label: string; in: number; out: number }> = [
-    { label: "None", in: 0, out: 0 },
-    { label: "Subtle", in: 0.25, out: 0.25 },
-    { label: "Smooth", in: 0.5, out: 1.0 },
-    { label: "Cinematic", in: 1.0, out: 2.0 },
-  ];
-
-  function applyPreset(preset: (typeof FADE_PRESETS)[number]) {
+  function applyPreset(preset: FadePreset) {
     store.pushUndoState();
     store.updateAudioSettings({ fadeIn: preset.in, fadeOut: preset.out });
   }
-  function isPresetActive(preset: (typeof FADE_PRESETS)[number]): boolean {
+  function isPresetActive(preset: FadePreset): boolean {
     const a = store.audioSettings;
     return (
       Math.abs(a.fadeIn - preset.in) < 0.01 &&
@@ -106,28 +96,10 @@
     FADE_PRESETS.map((p) => ({ value: p.label, label: p.label })),
   );
 
-  // SVG path for a tiny gain envelope visualization. Mirrors the FFmpeg
-  // afade behaviour: linear ramp 0→1 over fadeIn at the head, hold at 1,
-  // then linear ramp 1→0 over fadeOut at the tail.
-  function envelopePath(fadeIn: number, fadeOut: number): string {
-    const W = 100;
-    const H = 24;
-    const totalSecs = Math.max(0.01, store.clipDuration || 1);
-    const fi = Math.max(0, Math.min(fadeIn, totalSecs * 0.5));
-    const fo = Math.max(0, Math.min(fadeOut, totalSecs * 0.5));
-    const xIn = (fi / totalSecs) * W;
-    const xOut = W - (fo / totalSecs) * W;
-    const yTop = 2;
-    const yBottom = H - 2;
-    return `M 0 ${yBottom} L ${xIn.toFixed(2)} ${yTop} L ${xOut.toFixed(2)} ${yTop} L ${W} ${yBottom}`;
-  }
-
-  function formatClipDuration(): string {
-    const t = Math.max(0, store.clipDuration || 0);
-    const m = Math.floor(t / 60);
-    const s = Math.floor(t % 60);
-    return `${m}:${s.toString().padStart(2, "0")}`;
-  }
+  // Wrappers: read the reactive store, defer the maths to the shared helpers.
+  const envelopePath = (fadeIn: number, fadeOut: number): string =>
+    envelopePathBase(fadeIn, fadeOut, store.clipDuration || 1);
+  const formatClipDuration = (): string => clock(store.clipDuration || 0);
 </script>
 
 <!-- Local, focus-aware: `M` toggles mute (documented in the central shortcut
@@ -261,7 +233,7 @@
 
   <PanelSection
     title="Fades"
-    hint="Fades are export-side only — playback stays responsive while you edit."
+    hint="Fades apply to the exported file, not to editor playback."
     flush
     collapsible
   >

--- a/apps/desktop/src/components/editor/properity-panel/BackgroundPicker.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/BackgroundPicker.svelte
@@ -38,6 +38,11 @@
   import * as Tabs from "@recast/ui/tabs";
   import { cn } from "@recast/ui/utils";
   import { convertFileSrc } from "@tauri-apps/api/core";
+  import {
+    imagePreviewSrc,
+    isValidImageValue,
+    sampleStopColor,
+  } from "./background-picker.logic";
   import { Image } from "@unpic/svelte";
   import { SliderControl } from "@recast/ui/slider-control";
   import PanelSection from "./PanelSection.svelte";
@@ -131,41 +136,9 @@
     commitGradient({ ...gradientDraft, angle });
   }
 
-  // Sample the draft at a position (0..100) to seed a new stop's color —
-  // mirrors the renderer's sRGB lerp so the inserted stop is visually neutral.
-  function sampleDraftColor(pos: number): string {
-    const stops = [...gradientDraft.stops].sort((a, b) => a.pos - b.pos);
-    if (pos <= stops[0].pos) return stops[0].color;
-    const last = stops[stops.length - 1];
-    if (pos >= last.pos) return last.color;
-    for (let i = 0; i < stops.length - 1; i++) {
-      const a = stops[i];
-      const b = stops[i + 1];
-      if (pos >= a.pos && pos <= b.pos) {
-        const f = (pos - a.pos) / Math.max(b.pos - a.pos, 1e-6);
-        return lerpHex(a.color, b.color, f);
-      }
-    }
-    return last.color;
-  }
-
-  function lerpHex(c0: string, c1: string, f: number): string {
-    const p = (h: string) => {
-      const s = h.replace("#", "");
-      return [
-        parseInt(s.slice(0, 2), 16),
-        parseInt(s.slice(2, 4), 16),
-        parseInt(s.slice(4, 6), 16),
-      ];
-    };
-    const [r0, g0, b0] = p(c0);
-    const [r1, g1, b1] = p(c1);
-    const mix = (a: number, b: number) =>
-      Math.round(a + (b - a) * f)
-        .toString(16)
-        .padStart(2, "0");
-    return `#${mix(r0, r1)}${mix(g0, g1)}${mix(b0, b1)}`;
-  }
+  // Wrapper: samples the reactive draft's stops via the shared sRGB helper.
+  const sampleDraftColor = (pos: number): string =>
+    sampleStopColor(gradientDraft.stops, pos);
 
   function addStop() {
     if (gradientDraft.stops.length >= MAX_GRADIENT_STOPS) return;
@@ -258,33 +231,6 @@
     }
   }
 
-  function isValidImageValue(value: string) {
-    if (!value) return false;
-    // Explicitly reject non-image values that might linger in
-    // `backgroundValue` after switching tabs (gradient strings, colour
-    // hex, internal asset ids). Without this guard these slip through to
-    // the `<Image>` element below, which feeds them into convertFileSrc
-    // and triggers a Tauri asset-protocol "file does not exist" error.
-    if (
-      value.includes("gradient(") ||
-      value.startsWith("#") ||
-      value.startsWith("asset:")
-    ) {
-      return false;
-    }
-    return (
-      value.startsWith("data:") ||
-      value.startsWith("http://") ||
-      value.startsWith("https://") ||
-      value.startsWith("asset://") ||
-      value.startsWith("/wallpapers/") ||
-      value.endsWith(".png") ||
-      value.endsWith(".jpg") ||
-      value.endsWith(".jpeg") ||
-      value.endsWith(".webp")
-    );
-  }
-
   function getSelectionValue(type: BackgroundType) {
     return isValidValueForType(type, store.backgroundValue)
       ? store.backgroundValue
@@ -317,29 +263,9 @@
     store.setBackground({ type: "image", value: selected });
   }
 
-  function getImagePreviewSrc(value: string) {
-    if (!value) return "";
-    // Mirror isValidImageValue's rejections — feeding a gradient string or
-    // colour hex to convertFileSrc reaches Tauri's asset protocol and
-    // produces "File does not exist" log spam.
-    if (
-      value.includes("gradient(") ||
-      value.startsWith("#") ||
-      value.startsWith("asset:")
-    ) {
-      return "";
-    }
-    if (
-      value.startsWith("data:") ||
-      value.startsWith("http://") ||
-      value.startsWith("https://") ||
-      value.startsWith("asset://") ||
-      value.startsWith("/wallpapers/")
-    ) {
-      return value;
-    }
-    return convertFileSrc(value);
-  }
+  // Wrapper: injects Tauri's convertFileSrc into the shared resolver.
+  const getImagePreviewSrc = (value: string): string =>
+    imagePreviewSrc(value, convertFileSrc);
 
   $effect(() => {
     blurValue = store.backgroundBlur;
@@ -523,7 +449,7 @@
   >
     <PanelSection
       title="Background"
-      hint="What fills the canvas behind your recording. Previewed live."
+      hint="What fills the canvas behind your recording."
       flush
     >
       <Tabs.List

--- a/apps/desktop/src/components/editor/properity-panel/BackgroundPicker.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/BackgroundPicker.svelte
@@ -2,17 +2,12 @@
   import LazyExternalImage from "$components/common/LazyExternalImage.svelte";
   import {
     COLOR_PRESETS,
-    DEFAULT_GRADIENT,
     GRADIENT_PRESETS,
     MAX_FRAME_PADDING_PERCENT,
-    MAX_GRADIENT_STOPS,
-    parseGradient,
-    serializeGradient,
     WALLPAPERS,
     wallpaperBackgroundValue,
     type BackgroundType,
     type EditorStore,
-    type GradientSpec,
   } from "$lib/stores/editor-store.svelte";
   import {
     Blend,
@@ -21,11 +16,8 @@
     LayoutTemplate,
     Move,
     Palette,
-    Plus,
-    RotateCw,
     Sparkles,
     SquareRoundCorner,
-    Trash2,
   } from "@lucide/svelte";
   import {
     getRecentColors,
@@ -41,10 +33,10 @@
   import {
     imagePreviewSrc,
     isValidImageValue,
-    sampleStopColor,
   } from "./background-picker.logic";
   import { Image } from "@unpic/svelte";
   import { SliderControl } from "@recast/ui/slider-control";
+  import GradientBuilder from "./GradientBuilder.svelte";
   import PanelSection from "./PanelSection.svelte";
 
   interface Props {
@@ -78,123 +70,6 @@
   let recents = $state<string[]>(getRecentColors());
   function rememberColor(color: string) {
     recents = pushRecentColor(color);
-  }
-
-  // Local editing draft so dragging a stop doesn't round-trip through the store
-  // every pointer-move; streamed back via setBackgroundLive (coalesced undo). It
-  // serialises to the same CSS string both renderers (preview + Rust export) parse.
-  let gradientDraft = $state<GradientSpec>(
-    parseGradient(
-      store.backgroundType === "gradient" ? store.backgroundValue : DEFAULT_GRADIENT,
-    ),
-  );
-  let selectedStop = $state(0);
-  let gradientBarEl = $state<HTMLDivElement | null>(null);
-
-  // Reconcile the draft on outside changes (undo/redo, preset click). The
-  // serialise-compare stops our own live edits from bouncing back into the drag.
-  $effect(() => {
-    if (store.backgroundType !== "gradient") return;
-    const current = store.backgroundValue;
-    if (current !== serializeGradient(gradientDraft)) {
-      gradientDraft = parseGradient(current);
-      if (selectedStop >= gradientDraft.stops.length) selectedStop = 0;
-    }
-  });
-
-  const gradientCss = $derived(serializeGradient(gradientDraft));
-
-  // Live commit (drag gestures) → single coalesced undo entry. Discrete edits
-  // (add/remove stop) pass `live=false` for a clean, individually-undoable step.
-  function commitGradient(next: GradientSpec, live = true) {
-    gradientDraft = next;
-    const value = serializeGradient(next);
-    if (live) store.setBackgroundLive("gradient", value);
-    else store.setBackground({ type: "gradient", value });
-  }
-
-  function setStopColor(i: number, color: string) {
-    commitGradient({
-      ...gradientDraft,
-      stops: gradientDraft.stops.map((s, j) => (j === i ? { ...s, color } : s)),
-    });
-  }
-
-  function setStopPos(i: number, pos: number) {
-    const clamped = Math.round(Math.min(100, Math.max(0, pos)));
-    commitGradient({
-      ...gradientDraft,
-      stops: gradientDraft.stops.map((s, j) => (j === i ? { ...s, pos: clamped } : s)),
-    });
-  }
-
-  function setAngle(angle: number) {
-    commitGradient({ ...gradientDraft, angle });
-  }
-
-  // Wrapper: samples the reactive draft's stops via the shared sRGB helper.
-  const sampleDraftColor = (pos: number): string =>
-    sampleStopColor(gradientDraft.stops, pos);
-
-  function addStop() {
-    if (gradientDraft.stops.length >= MAX_GRADIENT_STOPS) return;
-    // Insert in the widest gap so the new handle lands somewhere useful.
-    const sorted = [...gradientDraft.stops].sort((a, b) => a.pos - b.pos);
-    let gapPos = 50;
-    let widest = -1;
-    for (let i = 0; i < sorted.length - 1; i++) {
-      const gap = sorted[i + 1].pos - sorted[i].pos;
-      if (gap > widest) {
-        widest = gap;
-        gapPos = Math.round((sorted[i].pos + sorted[i + 1].pos) / 2);
-      }
-    }
-    const stops = [
-      ...gradientDraft.stops,
-      { color: sampleDraftColor(gapPos), pos: gapPos },
-    ];
-    commitGradient({ ...gradientDraft, stops }, false);
-    selectedStop = stops.length - 1;
-  }
-
-  function removeStop(i: number) {
-    if (gradientDraft.stops.length <= 2) return;
-    const stops = gradientDraft.stops.filter((_, j) => j !== i);
-    commitGradient({ ...gradientDraft, stops }, false);
-    selectedStop = Math.min(selectedStop, stops.length - 1);
-  }
-
-  // Drag a stop handle along the bar. Streams position live; the whole drag
-  // coalesces to one undo entry via `setBackgroundLive`.
-  function startStopDrag(e: PointerEvent, i: number) {
-    e.preventDefault();
-    selectedStop = i;
-    const bar = gradientBarEl;
-    if (!bar) return;
-    const rect = bar.getBoundingClientRect();
-    const move = (ev: PointerEvent) => {
-      setStopPos(i, ((ev.clientX - rect.left) / Math.max(rect.width, 1)) * 100);
-    };
-    const up = () => {
-      window.removeEventListener("pointermove", move);
-      window.removeEventListener("pointerup", up);
-    };
-    window.addEventListener("pointermove", move);
-    window.addEventListener("pointerup", up);
-  }
-
-  // Double-click an empty spot on the bar to drop a new stop there.
-  function addStopAtPointer(e: MouseEvent) {
-    if (gradientDraft.stops.length >= MAX_GRADIENT_STOPS) return;
-    const bar = gradientBarEl;
-    if (!bar) return;
-    const rect = bar.getBoundingClientRect();
-    const pos = Math.round(
-      Math.min(100, Math.max(0, ((e.clientX - rect.left) / Math.max(rect.width, 1)) * 100)),
-    );
-    const stops = [...gradientDraft.stops, { color: sampleDraftColor(pos), pos }];
-    commitGradient({ ...gradientDraft, stops }, false);
-    selectedStop = stops.length - 1;
   }
 
   // Mode tabs only choose which preset list is shown — they don't mutate the
@@ -590,110 +465,7 @@
       </div>
     </PanelSection>
 
-    <!-- Custom gradient builder: drag stops, double-click to add, edit the
-         selected stop's color/position/angle. Edits stream live and coalesce
-         into one undo step per gesture. -->
-    <PanelSection
-      title="Custom"
-      hint="Drag stops to reposition · double-click the bar to add a stop."
-      flush
-    >
-      {#snippet action()}
-        <Button
-          variant="ghost"
-          size="xs"
-          class="h-6 gap-1 px-1.5 text-[10.5px] text-muted-foreground"
-          onclick={addStop}
-          disabled={gradientDraft.stops.length >= MAX_GRADIENT_STOPS}
-        >
-          <Plus size={11} />
-          Add stop
-        </Button>
-      {/snippet}
-
-      <div class="flex flex-col gap-2.5">
-        <div
-          bind:this={gradientBarEl}
-          ondblclick={addStopAtPointer}
-          role="presentation"
-          class="relative h-9 w-full overflow-visible rounded-md border border-border/60 shadow-(--shadow-craft-inset)"
-          style="background: {gradientCss}"
-        >
-          {#each gradientDraft.stops as stop, i (i)}
-            <button
-              type="button"
-              onpointerdown={(e) => startStopDrag(e, i)}
-              onclick={() => (selectedStop = i)}
-              ondblclick={(e) => e.stopPropagation()}
-              class={cn(
-                "absolute top-1/2 size-4 -translate-x-1/2 -translate-y-1/2 cursor-grab rounded-full border-2 shadow-md transition-transform active:cursor-grabbing",
-                i === selectedStop
-                  ? "scale-110 border-primary ring-2 ring-primary/40"
-                  : "border-white/90 hover:scale-105",
-              )}
-              style="left: {stop.pos}%; background-color: {stop.color}"
-              aria-label="Gradient stop {i + 1} at {Math.round(stop.pos)}%"
-              aria-pressed={i === selectedStop}
-            ></button>
-          {/each}
-        </div>
-
-        <div class="flex items-center gap-1.5">
-          <div class="min-w-0 flex-1">
-            <ColorField
-              label="Stop {selectedStop + 1}"
-              value={gradientDraft.stops[selectedStop]?.color ?? "#000000"}
-              {recents}
-              allowAlpha={false}
-              oncommit={(c: string) => {
-                setStopColor(selectedStop, c);
-                rememberColor(c);
-              }}
-            />
-          </div>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            class="shrink-0 text-muted-foreground hover:text-destructive"
-            onclick={() => removeStop(selectedStop)}
-            disabled={gradientDraft.stops.length <= 2}
-            aria-label="Remove selected stop"
-          >
-            <Trash2 size={13} />
-          </Button>
-        </div>
-
-        <SliderControl
-          label="Position"
-          value={gradientDraft.stops[selectedStop]?.pos ?? 0}
-          min={0}
-          max={100}
-          step={1}
-          unit="%"
-          onstart={() => {}}
-          onchange={(v) => setStopPos(selectedStop, v)}
-        >
-          {#snippet icon()}
-            <Move size={11} />
-          {/snippet}
-        </SliderControl>
-
-        <SliderControl
-          label="Angle"
-          value={gradientDraft.angle}
-          min={0}
-          max={360}
-          step={1}
-          unit="°"
-          onstart={() => {}}
-          onchange={(v) => setAngle(v)}
-        >
-          {#snippet icon()}
-            <RotateCw size={11} />
-          {/snippet}
-        </SliderControl>
-      </div>
-    </PanelSection>
+    <GradientBuilder {store} {recents} onRememberColor={rememberColor} />
   </Tabs.Content>
 
   <Tabs.Content value="image">

--- a/apps/desktop/src/components/editor/properity-panel/BackgroundPicker.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/BackgroundPicker.svelte
@@ -80,12 +80,9 @@
     recents = pushRecentColor(color);
   }
 
-  // ── Custom gradient builder ────────────────────────────────────────────
-  // The draft is the editing source of truth; it serialises to the same CSS
-  // string the store holds and both renderers (WebGL preview + Rust export)
-  // parse. We keep a local draft so dragging a stop doesn't round-trip
-  // through the store on every pointer-move, then stream it back via
-  // `setBackgroundLive` (coalesced undo) for a live preview.
+  // Local editing draft so dragging a stop doesn't round-trip through the store
+  // every pointer-move; streamed back via setBackgroundLive (coalesced undo). It
+  // serialises to the same CSS string both renderers (preview + Rust export) parse.
   let gradientDraft = $state<GradientSpec>(
     parseGradient(
       store.backgroundType === "gradient" ? store.backgroundValue : DEFAULT_GRADIENT,
@@ -94,9 +91,8 @@
   let selectedStop = $state(0);
   let gradientBarEl = $state<HTMLDivElement | null>(null);
 
-  // Reconcile the draft when the store's gradient changes from the outside
-  // (undo/redo, a preset click). Guard with a serialise-compare so our own
-  // live edits don't bounce back and fight the drag.
+  // Reconcile the draft on outside changes (undo/redo, preset click). The
+  // serialise-compare stops our own live edits from bouncing back into the drag.
   $effect(() => {
     if (store.backgroundType !== "gradient") return;
     const current = store.backgroundValue;
@@ -201,11 +197,9 @@
     selectedStop = stops.length - 1;
   }
 
-  // Mode tabs (Wallpaper/Color/Gradient/Image) drive which preset list is
-  // shown — they do NOT mutate the actual background. The store is only
-  // updated when the user explicitly picks a preset. This keeps a user's
-  // applied background intact while they browse other modes, and prevents
-  // a tab-switch from silently replacing it with the first preset.
+  // Mode tabs only choose which preset list is shown — they don't mutate the
+  // background (only an explicit preset pick does), so browsing other modes
+  // keeps the applied background intact.
   let displayedMode = $state<BackgroundType>(store.backgroundType);
   $effect(() => {
     displayedMode = store.backgroundType;
@@ -275,10 +269,8 @@
 </script>
 
 <div class="flex flex-col gap-4 animate-in fade-in duration-200">
-  <!-- Reusable blur control. Background blur only affects texture backgrounds
-       (image/wallpaper) — the shader leaves color/gradient fills sharp — so it
-       lives contextually inside those two modes instead of as a global knob
-       that does nothing two-thirds of the time. -->
+  <!-- Blur only affects texture backgrounds (image/wallpaper), so it lives
+       inside those modes rather than as a global knob. -->
   {#snippet blurControl()}
     <SliderControl
       label="Background blur"
@@ -298,11 +290,9 @@
     </SliderControl>
   {/snippet}
 
-  <!-- Frame + Drop shadow are pinned ABOVE the background browser. They shape
-       the video rect regardless of background type and are used often, so they
-       stay in a fixed, scroll-free position instead of being pushed down by the
-       variable-height background modes (a short Color grid vs. a tall Wallpaper
-       grid would otherwise make these controls jump around). -->
+  <!-- Frame + Drop shadow pinned above the background browser: they apply to
+       every background and are used often, so they keep a fixed position
+       instead of jumping with the variable-height background modes. -->
   <PanelSection
     title="Frame"
     hint="Padding adds space around the recording; corner radius rounds its edges. Both apply to every background."
@@ -342,8 +332,6 @@
     </SliderControl>
   </PanelSection>
 
-  <!-- Drop shadow — collapses to a single toggle row, so it stays compact at
-       the top even when off. -->
   <PanelSection
     title="Drop shadow"
     hint="Adds depth by casting a soft shadow under the recording onto the canvas background."
@@ -435,13 +423,9 @@
     {/if}
   </PanelSection>
 
-  <!-- Background mode switcher + per-mode preset lists, built on the shared
-       Tabs component (variant="soft") so it matches the outer properties-panel
-       tabs and gets the same sliding active-indicator plus content slide/fade.
-       Placed LAST: it's the tall, browse-heavy section, so scrolling is
-       reserved for it. The active tab is intentionally decoupled from the
-       store: switching tabs only changes which preset list is shown — the
-       background isn't mutated until a preset is clicked (see `displayedMode`). -->
+  <!-- Background mode switcher + per-mode preset lists. Placed last as the
+       tall, browse-heavy section. The active tab is decoupled from the store —
+       it only picks the preset list shown (see `displayedMode`). -->
   <Tabs.Root
     value={displayedMode}
     onValueChange={(v: string) => (displayedMode = v as BackgroundType)}
@@ -463,10 +447,8 @@
             title={mode.label}
             class="h-6 flex-1 gap-1 px-2 text-[11px] font-medium"
           >
-            <!-- Explicit `size-` class (not the `size` prop): Tabs.Trigger's
-                 base style forces unsized SVGs to size-4, so the class both
-                 sets the real 11px size (size-2.75) and opts out of that
-                 default. -->
+            <!-- `size-` class, not the `size` prop: Tabs.Trigger forces unsized
+                 SVGs to size-4, so the class both sets 11px and opts out. -->
             <Icon class="size-2.75" />
             <span class="hidden @[260px]/panel:inline">{mode.label}</span>
           </Tabs.Trigger>
@@ -608,10 +590,9 @@
       </div>
     </PanelSection>
 
-    <!-- Custom gradient builder. The bar is the source of truth: drag a stop
-         to move it, double-click empty space to add one, pick the selected
-         stop's color below, and set the angle. Edits stream live to the
-         preview and coalesce into a single undo step per gesture. -->
+    <!-- Custom gradient builder: drag stops, double-click to add, edit the
+         selected stop's color/position/angle. Edits stream live and coalesce
+         into one undo step per gesture. -->
     <PanelSection
       title="Custom"
       hint="Drag stops to reposition · double-click the bar to add a stop."
@@ -631,7 +612,6 @@
       {/snippet}
 
       <div class="flex flex-col gap-2.5">
-        <!-- Gradient track + draggable stop handles -->
         <div
           bind:this={gradientBarEl}
           ondblclick={addStopAtPointer}
@@ -658,7 +638,6 @@
           {/each}
         </div>
 
-        <!-- Selected stop: color + remove -->
         <div class="flex items-center gap-1.5">
           <div class="min-w-0 flex-1">
             <ColorField
@@ -684,7 +663,6 @@
           </Button>
         </div>
 
-        <!-- Selected stop position -->
         <SliderControl
           label="Position"
           value={gradientDraft.stops[selectedStop]?.pos ?? 0}
@@ -700,7 +678,6 @@
           {/snippet}
         </SliderControl>
 
-        <!-- Gradient angle -->
         <SliderControl
           label="Angle"
           value={gradientDraft.angle}

--- a/apps/desktop/src/components/editor/properity-panel/CameraPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/CameraPanel.svelte
@@ -250,7 +250,7 @@
 
     <PanelSection
       title="Mirror"
-      hint="On (default): the bubble matches what you see in a webcam preview. Off: the bubble shows you as others see you — text behind you reads correctly."
+      hint="On: the bubble matches a webcam preview. Off: it shows you as others see you, so text behind you reads correctly."
       flush
     >
       {#snippet action()}

--- a/apps/desktop/src/components/editor/properity-panel/CameraPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/CameraPanel.svelte
@@ -26,9 +26,8 @@
 
   const hasCamera = $derived(!!cameraPath);
 
-  // Active preset chip — derives from the placement on every change so a
-  // drag in the preview that lands exactly on a corner re-highlights the
-  // matching chip without the user re-clicking it.
+  // Derived from the placement so a preview drag onto a corner re-highlights
+  // the matching chip without a re-click.
   const activePreset = $derived(
     cameraPresetFromPlacement(store.cameraOverlay.defaultPlacement),
   );
@@ -44,10 +43,8 @@
   }
 
   function setSize(size: number) {
-    // Resize anchored on the current preset corner so the bubble doesn't
-    // visually drift when scaling. Falls back to keeping x/y as-is for
-    // custom placements (pure scale-from-top-left, which is fine because
-    // the user just dragged to that exact spot).
+    // Anchor the resize on the current preset corner so the bubble doesn't
+    // drift; custom placements just scale from their top-left.
     const current = store.cameraOverlay.defaultPlacement;
     if (activePreset === "custom") {
       store.updateCameraOverlay({
@@ -92,10 +89,8 @@
     return xPart + yPart + transform;
   }
 
-  // Preset chip rows — laid out on a 3×3 grid that mirrors the spatial
-  // position the chip represents (top-left chip is in the top-left grid
-  // cell, etc.) so users can pick by spatial intuition rather than reading
-  // each label.
+  // 3×3 grid mirroring the spatial position each chip represents, so users
+  // pick by location rather than reading labels.
   const presetGrid: Array<CameraPositionPreset | null> = [
     "top-left", "top-center", "top-right",
     "left-center", null, "right-center",
@@ -111,7 +106,6 @@
 
 <div class="flex flex-col gap-4 animate-in fade-in duration-200">
   {#if hasCamera}
-    <!-- Visibility toggle bar (no section title — panel name is in header) -->
     <div class="flex items-center justify-between gap-2 rounded-md border border-border/60 bg-card/40 px-2.5 py-1.5">
       <span class="text-[11px] text-muted-foreground">
         Composite the camera track onto the screen video.
@@ -131,9 +125,8 @@
   {/if}
 
   {#if !hasCamera}
-    <!-- Empty state — panel still appears in the tab strip so the layout is
-         predictable across recordings, but the controls collapse to a hint
-         the user can act on next time they record. -->
+    <!-- Empty state — the panel stays in the tab strip for a predictable
+         layout, collapsed to an actionable hint. -->
     <div
       class="flex flex-col items-start gap-2 rounded-lg border border-dashed border-border/60 bg-muted/30 p-3"
     >
@@ -152,7 +145,6 @@
       </p>
     </div>
   {:else if store.cameraOverlay.enabled}
-    <!-- Position presets: 3×3 grid mirroring spatial position. -->
     <PanelSection
       title="Position"
       hint="Pick a corner or edge anchor. Drag the bubble in the preview for a custom position."
@@ -168,9 +160,7 @@
       >
         {#each presetGrid as cell, i (i)}
           {#if cell === null}
-            <!-- Centre cell of the 3×3 — left empty so the corner/edge
-                 chips visually map to where the bubble will sit on the
-                 frame. The grid IS the legend. -->
+            <!-- Centre cell left empty so the chips map to bubble position. -->
             <div aria-hidden="true" class="aspect-square"></div>
           {:else}
             {@const isActive = activePreset === cell}
@@ -188,7 +178,6 @@
                   : "border-transparent bg-background/40 text-foreground/80 hover:border-border hover:bg-background/80",
               )}
             >
-              <!-- Tiny dot inside the chip showing where the bubble lands. -->
               <span
                 aria-hidden="true"
                 class={cn(

--- a/apps/desktop/src/components/editor/properity-panel/CursorPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/CursorPanel.svelte
@@ -98,7 +98,7 @@
     <!-- Style + size = "the cursor itself" -->
     <PanelSection
       title="Style"
-      hint="Pick a cursor sprite and set its size. The default soft dot ships through both preview and export; other styles show in the editor preview today, while export still uses the soft dot until the cursor sprite raster lands in the export overlay."
+      hint="Pick a cursor style and size. The soft dot works in preview and export; other styles preview in the editor but export as the soft dot for now."
       flush
     >
       {#snippet action()}

--- a/apps/desktop/src/components/editor/properity-panel/CursorPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/CursorPanel.svelte
@@ -24,7 +24,6 @@
   import InspectorHint from "../InspectorHint.svelte";
   import PanelSection from "./PanelSection.svelte";
 
-  // Semantic-token accents — no hardcoded hex beyond the actual highlight swatches
   const highlightColors = [
     "#3b82f6",
     "#ef4444",
@@ -47,9 +46,7 @@
     registry.get("cursor", store.cursorSettings.style),
   );
 
-  // Smoothing + easing presets come from the registry so installed extension
-  // packs surface alongside the built-ins (which register there too), instead
-  // of reading the static built-in arrays directly.
+  // From the registry so installed extension packs surface alongside built-ins.
   const smoothingPresets = $derived(registry.list("smoothing"));
   const easingPresets = $derived(
     registry
@@ -65,9 +62,8 @@
     store.updateCursorSettings(updates);
   }
 
-  // Cursor SVGs can come from downloaded extension packs (untrusted). Render
-  // them through a data-URL <img> rather than {@html} so SVG loads in the
-  // browser's secure static mode — scripts/event handlers never execute.
+  // Cursor SVGs may come from untrusted extension packs. Render via a data-URL
+  // <img>, not {@html}, so SVG loads in secure static mode (no script execution).
   function svgSwatchUrl(svg: string): string {
     return (
       "data:image/svg+xml;utf8," +
@@ -77,7 +73,6 @@
 </script>
 
 <div class="flex flex-col gap-4 animate-in fade-in duration-200">
-  <!-- Visibility toggle (no section title — panel name is shown in the header) -->
   <div
     class="flex items-center justify-between gap-2 rounded-md border border-border/60 bg-card/40 px-2.5 py-1.5"
   >
@@ -95,7 +90,6 @@
   </div>
 
   {#if store.cursorSettings.enabled}
-    <!-- Style + size = "the cursor itself" -->
     <PanelSection
       title="Style"
       hint="Pick a cursor style and size. The soft dot works in preview and export; other styles preview in the editor but export as the soft dot for now."
@@ -183,7 +177,6 @@
       </div>
     </PanelSection>
 
-    <!-- Motion = how the captured path is smoothed AND eased between samples -->
     <PanelSection
       title="Motion"
       hint="Gaussian-window smoothing over the captured path, click-snap anchoring, and an optional easing curve that reshapes interpolation between samples."
@@ -214,7 +207,6 @@
           />
         {/if}
 
-        <!-- Smoothing presets -->
         <div class="flex flex-wrap gap-1">
           {#each smoothingPresets as preset, i (preset.id)}
             {@const isActive =
@@ -303,7 +295,7 @@
           </SliderControl>
         {/if}
 
-        <!-- Motion easing — opt-in curve, presets-first with a hidden custom graph -->
+        <!-- Motion easing — opt-in, presets-first with a hidden custom graph -->
         <div
           class="space-y-2 rounded-xl border border-border/60 bg-card/40 p-2 shadow-(--shadow-craft-inset)"
         >

--- a/apps/desktop/src/components/editor/properity-panel/ExtensionDetailsDialog.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/ExtensionDetailsDialog.svelte
@@ -32,8 +32,7 @@
 
   interface Props {
     open: boolean;
-    /** Registry metadata (carries manifestUrl + version). Null when opened from
-     *  a purely-local install with no matching registry entry. */
+    /** Registry metadata (manifestUrl + version). Null for a local-only install. */
     entry: RegistryIndexEntry | null;
     /** The installed record, when this pack is installed. */
     installed: InstalledExtension | null;
@@ -41,9 +40,8 @@
 
   let { open = $bindable(), entry, installed }: Props = $props();
 
-  // Manifest drives the "what's inside" section. For an installed pack we
-  // already have it; for a registry entry we fetch the full manifest (the index
-  // only carries summary metadata) so the user sees contents before installing.
+  // Installed packs already carry the manifest; for a registry entry we fetch it
+  // (the index only has summary metadata) so contents show before install.
   let manifest = $state<ExtensionManifest | null>(null);
   let loadingManifest = $state(false);
   // Guards the load effect against re-fetching the same target on every re-run.
@@ -85,8 +83,7 @@
   const author = $derived(
     installed?.manifest.author ?? entry?.author ?? manifest?.author ?? null,
   );
-  // Only the registry index entry carries a description — the installable
-  // manifest drops it, so there's no manifest-side fallback.
+  // Only the registry entry carries a description; the manifest has none.
   const description = $derived(entry?.description ?? null);
   const updateAvailable = $derived(
     isInstalled && hasUpdate(installedVersion ?? "0.0.0", latestVersion),
@@ -117,11 +114,8 @@
   const assetCount = $derived(manifest?.assets?.length ?? 0);
 
   // Which action is in flight, so the matching button shows a spinner + verb.
-  // `installed`/`entry` are reactive props that change the instant the store
-  // updates, so action handlers MUST capture any name/id they need for the
-  // result toast BEFORE awaiting — otherwise the success line reads a prop
-  // that's already gone null and throws (the "Remove failed: …null… manifest"
-  // bug). Capture first, await second.
+  // GOTCHA: `installed`/`entry` are reactive props that go null the moment the
+  // store updates, so handlers must capture any name/id for the toast BEFORE awaiting.
   let pending = $state<null | "install" | "update" | "uninstall">(null);
 
   async function onInstall() {
@@ -152,8 +146,7 @@
 
   async function onUninstall() {
     if (!installed || pending) return;
-    // Capture name + id now — `installed` goes null the moment the store drops
-    // this pack, which happens before the await resolves.
+    // Capture before await: `installed` goes null when the store drops the pack.
     const { id, name: packName } = installed.manifest;
     pending = "uninstall";
     try {
@@ -183,7 +176,6 @@
     showCloseButton={false}
     class="top-[10%] w-[min(92vw,32rem)] max-w-none translate-y-0 gap-0 overflow-hidden rounded-xl p-0 ring-1 ring-border sm:max-w-none"
   >
-    <!-- Header -->
     <Dialog.Header class="space-y-0 border-b border-border px-4 py-2.5 text-left">
       <div class="flex items-center gap-2.5">
         {#if entry?.iconUrl}
@@ -224,10 +216,8 @@
       </div>
     </Dialog.Header>
 
-    <!-- Body -->
     <div class="max-h-[70vh] overflow-y-auto overflow-x-hidden">
       <div class="divide-y divide-border/30">
-        <!-- Description + safety -->
         <div class="px-4 py-3">
           {#if description}
             <p class="text-[11.5px] leading-relaxed text-pretty text-foreground/90">
@@ -250,7 +240,6 @@
             <Spinner class="size-5 text-muted-foreground" />
           </div>
         {:else if manifest}
-          <!-- What's inside -->
           {#if groups.length > 0}
             <div class="space-y-3 px-4 py-3">
               <h4
@@ -282,7 +271,6 @@
             </div>
           {/if}
 
-          <!-- Assets it manages -->
           {#if assetCount > 0}
             <div class="px-4 py-3">
               <div class="mb-1.5 flex items-center gap-1.5">
@@ -298,7 +286,6 @@
             </div>
           {/if}
 
-          <!-- Enabled toggle (installed only) -->
           {#if isInstalled}
             <div class="flex items-center justify-between gap-2 px-4 py-3">
               <span class="text-[11px] font-medium text-foreground">Enabled</span>
@@ -320,7 +307,6 @@
       </div>
     </div>
 
-    <!-- Footer -->
     <footer
       class="flex h-10 items-center justify-between gap-2 border-t border-border bg-muted/30 px-3 text-[11px] text-muted-foreground"
     >

--- a/apps/desktop/src/components/editor/properity-panel/ExtensionsPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/ExtensionsPanel.svelte
@@ -37,9 +37,8 @@
   let index = $state<RegistryIndexEntry[] | null>(null);
   let loadingIndex = $state(false);
 
-  // Details dialog: addressed by id so both the registry entry and the installed
-  // record resolve reactively (so the dialog reflects post-install/uninstall
-  // state without re-opening).
+  // Addressed by id so the dialog resolves entry + installed reactively (reflects
+  // install/uninstall without re-opening).
   let dialogOpen = $state(false);
   let selectedId = $state<string | null>(null);
 
@@ -145,7 +144,6 @@
     </span>
   </div>
 
-  <!-- Install from URL -->
   <PanelSection
     title="Install from URL"
     hint="Paste a pack manifest URL (https, or http://localhost for testing). Assets are SHA-256 verified before install."
@@ -183,7 +181,6 @@
     {/if}
   </PanelSection>
 
-  <!-- Installed -->
   <PanelSection title="Installed" flush>
     {#snippet action()}
       <span class="flex items-center gap-1.5">
@@ -265,7 +262,6 @@
     {/if}
   </PanelSection>
 
-  <!-- Browse curated registry -->
   <PanelSection title="Browse" flush>
     {#snippet action()}
       <button

--- a/apps/desktop/src/components/editor/properity-panel/FocusPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/FocusPanel.svelte
@@ -5,6 +5,12 @@
     type Easing,
   } from "$lib/easing/cubic-bezier";
   import { registry } from "$lib/registry";
+  import { clockCentis as fmtTime } from "$lib/format/time";
+  import {
+    regionMaxRamp,
+    scaleAt,
+    sparklinePath,
+  } from "./focus-panel.logic";
   import {
     DEFAULT_ZOOM_CENTER,
     DEFAULT_ZOOM_MOTION_BLUR,
@@ -120,70 +126,6 @@
       centerY: DEFAULT_ZOOM_CENTER,
       motionBlur: DEFAULT_ZOOM_MOTION_BLUR,
     });
-  }
-
-  function fmtTime(sec: number): string {
-    const total = Math.max(0, sec);
-    const s = Math.floor(total);
-    const ms = Math.round((total - s) * 1000);
-    return `${Math.floor(s / 60)}:${(s % 60).toString().padStart(2, "0")}.${ms
-      .toString()
-      .padStart(3, "0")
-      .slice(0, 2)}`;
-  }
-
-  function regionMaxRamp(r: ZoomRegion): number {
-    return Math.max(0, (r.end - r.start) * 0.5);
-  }
-
-  // Precompute the sparkline path for one region card — encodes the
-  // rampIn → hold → rampOut shape as a normalised 1.0 → scale → 1.0 curve.
-  function sparklinePath(r: ZoomRegion, w: number, h: number): string {
-    const duration = Math.max(0.001, r.end - r.start);
-    const maxScale = Math.max(r.scale, 1.0);
-    const normScale = (s: number) =>
-      maxScale === 1 ? 1 : (s - 1) / (maxScale - 1);
-    const samples: Array<[number, number]> = [];
-    const N = 40;
-    for (let i = 0; i <= N; i++) {
-      const t = (i / N) * duration;
-      const absT = r.start + t;
-      const s = scaleAt(r, absT);
-      const x = (t / duration) * w;
-      const y = h - normScale(s) * h * 0.9 - 1;
-      samples.push([x, y]);
-    }
-    return samples
-      .map(([x, y], i) => `${i === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)}`)
-      .join(" ");
-  }
-
-  function scaleAt(r: ZoomRegion, t: number): number {
-    if (t <= r.start || t >= r.end) return 1;
-    const duration = Math.max(0, r.end - r.start);
-    const half = duration * 0.5;
-    const rampIn = Math.min(Math.max(0, r.rampIn), half);
-    const rampOut = Math.min(Math.max(0, r.rampOut), half);
-    const holdStart = r.start + rampIn;
-    const holdEnd = r.end - rampOut;
-    let phase: number, curve: Easing;
-    if (t < holdStart) {
-      phase = rampIn > 0 ? (t - r.start) / rampIn : 1;
-      curve = r.easeIn;
-    } else if (t > holdEnd) {
-      phase = rampOut > 0 ? (r.end - t) / rampOut : 1;
-      curve = r.easeOut;
-    } else {
-      return r.scale;
-    }
-    phase = Math.max(0, Math.min(1, phase));
-    // Low-budget x→y approximation (polynomial-in-t with t ≈ x). Indistinguishable
-    // at sparkline resolution; avoids pulling in the full Newton-Raphson solver.
-    const a = 1 - 3 * curve.y2 + 3 * curve.y1;
-    const b = 3 * curve.y2 - 6 * curve.y1;
-    const c = 3 * curve.y1;
-    const s = ((a * phase + b) * phase + c) * phase;
-    return 1 + (r.scale - 1) * s;
   }
 
   function applyPresetToBoth(preset: Easing) {

--- a/apps/desktop/src/components/editor/properity-panel/FocusPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/FocusPanel.svelte
@@ -63,9 +63,7 @@
     store.zoomRegions.find((r) => r.id === store.selectedZoomRegionId) ?? null,
   );
 
-  // Which ramp the Custom-curves editor is targeting. One large, usable graph
-  // shown at a time (switched here) beats two cramped side-by-side editors in
-  // the narrow inspector.
+  // Which ramp the Custom-curves editor targets (one graph at a time).
   let customCurve = $state<"in" | "out">("in");
 
   function addRegion() {
@@ -74,8 +72,7 @@
     const clipEnd = store.trimEnd || duration;
     const start = Math.max(store.trimStart, store.currentTime - 0.35);
     const end = Math.min(clipEnd, Math.max(start + 0.8, store.currentTime + 0.85));
-    // Look up where the cursor actually was at this moment so the new
-    // region zooms toward the user's pointer rather than dead-centre.
+    // Zoom toward where the cursor actually was, not dead-centre.
     const w = store.metadata?.width ?? 0;
     const h = store.metadata?.height ?? 0;
     const center = resolveZoomCenter(store.cursorSamplesRaw, store.currentTime, w, h);
@@ -139,9 +136,6 @@
 </script>
 
 <div class="flex flex-col gap-4 animate-in fade-in duration-200">
-  <!-- Regions: the navigator + Add. The list is the primary, frequently-used
-       surface, so it leads; the set-once Auto-zoom config is pushed to a
-       collapsed section at the bottom rather than sitting on top of it. -->
   <PanelSection
     title="Regions"
     hint="Each region zooms the clip with its own ease-in / ease-out. Park the playhead where you want to zoom, then Add."
@@ -175,9 +169,8 @@
       </div>
     {/snippet}
 
-    <!-- Smart Auto-Zoom — a headline feature, kept right next to "Add" (the
-         other way to create regions) so it's the first thing you see, not
-         buried below the list. On-import preference + an on-demand re-run. -->
+    <!-- Smart Auto-Zoom, kept next to "Add" rather than below the list.
+         On-import preference + an on-demand re-run. -->
     <div
       class="flex flex-col gap-2 rounded-xl border border-border/60 bg-card/70 px-2.5 py-2 shadow-(--shadow-craft-inset) backdrop-blur"
     >
@@ -238,9 +231,9 @@
         {#each store.zoomRegions as region, i (region.id)}
           {@const isActive = region.id === store.selectedZoomRegionId}
           {@const isHidden = region.hidden === true}
-          <!-- Card with an absolute-inset select button so the whole row picks
-               the region, while the per-row action buttons sit above it (own
-               z-layer) — nesting <button>s would be invalid markup. -->
+          <!-- Absolute-inset select button so the whole row picks the region,
+               with action buttons on their own z-layer — nesting <button>s
+               would be invalid markup. -->
           <div
             in:fly={{ y: 4, duration: 200, delay: i * 25, easing: cubicOut }}
             class={cn(
@@ -307,8 +300,8 @@
                 {(region.end - region.start).toFixed(2)}s duration
               </div>
             </div>
-            <!-- Row actions: revealed on hover/focus, always shown for the
-                 active row. Above the select button via z-10. -->
+            <!-- Row actions: revealed on hover/focus, always for the active
+                 row. Above the select button via z-10. -->
             <div
               class={cn(
                 "relative z-10 flex shrink-0 items-center gap-0.5 transition-opacity",
@@ -355,8 +348,8 @@
     {/if}
   </PanelSection>
 
-  <!-- Region editor (master-detail). Shows a small orientation header so the
-       user always knows which region these controls are editing. -->
+  <!-- Region editor (master-detail) with a header showing which region the
+       controls edit. -->
   {#if selected}
     {@const region = selected}
     {@const maxRamp = regionMaxRamp(region)}
@@ -555,8 +548,7 @@
         </SliderControl>
       </PanelSection>
 
-      <!-- Easing: lead with intent-named presets (the common path); the raw
-           bezier curves live behind a "Custom curves" disclosure. -->
+      <!-- Presets lead; raw bezier curves live behind a "Custom curves" disclosure. -->
       <PanelSection title="Easing" hint="How the zoom accelerates in and decelerates out.">
         {#snippet action()}
           <Button variant="ghost" size="xs" onclick={resetCurves}>Reset</Button>
@@ -580,9 +572,8 @@
 
         <PanelSection title="Custom curves" flush collapsible defaultOpen={false}>
           <div class="flex flex-col gap-2 pt-1">
-            <!-- One large editor at a time, switched in/out — far more usable
-                 than two cramped graphs squeezed side-by-side in the inspector.
-                 The region card's sparkline previews the combined result. -->
+            <!-- One editor at a time, switched in/out; the card's sparkline
+                 previews the combined result. -->
             <div class="flex items-center justify-between gap-2">
               <div class="flex items-center gap-1.5">
                 <span class="text-[10px] font-medium text-muted-foreground">

--- a/apps/desktop/src/components/editor/properity-panel/GradientBuilder.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/GradientBuilder.svelte
@@ -1,0 +1,249 @@
+<script lang="ts">
+  import {
+    DEFAULT_GRADIENT,
+    MAX_GRADIENT_STOPS,
+    parseGradient,
+    serializeGradient,
+    type EditorStore,
+    type GradientSpec,
+  } from "$lib/stores/editor-store.svelte";
+  import { Move, Plus, RotateCw, Trash2 } from "@lucide/svelte";
+  import { Button } from "@recast/ui/button";
+  import { ColorField } from "@recast/ui/color-field";
+  import { SliderControl } from "@recast/ui/slider-control";
+  import { cn } from "@recast/ui/utils";
+  import { sampleStopColor } from "./background-picker.logic";
+  import PanelSection from "./PanelSection.svelte";
+
+  interface Props {
+    store: EditorStore;
+    /** Shared recent-colors list (also used by the color/shadow pickers). */
+    recents: string[];
+    /** Record a freshly-picked color into the shared recents. */
+    onRememberColor: (color: string) => void;
+  }
+
+  let { store, recents, onRememberColor }: Props = $props();
+
+  // Local editing draft so dragging a stop doesn't round-trip through the store
+  // every pointer-move; streamed back via setBackgroundLive (coalesced undo). It
+  // serialises to the same CSS string both renderers (preview + Rust export) parse.
+  let gradientDraft = $state<GradientSpec>(
+    parseGradient(
+      store.backgroundType === "gradient" ? store.backgroundValue : DEFAULT_GRADIENT,
+    ),
+  );
+  let selectedStop = $state(0);
+  let gradientBarEl = $state<HTMLDivElement | null>(null);
+
+  // Reconcile the draft on outside changes (undo/redo, preset click). The
+  // serialise-compare stops our own live edits from bouncing back into the drag.
+  $effect(() => {
+    if (store.backgroundType !== "gradient") return;
+    const current = store.backgroundValue;
+    if (current !== serializeGradient(gradientDraft)) {
+      gradientDraft = parseGradient(current);
+      if (selectedStop >= gradientDraft.stops.length) selectedStop = 0;
+    }
+  });
+
+  const gradientCss = $derived(serializeGradient(gradientDraft));
+
+  // Live commit (drag gestures) → single coalesced undo entry. Discrete edits
+  // (add/remove stop) pass `live=false` for a clean, individually-undoable step.
+  function commitGradient(next: GradientSpec, live = true) {
+    gradientDraft = next;
+    const value = serializeGradient(next);
+    if (live) store.setBackgroundLive("gradient", value);
+    else store.setBackground({ type: "gradient", value });
+  }
+
+  function setStopColor(i: number, color: string) {
+    commitGradient({
+      ...gradientDraft,
+      stops: gradientDraft.stops.map((s, j) => (j === i ? { ...s, color } : s)),
+    });
+  }
+
+  function setStopPos(i: number, pos: number) {
+    const clamped = Math.round(Math.min(100, Math.max(0, pos)));
+    commitGradient({
+      ...gradientDraft,
+      stops: gradientDraft.stops.map((s, j) => (j === i ? { ...s, pos: clamped } : s)),
+    });
+  }
+
+  function setAngle(angle: number) {
+    commitGradient({ ...gradientDraft, angle });
+  }
+
+  // Wrapper: samples the reactive draft's stops via the shared sRGB helper.
+  const sampleDraftColor = (pos: number): string =>
+    sampleStopColor(gradientDraft.stops, pos);
+
+  function addStop() {
+    if (gradientDraft.stops.length >= MAX_GRADIENT_STOPS) return;
+    // Insert in the widest gap so the new handle lands somewhere useful.
+    const sorted = [...gradientDraft.stops].sort((a, b) => a.pos - b.pos);
+    let gapPos = 50;
+    let widest = -1;
+    for (let i = 0; i < sorted.length - 1; i++) {
+      const gap = sorted[i + 1].pos - sorted[i].pos;
+      if (gap > widest) {
+        widest = gap;
+        gapPos = Math.round((sorted[i].pos + sorted[i + 1].pos) / 2);
+      }
+    }
+    const stops = [
+      ...gradientDraft.stops,
+      { color: sampleDraftColor(gapPos), pos: gapPos },
+    ];
+    commitGradient({ ...gradientDraft, stops }, false);
+    selectedStop = stops.length - 1;
+  }
+
+  function removeStop(i: number) {
+    if (gradientDraft.stops.length <= 2) return;
+    const stops = gradientDraft.stops.filter((_, j) => j !== i);
+    commitGradient({ ...gradientDraft, stops }, false);
+    selectedStop = Math.min(selectedStop, stops.length - 1);
+  }
+
+  // Drag a stop handle along the bar. Streams position live; the whole drag
+  // coalesces to one undo entry via `setBackgroundLive`.
+  function startStopDrag(e: PointerEvent, i: number) {
+    e.preventDefault();
+    selectedStop = i;
+    const bar = gradientBarEl;
+    if (!bar) return;
+    const rect = bar.getBoundingClientRect();
+    const move = (ev: PointerEvent) => {
+      setStopPos(i, ((ev.clientX - rect.left) / Math.max(rect.width, 1)) * 100);
+    };
+    const up = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+  }
+
+  // Double-click an empty spot on the bar to drop a new stop there.
+  function addStopAtPointer(e: MouseEvent) {
+    if (gradientDraft.stops.length >= MAX_GRADIENT_STOPS) return;
+    const bar = gradientBarEl;
+    if (!bar) return;
+    const rect = bar.getBoundingClientRect();
+    const pos = Math.round(
+      Math.min(100, Math.max(0, ((e.clientX - rect.left) / Math.max(rect.width, 1)) * 100)),
+    );
+    const stops = [...gradientDraft.stops, { color: sampleDraftColor(pos), pos }];
+    commitGradient({ ...gradientDraft, stops }, false);
+    selectedStop = stops.length - 1;
+  }
+</script>
+
+<!-- Custom gradient builder: drag stops, double-click to add, edit the
+     selected stop's color/position/angle. Edits stream live and coalesce
+     into one undo step per gesture. -->
+<PanelSection
+  title="Custom"
+  hint="Drag stops to reposition · double-click the bar to add a stop."
+  flush
+>
+  {#snippet action()}
+    <Button
+      variant="ghost"
+      size="xs"
+      class="h-6 gap-1 px-1.5 text-[10.5px] text-muted-foreground"
+      onclick={addStop}
+      disabled={gradientDraft.stops.length >= MAX_GRADIENT_STOPS}
+    >
+      <Plus size={11} />
+      Add stop
+    </Button>
+  {/snippet}
+
+  <div class="flex flex-col gap-2.5">
+    <div
+      bind:this={gradientBarEl}
+      ondblclick={addStopAtPointer}
+      role="presentation"
+      class="relative h-9 w-full overflow-visible rounded-md border border-border/60 shadow-(--shadow-craft-inset)"
+      style="background: {gradientCss}"
+    >
+      {#each gradientDraft.stops as stop, i (i)}
+        <button
+          type="button"
+          onpointerdown={(e) => startStopDrag(e, i)}
+          onclick={() => (selectedStop = i)}
+          ondblclick={(e) => e.stopPropagation()}
+          class={cn(
+            "absolute top-1/2 size-4 -translate-x-1/2 -translate-y-1/2 cursor-grab rounded-full border-2 shadow-md transition-transform active:cursor-grabbing",
+            i === selectedStop
+              ? "scale-110 border-primary ring-2 ring-primary/40"
+              : "border-white/90 hover:scale-105",
+          )}
+          style="left: {stop.pos}%; background-color: {stop.color}"
+          aria-label="Gradient stop {i + 1} at {Math.round(stop.pos)}%"
+          aria-pressed={i === selectedStop}
+        ></button>
+      {/each}
+    </div>
+
+    <div class="flex items-center gap-1.5">
+      <div class="min-w-0 flex-1">
+        <ColorField
+          label="Stop {selectedStop + 1}"
+          value={gradientDraft.stops[selectedStop]?.color ?? "#000000"}
+          {recents}
+          allowAlpha={false}
+          oncommit={(c: string) => {
+            setStopColor(selectedStop, c);
+            onRememberColor(c);
+          }}
+        />
+      </div>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        class="shrink-0 text-muted-foreground hover:text-destructive"
+        onclick={() => removeStop(selectedStop)}
+        disabled={gradientDraft.stops.length <= 2}
+        aria-label="Remove selected stop"
+      >
+        <Trash2 size={13} />
+      </Button>
+    </div>
+
+    <SliderControl
+      label="Position"
+      value={gradientDraft.stops[selectedStop]?.pos ?? 0}
+      min={0}
+      max={100}
+      step={1}
+      unit="%"
+      onstart={() => {}}
+      onchange={(v) => setStopPos(selectedStop, v)}
+    >
+      {#snippet icon()}
+        <Move size={11} />
+      {/snippet}
+    </SliderControl>
+
+    <SliderControl
+      label="Angle"
+      value={gradientDraft.angle}
+      min={0}
+      max={360}
+      step={1}
+      unit="°"
+      onstart={() => {}}
+      onchange={(v) => setAngle(v)}
+    >
+      {#snippet icon()}
+        <RotateCw size={11} />
+      {/snippet}
+    </SliderControl>
+  </div>
+</PanelSection>

--- a/apps/desktop/src/components/editor/properity-panel/InfoPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/InfoPanel.svelte
@@ -5,6 +5,9 @@
     EditorStore,
     PanelTab,
   } from "$lib/stores/editor-store.svelte";
+  import { clock } from "$lib/format/time";
+  import { formatBytes as formatBytesBase } from "$lib/format/bytes";
+  import { basename, countByKind, formatRelative } from "./info-panel.logic";
   import {
     ArrowUpRight,
     ChevronRight,
@@ -56,12 +59,11 @@
     store.activePanel = tab;
   }
 
+  // Keeps the "--:--" placeholder (a presentation choice) but defers the clock
+  // formatting to the shared helper.
   function formatDuration(seconds: number | undefined): string {
     if (!seconds || seconds <= 0) return "--:--";
-    const t = Math.max(0, seconds);
-    const m = Math.floor(t / 60);
-    const s = Math.floor(t % 60);
-    return `${m}:${s.toString().padStart(2, "0")}`;
+    return clock(seconds);
   }
 
   function formatResolution(): string {
@@ -74,45 +76,9 @@
     return `${Math.round(store.metadata.fps)} fps`;
   }
 
-  /** Human-readable bytes: 1.4 GB, 932 MB, 84 KB. Defaults to "--" on 0/missing. */
-  function formatBytes(bytes: number | undefined): string {
-    if (!bytes || bytes <= 0) return "--";
-    const units = ["B", "KB", "MB", "GB", "TB"];
-    let i = 0;
-    let v = bytes;
-    while (v >= 1024 && i < units.length - 1) {
-      v /= 1024;
-      i++;
-    }
-    return `${v < 10 && i > 0 ? v.toFixed(1) : Math.round(v)} ${units[i]}`;
-  }
-
-  /** "in 2 min", "5 sec ago", "3 hr ago". Floors aggressively at the cutoffs
-   *  used in chat-style UIs so the readout doesn't bounce by 1 unit each tick. */
-  function formatRelative(ts: number | null, current: number): string {
-    if (!ts) return "Never";
-    const diffMs = current - ts;
-    const future = diffMs < 0;
-    const seconds = Math.floor(Math.abs(diffMs) / 1000);
-    const minutes = Math.floor(seconds / 60);
-    const hours = Math.floor(minutes / 60);
-    const days = Math.floor(hours / 24);
-    let label: string;
-    if (seconds < 5) label = "just now";
-    else if (seconds < 60) label = `${seconds}s`;
-    else if (minutes < 60) label = `${minutes} min`;
-    else if (hours < 24) label = `${hours} hr`;
-    else label = `${days} day${days === 1 ? "" : "s"}`;
-    if (label === "just now") return label;
-    return future ? `in ${label}` : `${label} ago`;
-  }
-
-  function basename(path: string): string {
-    if (!path) return "—";
-    const sep = path.includes("\\") ? "\\" : "/";
-    const last = path.split(sep).filter(Boolean).pop() ?? path;
-    return last;
-  }
+  // Wrapper: InfoPanel shows "--" for missing sizes (vs the shared default "0 B").
+  const formatBytes = (bytes: number | undefined): string =>
+    formatBytesBase(bytes, "--");
 
   // Annotation kind counts. Always render every kind (with 0) so the row
   // doesn't shift around as the user adds/removes shapes.
@@ -127,18 +93,6 @@
     { id: "text", label: "Text", icon: TypeIcon },
     { id: "image", label: "Image", icon: ImageIcon },
   ];
-
-  function countByKind(annotations: Annotation[]): Record<string, number> {
-    const out: Record<string, number> = {
-      rect: 0,
-      ellipse: 0,
-      arrow: 0,
-      text: 0,
-      image: 0,
-    };
-    for (const a of annotations) out[a.kind.kind] = (out[a.kind.kind] ?? 0) + 1;
-    return out;
-  }
 
   const annotationCounts = $derived(countByKind(store.annotations));
   const totalAnnotations = $derived(store.annotations.length);

--- a/apps/desktop/src/components/editor/properity-panel/InfoPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/InfoPanel.svelte
@@ -44,8 +44,7 @@
 
   let { store }: Props = $props();
 
-  // Tick `now` every 30s so the relative-time labels ("Saved 2 min ago")
-  // stay fresh without paying for a per-frame redraw.
+  // Tick every 30s so relative-time labels stay fresh without a per-frame redraw.
   let now = $state(Date.now());
   let nowTimer: ReturnType<typeof setInterval> | null = null;
   onMount(() => {
@@ -59,8 +58,7 @@
     store.activePanel = tab;
   }
 
-  // Keeps the "--:--" placeholder (a presentation choice) but defers the clock
-  // formatting to the shared helper.
+  // Keeps the "--:--" placeholder; defers clock formatting to the shared helper.
   function formatDuration(seconds: number | undefined): string {
     if (!seconds || seconds <= 0) return "--:--";
     return clock(seconds);
@@ -80,8 +78,7 @@
   const formatBytes = (bytes: number | undefined): string =>
     formatBytesBase(bytes, "--");
 
-  // Annotation kind counts. Always render every kind (with 0) so the row
-  // doesn't shift around as the user adds/removes shapes.
+  // Every kind always rendered (with 0) so the row doesn't shift as shapes change.
   const KIND_META: Array<{
     id: AnnotationKindName;
     label: string;

--- a/apps/desktop/src/components/editor/properity-panel/PropertiesPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/PropertiesPanel.svelte
@@ -25,8 +25,7 @@
 
   interface Props {
     store: EditorStore;
-    /** Path to camera.mp4 in this project, or null when no camera was
-     *  recorded. Forwarded to CameraPanel for its empty state. */
+    /** Path to camera.mp4, or null when no camera was recorded. */
     cameraPath?: string | null;
   }
   type TabType = {
@@ -84,7 +83,6 @@
     }}
     class="flex min-h-0 flex-1 flex-col"
   >
-    <!-- Header: segmented icon rail + active label -->
     <div
       class="shrink-0 flex items-center justify-between gap-2 border-b border-border/60 px-2 py-1.5"
     >

--- a/apps/desktop/src/components/editor/properity-panel/annotations/AnnotationAppearance.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/annotations/AnnotationAppearance.svelte
@@ -88,7 +88,7 @@
 
 <PanelSection
   title="Appearance"
-  hint="Stroke styles render in the preview. Glow is preview-only in v2 — exports fall back to a solid stroke."
+  hint="Stroke styles show in preview. Glow previews only; exports use a solid stroke for now."
   flush
 >
   <div class="flex flex-col gap-3">

--- a/apps/desktop/src/components/editor/properity-panel/annotations/AnnotationAppearance.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/annotations/AnnotationAppearance.svelte
@@ -93,7 +93,6 @@
 >
   <div class="flex flex-col gap-3">
     {#if isShape}
-      <!-- Stroke -->
       <div class="space-y-2">
         <SliderControl
           label="Stroke width"
@@ -122,7 +121,6 @@
           />
         </div>
 
-        <!-- Stroke color: quick swatches + custom picker -->
         <div class="flex flex-wrap items-center gap-1">
           {#each STROKE_SWATCHES as swatch (swatch)}
             {@const isActive = annotation.stroke.color === swatch}
@@ -170,7 +168,6 @@
     {/if}
 
     {#if hasFill}
-      <!-- Fill -->
       <div class="space-y-1.5">
         <span class="text-[10px] text-muted-foreground">Fill</span>
         <div class="flex flex-wrap items-center gap-1">
@@ -227,7 +224,6 @@
       </div>
     {/if}
 
-    <!-- Master opacity -->
     <SliderControl
       label="Opacity"
       value={(annotation.opacity ?? 1) * 100}
@@ -240,7 +236,6 @@
       onchange={(v) => setOpacity(v / 100)}
     />
 
-    <!-- Glow disclosure -->
     <div
       class="space-y-2 rounded-xl border border-border/60 bg-card/40 p-2 shadow-(--shadow-craft-inset)"
     >

--- a/apps/desktop/src/components/editor/properity-panel/annotations/AnnotationGeometry.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/annotations/AnnotationGeometry.svelte
@@ -215,7 +215,6 @@
       </div>
     {/if}
 
-    <!-- Frame-relative alignment -->
     <div class="flex flex-col gap-1">
       <span class="text-[10px] text-muted-foreground">Align to frame</span>
       <div class="flex items-center gap-1">

--- a/apps/desktop/src/components/editor/properity-panel/annotations/AnnotationLayerPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/annotations/AnnotationLayerPanel.svelte
@@ -22,8 +22,7 @@
 
   let { store }: Props = $props();
 
-  // Reverse so the topmost (highest z) renders at the top of the panel —
-  // matches the convention in Photoshop / Figma / After Effects.
+  // Topmost (highest z) at the top of the panel, like Photoshop/Figma.
   const ordered = $derived([...store.annotationsByZ].reverse());
 
   let renamingId = $state<string | null>(null);
@@ -64,8 +63,6 @@
     store.hoveredAnnotationId = id;
   }
 
-  // Pointer-driven drag reorder. We commit by passing the new id list to
-  // `setAnnotationZOrder` so the store updates z values in one shot.
   function handleDragStart(e: DragEvent, a: Annotation) {
     if (a.locked) {
       e.preventDefault();
@@ -95,8 +92,6 @@
     }
     e.preventDefault();
 
-    // Build the new visual order, then translate it back to the store's
-    // bottom-up z order before committing.
     const visual = ordered.map((a) => a.id);
     const fromIdx = visual.indexOf(dragId);
     const toIdx = visual.indexOf(target.id);

--- a/apps/desktop/src/components/editor/properity-panel/audio-panel.logic.test.ts
+++ b/apps/desktop/src/components/editor/properity-panel/audio-panel.logic.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { dbForVolume, envelopePath } from "./audio-panel.logic";
+
+describe("dbForVolume", () => {
+	it("is −∞ at or below zero", () => {
+		expect(dbForVolume(0)).toBe("−∞ dB");
+		expect(dbForVolume(-5)).toBe("−∞ dB");
+	});
+	it("is 0.0 dB at 100% and signed otherwise", () => {
+		expect(dbForVolume(100)).toBe("0.0 dB");
+		expect(dbForVolume(200)).toBe("+6.0 dB");
+		expect(dbForVolume(50)).toBe("-6.0 dB");
+	});
+});
+
+describe("envelopePath", () => {
+	it("draws a flat top with no fades", () => {
+		// fades 0 → xIn 0, xOut 100
+		expect(envelopePath(0, 0, 10)).toBe("M 0 22 L 0.00 2 L 100.00 2 L 100 22");
+	});
+	it("caps each fade at half the clip", () => {
+		// clip 10s, fadeIn 8 → capped to 5 → xIn 50
+		const p = envelopePath(8, 0, 10);
+		expect(p).toContain("L 50.00 2");
+	});
+});

--- a/apps/desktop/src/components/editor/properity-panel/audio-panel.logic.ts
+++ b/apps/desktop/src/components/editor/properity-panel/audio-panel.logic.ts
@@ -1,8 +1,4 @@
-/**
- * Pure helpers + data for AudioPanel: fade presets, the dB readout, and the SVG
- * gain-envelope path. Extracted so the maths is testable; the component keeps
- * the store wiring (and a thin wrapper that feeds clip duration into the path).
- */
+/** AudioPanel helpers + data: fade presets, the dB readout, and the SVG gain-envelope path. */
 
 export interface FadePreset {
 	label: string;
@@ -18,9 +14,8 @@ export const FADE_PRESETS: FadePreset[] = [
 ];
 
 /**
- * dB-ish display ("0 dB" at 100%, calibrated as 20·log10(volume/100)). Not the
- * exact same curve as the Rust ffmpeg `volume=` filter (a linear multiplier) but
- * matches user intuition.
+ * dB-ish display: 20·log10(volume/100), so "0 dB" at 100%. Intentionally not the
+ * ffmpeg `volume=` curve (a linear multiplier) — this matches user intuition.
  */
 export function dbForVolume(v: number): string {
 	if (v <= 0) return "−∞ dB";
@@ -30,9 +25,8 @@ export function dbForVolume(v: number): string {
 }
 
 /**
- * SVG path for a gain envelope across a 100×24 box. Mirrors the FFmpeg afade
- * behaviour: linear ramp 0→1 over `fadeIn` at the head, hold at 1, then linear
- * ramp 1→0 over `fadeOut` at the tail. Each fade is capped at half the clip.
+ * SVG gain-envelope path over a 100×24 box, mirroring FFmpeg afade: linear ramp
+ * 0→1 over `fadeIn`, hold, then 1→0 over `fadeOut`. Each fade capped at half the clip.
  */
 export function envelopePath(
 	fadeIn: number,

--- a/apps/desktop/src/components/editor/properity-panel/audio-panel.logic.ts
+++ b/apps/desktop/src/components/editor/properity-panel/audio-panel.logic.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure helpers + data for AudioPanel: fade presets, the dB readout, and the SVG
+ * gain-envelope path. Extracted so the maths is testable; the component keeps
+ * the store wiring (and a thin wrapper that feeds clip duration into the path).
+ */
+
+export interface FadePreset {
+	label: string;
+	in: number;
+	out: number;
+}
+
+export const FADE_PRESETS: FadePreset[] = [
+	{ label: "None", in: 0, out: 0 },
+	{ label: "Subtle", in: 0.25, out: 0.25 },
+	{ label: "Smooth", in: 0.5, out: 1.0 },
+	{ label: "Cinematic", in: 1.0, out: 2.0 },
+];
+
+/**
+ * dB-ish display ("0 dB" at 100%, calibrated as 20·log10(volume/100)). Not the
+ * exact same curve as the Rust ffmpeg `volume=` filter (a linear multiplier) but
+ * matches user intuition.
+ */
+export function dbForVolume(v: number): string {
+	if (v <= 0) return "−∞ dB";
+	const db = 20 * Math.log10(v / 100);
+	if (Math.abs(db) < 0.05) return "0.0 dB";
+	return `${db > 0 ? "+" : ""}${db.toFixed(1)} dB`;
+}
+
+/**
+ * SVG path for a gain envelope across a 100×24 box. Mirrors the FFmpeg afade
+ * behaviour: linear ramp 0→1 over `fadeIn` at the head, hold at 1, then linear
+ * ramp 1→0 over `fadeOut` at the tail. Each fade is capped at half the clip.
+ */
+export function envelopePath(
+	fadeIn: number,
+	fadeOut: number,
+	clipDuration: number,
+): string {
+	const W = 100;
+	const H = 24;
+	const totalSecs = Math.max(0.01, clipDuration || 1);
+	const fi = Math.max(0, Math.min(fadeIn, totalSecs * 0.5));
+	const fo = Math.max(0, Math.min(fadeOut, totalSecs * 0.5));
+	const xIn = (fi / totalSecs) * W;
+	const xOut = W - (fo / totalSecs) * W;
+	const yTop = 2;
+	const yBottom = H - 2;
+	return `M 0 ${yBottom} L ${xIn.toFixed(2)} ${yTop} L ${xOut.toFixed(2)} ${yTop} L ${W} ${yBottom}`;
+}

--- a/apps/desktop/src/components/editor/properity-panel/background-picker.logic.test.ts
+++ b/apps/desktop/src/components/editor/properity-panel/background-picker.logic.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+	imagePreviewSrc,
+	isValidImageValue,
+	lerpHex,
+	sampleStopColor,
+} from "./background-picker.logic";
+
+describe("lerpHex", () => {
+	it("returns the endpoints at f=0 and f=1", () => {
+		expect(lerpHex("#000000", "#ffffff", 0)).toBe("#000000");
+		expect(lerpHex("#000000", "#ffffff", 1)).toBe("#ffffff");
+	});
+	it("interpolates the midpoint per channel", () => {
+		expect(lerpHex("#000000", "#ffffff", 0.5)).toBe("#808080");
+		expect(lerpHex("#ff0000", "#0000ff", 0.5)).toBe("#800080");
+	});
+});
+
+describe("sampleStopColor", () => {
+	const stops = [
+		{ color: "#000000", pos: 0 },
+		{ color: "#ffffff", pos: 100 },
+	];
+	it("clamps to the nearest endpoint outside the range", () => {
+		expect(sampleStopColor(stops, -10)).toBe("#000000");
+		expect(sampleStopColor(stops, 200)).toBe("#ffffff");
+	});
+	it("interpolates between surrounding stops", () => {
+		expect(sampleStopColor(stops, 50)).toBe("#808080");
+	});
+	it("works regardless of stop order", () => {
+		const unsorted = [
+			{ color: "#ffffff", pos: 100 },
+			{ color: "#000000", pos: 0 },
+		];
+		expect(sampleStopColor(unsorted, 50)).toBe("#808080");
+	});
+});
+
+describe("isValidImageValue", () => {
+	it("rejects gradient/colour/asset leftovers and empties", () => {
+		expect(isValidImageValue("")).toBe(false);
+		expect(isValidImageValue("linear-gradient(...)")).toBe(false);
+		expect(isValidImageValue("#ff0000")).toBe(false);
+		expect(isValidImageValue("asset:abc")).toBe(false);
+	});
+	it("accepts direct sources and image extensions", () => {
+		expect(isValidImageValue("https://x/y.png")).toBe(true);
+		expect(isValidImageValue("data:image/png;base64,AAA")).toBe(true);
+		expect(isValidImageValue("/wallpapers/foo")).toBe(true);
+		expect(isValidImageValue("C:/pics/shot.webp")).toBe(true);
+	});
+	it("rejects a bare path with no image extension", () => {
+		expect(isValidImageValue("C:/pics/shot")).toBe(false);
+	});
+});
+
+describe("imagePreviewSrc", () => {
+	const resolve = (v: string) => `asset://localhost/${v}`;
+	it("returns empty for non-image leftovers", () => {
+		expect(imagePreviewSrc("#fff", resolve)).toBe("");
+		expect(imagePreviewSrc("", resolve)).toBe("");
+	});
+	it("returns direct sources unchanged", () => {
+		expect(imagePreviewSrc("https://x/y.png", resolve)).toBe("https://x/y.png");
+	});
+	it("resolves a file path (even without an image extension)", () => {
+		expect(imagePreviewSrc("C:/pics/shot", resolve)).toBe(
+			"asset://localhost/C:/pics/shot",
+		);
+	});
+});

--- a/apps/desktop/src/components/editor/properity-panel/background-picker.logic.ts
+++ b/apps/desktop/src/components/editor/properity-panel/background-picker.logic.ts
@@ -1,7 +1,6 @@
 /**
- * Pure helpers for BackgroundPicker — colour interpolation, gradient-stop
- * sampling, and background `image` value classification. Extracted from the
- * component so the maths is testable and the `.svelte` file is just wiring.
+ * BackgroundPicker helpers: colour interpolation, gradient-stop sampling, and
+ * background `image` value classification.
  */
 
 /** A gradient colour stop: `color` is a hex string, `pos` is 0..100. */
@@ -30,9 +29,9 @@ export function lerpHex(c0: string, c1: string, f: number): string {
 }
 
 /**
- * Colour of a gradient at position `pos` (0..100), interpolating between the
- * surrounding stops in sRGB — mirrors the renderer so an inserted stop is
- * visually neutral. Stops need not be pre-sorted.
+ * Colour of a gradient at `pos` (0..100), interpolating surrounding stops in
+ * sRGB — mirrors the renderer so an inserted stop is visually neutral. Stops
+ * need not be pre-sorted.
  */
 export function sampleStopColor(stops: GradientStop[], pos: number): string {
 	const sorted = [...stops].sort((a, b) => a.pos - b.pos);
@@ -50,8 +49,7 @@ export function sampleStopColor(stops: GradientStop[], pos: number): string {
 	return last.color;
 }
 
-/** Values that are NOT images even if they linger in `backgroundValue` after a
- * tab switch (gradient strings, colour hex, internal asset ids). */
+/** Non-image values that can linger in `backgroundValue` after a tab switch. */
 function isNonImageValue(value: string): boolean {
 	return (
 		value.includes("gradient(") ||
@@ -74,7 +72,7 @@ function isDirectSrc(value: string): boolean {
 /**
  * Whether `value` is usable as a background image. Rejects gradient/colour/asset
  * leftovers (which would otherwise hit Tauri's asset protocol and log "file does
- * not exist"), accepts direct sources and recognised image extensions.
+ * not exist").
  */
 export function isValidImageValue(value: string): boolean {
 	if (!value) return false;
@@ -89,10 +87,9 @@ export function isValidImageValue(value: string): boolean {
 }
 
 /**
- * Resolve a background `image` value to a `src`. Returns `""` for non-image
- * leftovers, the value as-is for direct sources, and otherwise the value run
- * through `resolve` (inject `convertFileSrc` at the call site so this stays
- * Tauri-free and testable).
+ * Resolve a background `image` value to a `src`: `""` for non-image leftovers,
+ * the value as-is for direct sources, else run through `resolve` (inject
+ * `convertFileSrc` at the call site to keep this Tauri-free).
  */
 export function imagePreviewSrc(
 	value: string,

--- a/apps/desktop/src/components/editor/properity-panel/background-picker.logic.ts
+++ b/apps/desktop/src/components/editor/properity-panel/background-picker.logic.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure helpers for BackgroundPicker — colour interpolation, gradient-stop
+ * sampling, and background `image` value classification. Extracted from the
+ * component so the maths is testable and the `.svelte` file is just wiring.
+ */
+
+/** A gradient colour stop: `color` is a hex string, `pos` is 0..100. */
+export interface GradientStop {
+	color: string;
+	pos: number;
+}
+
+/** Linearly interpolate two `#rrggbb` hex colours in sRGB. `f` is 0..1. */
+export function lerpHex(c0: string, c1: string, f: number): string {
+	const parse = (h: string): [number, number, number] => {
+		const s = h.replace("#", "");
+		return [
+			parseInt(s.slice(0, 2), 16),
+			parseInt(s.slice(2, 4), 16),
+			parseInt(s.slice(4, 6), 16),
+		];
+	};
+	const [r0, g0, b0] = parse(c0);
+	const [r1, g1, b1] = parse(c1);
+	const mix = (a: number, b: number) =>
+		Math.round(a + (b - a) * f)
+			.toString(16)
+			.padStart(2, "0");
+	return `#${mix(r0, r1)}${mix(g0, g1)}${mix(b0, b1)}`;
+}
+
+/**
+ * Colour of a gradient at position `pos` (0..100), interpolating between the
+ * surrounding stops in sRGB — mirrors the renderer so an inserted stop is
+ * visually neutral. Stops need not be pre-sorted.
+ */
+export function sampleStopColor(stops: GradientStop[], pos: number): string {
+	const sorted = [...stops].sort((a, b) => a.pos - b.pos);
+	if (pos <= sorted[0].pos) return sorted[0].color;
+	const last = sorted[sorted.length - 1];
+	if (pos >= last.pos) return last.color;
+	for (let i = 0; i < sorted.length - 1; i++) {
+		const a = sorted[i];
+		const b = sorted[i + 1];
+		if (pos >= a.pos && pos <= b.pos) {
+			const f = (pos - a.pos) / Math.max(b.pos - a.pos, 1e-6);
+			return lerpHex(a.color, b.color, f);
+		}
+	}
+	return last.color;
+}
+
+/** Values that are NOT images even if they linger in `backgroundValue` after a
+ * tab switch (gradient strings, colour hex, internal asset ids). */
+function isNonImageValue(value: string): boolean {
+	return (
+		value.includes("gradient(") ||
+		value.startsWith("#") ||
+		value.startsWith("asset:")
+	);
+}
+
+/** Sources that can be shown directly without going through `convertFileSrc`. */
+function isDirectSrc(value: string): boolean {
+	return (
+		value.startsWith("data:") ||
+		value.startsWith("http://") ||
+		value.startsWith("https://") ||
+		value.startsWith("asset://") ||
+		value.startsWith("/wallpapers/")
+	);
+}
+
+/**
+ * Whether `value` is usable as a background image. Rejects gradient/colour/asset
+ * leftovers (which would otherwise hit Tauri's asset protocol and log "file does
+ * not exist"), accepts direct sources and recognised image extensions.
+ */
+export function isValidImageValue(value: string): boolean {
+	if (!value) return false;
+	if (isNonImageValue(value)) return false;
+	return (
+		isDirectSrc(value) ||
+		value.endsWith(".png") ||
+		value.endsWith(".jpg") ||
+		value.endsWith(".jpeg") ||
+		value.endsWith(".webp")
+	);
+}
+
+/**
+ * Resolve a background `image` value to a `src`. Returns `""` for non-image
+ * leftovers, the value as-is for direct sources, and otherwise the value run
+ * through `resolve` (inject `convertFileSrc` at the call site so this stays
+ * Tauri-free and testable).
+ */
+export function imagePreviewSrc(
+	value: string,
+	resolve: (v: string) => string,
+): string {
+	if (!value) return "";
+	if (isNonImageValue(value)) return "";
+	if (isDirectSrc(value)) return value;
+	return resolve(value);
+}

--- a/apps/desktop/src/components/editor/properity-panel/focus-panel.logic.test.ts
+++ b/apps/desktop/src/components/editor/properity-panel/focus-panel.logic.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { ZoomRegion } from "$lib/stores/editor-store.svelte";
+import { regionMaxRamp, scaleAt, sparklinePath } from "./focus-panel.logic";
+
+const linear = { x1: 0, y1: 0, x2: 1, y2: 1 };
+function region(over: Partial<ZoomRegion> = {}): ZoomRegion {
+	return {
+		start: 0,
+		end: 10,
+		scale: 2,
+		rampIn: 2,
+		rampOut: 2,
+		easeIn: linear,
+		easeOut: linear,
+		...over,
+	} as unknown as ZoomRegion;
+}
+
+describe("regionMaxRamp", () => {
+	it("is half the region duration", () => {
+		expect(regionMaxRamp(region({ start: 0, end: 10 }))).toBe(5);
+		expect(regionMaxRamp(region({ start: 4, end: 4 }))).toBe(0);
+	});
+});
+
+describe("scaleAt", () => {
+	const r = region();
+	it("is 1 outside the region", () => {
+		expect(scaleAt(r, -1)).toBe(1);
+		expect(scaleAt(r, 0)).toBe(1);
+		expect(scaleAt(r, 10)).toBe(1);
+		expect(scaleAt(r, 99)).toBe(1);
+	});
+	it("holds at full scale between the ramps", () => {
+		// rampIn 2 → holdStart 2; rampOut 2 → holdEnd 8
+		expect(scaleAt(r, 5)).toBe(2);
+		expect(scaleAt(r, 2)).toBe(2);
+	});
+	it("rises from 1 toward scale during ramp-in (linear easing)", () => {
+		// halfway through a linear ramp-in → scale 1.5
+		expect(scaleAt(r, 1)).toBeCloseTo(1.5, 5);
+	});
+});
+
+describe("sparklinePath", () => {
+	it("emits a moveto then 40 linetos across the width", () => {
+		const path = sparklinePath(region(), 100, 20);
+		expect(path.startsWith("M ")).toBe(true);
+		expect((path.match(/L /g) ?? []).length).toBe(40);
+		expect(path).toContain("100.00"); // last sample reaches full width
+	});
+});

--- a/apps/desktop/src/components/editor/properity-panel/focus-panel.logic.ts
+++ b/apps/desktop/src/components/editor/properity-panel/focus-panel.logic.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure maths for FocusPanel: the zoom scale at a given time (ramp-in → hold →
+ * ramp-out), the sparkline path that visualises it, and the max ramp length for
+ * a region. Extracted from the component so the curve maths is testable.
+ */
+
+import type { Easing } from "$lib/easing/cubic-bezier";
+import type { ZoomRegion } from "$lib/stores/editor-store.svelte";
+
+/** Longest a single ramp can be: half the region (so in+out can't overlap). */
+export function regionMaxRamp(r: ZoomRegion): number {
+	return Math.max(0, (r.end - r.start) * 0.5);
+}
+
+/**
+ * Zoom scale at absolute time `t` for region `r`: 1 outside the region, ramping
+ * up over `rampIn` (eased by `easeIn`), holding at `r.scale`, then ramping back
+ * down over `rampOut` (eased by `easeOut`).
+ */
+export function scaleAt(r: ZoomRegion, t: number): number {
+	if (t <= r.start || t >= r.end) return 1;
+	const duration = Math.max(0, r.end - r.start);
+	const half = duration * 0.5;
+	const rampIn = Math.min(Math.max(0, r.rampIn), half);
+	const rampOut = Math.min(Math.max(0, r.rampOut), half);
+	const holdStart = r.start + rampIn;
+	const holdEnd = r.end - rampOut;
+	let phase: number;
+	let curve: Easing;
+	if (t < holdStart) {
+		phase = rampIn > 0 ? (t - r.start) / rampIn : 1;
+		curve = r.easeIn;
+	} else if (t > holdEnd) {
+		phase = rampOut > 0 ? (r.end - t) / rampOut : 1;
+		curve = r.easeOut;
+	} else {
+		return r.scale;
+	}
+	phase = Math.max(0, Math.min(1, phase));
+	// Low-budget x→y approximation (polynomial-in-t with t ≈ x). Indistinguishable
+	// at sparkline resolution; avoids pulling in the full Newton-Raphson solver.
+	const a = 1 - 3 * curve.y2 + 3 * curve.y1;
+	const b = 3 * curve.y2 - 6 * curve.y1;
+	const c = 3 * curve.y1;
+	const s = ((a * phase + b) * phase + c) * phase;
+	return 1 + (r.scale - 1) * s;
+}
+
+/**
+ * SVG path for a region's zoom envelope across a `w × h` box — a normalised
+ * 1.0 → scale → 1.0 curve sampled at 41 points.
+ */
+export function sparklinePath(r: ZoomRegion, w: number, h: number): string {
+	const duration = Math.max(0.001, r.end - r.start);
+	const maxScale = Math.max(r.scale, 1.0);
+	const normScale = (s: number) =>
+		maxScale === 1 ? 1 : (s - 1) / (maxScale - 1);
+	const samples: Array<[number, number]> = [];
+	const N = 40;
+	for (let i = 0; i <= N; i++) {
+		const t = (i / N) * duration;
+		const absT = r.start + t;
+		const s = scaleAt(r, absT);
+		const x = (t / duration) * w;
+		const y = h - normScale(s) * h * 0.9 - 1;
+		samples.push([x, y]);
+	}
+	return samples
+		.map(([x, y], i) => `${i === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)}`)
+		.join(" ");
+}

--- a/apps/desktop/src/components/editor/properity-panel/focus-panel.logic.ts
+++ b/apps/desktop/src/components/editor/properity-panel/focus-panel.logic.ts
@@ -1,7 +1,6 @@
 /**
- * Pure maths for FocusPanel: the zoom scale at a given time (ramp-in → hold →
- * ramp-out), the sparkline path that visualises it, and the max ramp length for
- * a region. Extracted from the component so the curve maths is testable.
+ * FocusPanel zoom maths: scale at a given time (ramp-in → hold → ramp-out), the
+ * sparkline path that visualises it, and a region's max ramp length.
  */
 
 import type { Easing } from "$lib/easing/cubic-bezier";
@@ -13,9 +12,8 @@ export function regionMaxRamp(r: ZoomRegion): number {
 }
 
 /**
- * Zoom scale at absolute time `t` for region `r`: 1 outside the region, ramping
- * up over `rampIn` (eased by `easeIn`), holding at `r.scale`, then ramping back
- * down over `rampOut` (eased by `easeOut`).
+ * Zoom scale at absolute time `t`: 1 outside the region, eased ramp up to
+ * `r.scale` over `rampIn`, hold, then eased ramp back down over `rampOut`.
  */
 export function scaleAt(r: ZoomRegion, t: number): number {
 	if (t <= r.start || t >= r.end) return 1;

--- a/apps/desktop/src/components/editor/properity-panel/info-panel.logic.test.ts
+++ b/apps/desktop/src/components/editor/properity-panel/info-panel.logic.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { Annotation } from "$lib/stores/editor-store.svelte";
+import { basename, countByKind, formatRelative } from "./info-panel.logic";
+
+describe("formatRelative", () => {
+	const now = 1_000_000_000_000;
+	it("returns Never for null", () => {
+		expect(formatRelative(null, now)).toBe("Never");
+	});
+	it("buckets past times with ' ago'", () => {
+		expect(formatRelative(now - 2000, now)).toBe("just now");
+		expect(formatRelative(now - 10_000, now)).toBe("10s ago");
+		expect(formatRelative(now - 5 * 60_000, now)).toBe("5 min ago");
+		expect(formatRelative(now - 3 * 3_600_000, now)).toBe("3 hr ago");
+		expect(formatRelative(now - 2 * 86_400_000, now)).toBe("2 days ago");
+	});
+	it("prefixes future times with 'in '", () => {
+		expect(formatRelative(now + 5 * 60_000, now)).toBe("in 5 min");
+	});
+	it("singularises one day", () => {
+		expect(formatRelative(now - 86_400_000, now)).toBe("1 day ago");
+	});
+});
+
+describe("basename", () => {
+	it("takes the last segment of either separator", () => {
+		expect(basename("C:\\a\\b\\clip.mp4")).toBe("clip.mp4");
+		expect(basename("/home/u/clip.mp4")).toBe("clip.mp4");
+		expect(basename("")).toBe("—");
+	});
+});
+
+describe("countByKind", () => {
+	it("seeds all kinds to 0 and counts present ones", () => {
+		const anns = [
+			{ kind: { kind: "rect" } },
+			{ kind: { kind: "rect" } },
+			{ kind: { kind: "arrow" } },
+		] as unknown as Annotation[];
+		expect(countByKind(anns)).toEqual({
+			rect: 2,
+			ellipse: 0,
+			arrow: 1,
+			text: 0,
+			image: 0,
+		});
+	});
+});

--- a/apps/desktop/src/components/editor/properity-panel/info-panel.logic.ts
+++ b/apps/desktop/src/components/editor/properity-panel/info-panel.logic.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure helpers for InfoPanel: relative-time labels, path basename, and
+ * annotation-kind counts. Extracted so they're testable; the component keeps the
+ * store reads (resolution/fps/duration) and the icon table.
+ */
+
+import type { Annotation } from "$lib/stores/editor-store.svelte";
+
+/**
+ * Chat-style relative time vs a `current` epoch (ms): "just now", "5s",
+ * "3 min", "2 hr", "4 days", prefixed "in "/suffixed " ago" by direction.
+ * Floors at each cutoff so the readout doesn't bounce by a unit each tick.
+ */
+export function formatRelative(ts: number | null, current: number): string {
+	if (!ts) return "Never";
+	const diffMs = current - ts;
+	const future = diffMs < 0;
+	const seconds = Math.floor(Math.abs(diffMs) / 1000);
+	const minutes = Math.floor(seconds / 60);
+	const hours = Math.floor(minutes / 60);
+	const days = Math.floor(hours / 24);
+	let label: string;
+	if (seconds < 5) label = "just now";
+	else if (seconds < 60) label = `${seconds}s`;
+	else if (minutes < 60) label = `${minutes} min`;
+	else if (hours < 24) label = `${hours} hr`;
+	else label = `${days} day${days === 1 ? "" : "s"}`;
+	if (label === "just now") return label;
+	return future ? `in ${label}` : `${label} ago`;
+}
+
+/** Last path segment (handles both separators); "—" when empty. */
+export function basename(path: string): string {
+	if (!path) return "—";
+	const sep = path.includes("\\") ? "\\" : "/";
+	const last = path.split(sep).filter(Boolean).pop() ?? path;
+	return last;
+}
+
+/**
+ * Count annotations by kind, always seeding every kind to 0 so the readout row
+ * doesn't shift as shapes are added/removed.
+ */
+export function countByKind(annotations: Annotation[]): Record<string, number> {
+	const out: Record<string, number> = {
+		rect: 0,
+		ellipse: 0,
+		arrow: 0,
+		text: 0,
+		image: 0,
+	};
+	for (const a of annotations) out[a.kind.kind] = (out[a.kind.kind] ?? 0) + 1;
+	return out;
+}

--- a/apps/desktop/src/components/editor/properity-panel/info-panel.logic.ts
+++ b/apps/desktop/src/components/editor/properity-panel/info-panel.logic.ts
@@ -1,15 +1,11 @@
-/**
- * Pure helpers for InfoPanel: relative-time labels, path basename, and
- * annotation-kind counts. Extracted so they're testable; the component keeps the
- * store reads (resolution/fps/duration) and the icon table.
- */
+/** InfoPanel helpers: relative-time labels, path basename, and annotation-kind counts. */
 
 import type { Annotation } from "$lib/stores/editor-store.svelte";
 
 /**
- * Chat-style relative time vs a `current` epoch (ms): "just now", "5s",
- * "3 min", "2 hr", "4 days", prefixed "in "/suffixed " ago" by direction.
- * Floors at each cutoff so the readout doesn't bounce by a unit each tick.
+ * Chat-style relative time vs a `current` epoch (ms): "just now", "5s", "3 min",
+ * "2 hr", "4 days", prefixed "in "/suffixed " ago". Floors at each cutoff so the
+ * readout doesn't bounce by a unit each tick.
  */
 export function formatRelative(ts: number | null, current: number): string {
 	if (!ts) return "Never";
@@ -37,10 +33,7 @@ export function basename(path: string): string {
 	return last;
 }
 
-/**
- * Count annotations by kind, always seeding every kind to 0 so the readout row
- * doesn't shift as shapes are added/removed.
- */
+/** Count annotations by kind; seeds every kind to 0 so the readout row doesn't shift. */
 export function countByKind(annotations: Annotation[]): Record<string, number> {
 	const out: Record<string, number> = {
 		rect: 0,

--- a/apps/desktop/src/components/editor/silence-review.logic.test.ts
+++ b/apps/desktop/src/components/editor/silence-review.logic.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+	confidenceBarClass,
+	confidenceLabel,
+	confidenceTextClass,
+	cutBounds,
+	parseSensitivity,
+} from "./silence-review.logic";
+
+describe("parseSensitivity", () => {
+	it("accepts the non-default presets and falls back to balanced", () => {
+		expect(parseSensitivity("relaxed")).toBe("relaxed");
+		expect(parseSensitivity("aggressive")).toBe("aggressive");
+		expect(parseSensitivity("balanced")).toBe("balanced");
+		expect(parseSensitivity("")).toBe("balanced");
+		expect(parseSensitivity("nonsense")).toBe("balanced");
+	});
+});
+
+describe("confidence classification", () => {
+	it("buckets by the 0.66 / 0.4 thresholds", () => {
+		expect(confidenceLabel(0.7)).toBe("Strong");
+		expect(confidenceLabel(0.5)).toBe("Likely");
+		expect(confidenceLabel(0.2)).toBe("Uncertain");
+		expect(confidenceTextClass(0.7)).toBe("text-success");
+		expect(confidenceTextClass(0.5)).toBe("text-warning");
+		expect(confidenceTextClass(0.2)).toBe("text-muted-foreground");
+		expect(confidenceBarClass(0.7)).toBe("bg-success");
+		expect(confidenceBarClass(0.39)).toBe("bg-muted-foreground/60");
+	});
+});
+
+describe("cutBounds", () => {
+	it("insets by the padding for a long segment", () => {
+		// pad = min(0.12, 10/3) = 0.12
+		expect(cutBounds(0, 10)).toEqual({ start: 0.12, end: 9.88 });
+	});
+	it("caps the pad at a third of the segment", () => {
+		// segment 0.9s → pad = min(0.12, 0.3) = 0.12 → 0.12..0.78 (len 0.66 ≥ 0.2)
+		expect(cutBounds(0, 0.9)).toEqual({ start: 0.12, end: 0.78 });
+	});
+	it("returns null when the padded region is too short", () => {
+		// 0.4s segment → pad min(0.12, 0.133)=0.12 → 0.12..0.28 len 0.16 < 0.2
+		expect(cutBounds(0, 0.4)).toBeNull();
+	});
+});

--- a/apps/desktop/src/components/editor/silence-review.logic.ts
+++ b/apps/desktop/src/components/editor/silence-review.logic.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure decision logic + presets for the silence-review popover: detection
+ * sensitivity presets, confidence classification, and the keep-margin cut-bounds
+ * maths. Extracted so they're testable; the store-coupled state machine
+ * (status/pending + detect/cut/dismiss against the editor store) stays in the
+ * component.
+ */
+
+import type { SilenceDetectOptions } from "$lib/ipc";
+
+export type Sensitivity = "relaxed" | "balanced" | "aggressive";
+
+/** A small margin kept at each end of a cut so speech onsets/tails beside the
+ *  silence are never clipped. */
+export const CUT_PADDING = 0.12;
+/** Bulk "Cut all" only takes confident suggestions; uncertain ones are left
+ *  for the user to judge individually. */
+export const BULK_MIN_CONFIDENCE = 0.5;
+
+/** "Balanced" uses the Rust-side defaults; the others trade recall vs false
+ *  positives. */
+export const SENSITIVITY_PRESETS: Record<Sensitivity, SilenceDetectOptions> = {
+	relaxed: {
+		flatnessDb: 3,
+		minAudioSilence: 1,
+		minSegment: 1.5,
+	},
+	balanced: {},
+	aggressive: {
+		flatnessDb: 8,
+		minAudioSilence: 0.4,
+		minSegment: 0.6,
+	},
+};
+
+export const SENSITIVITY_OPTIONS: Array<{ id: Sensitivity; label: string }> = [
+	{ id: "relaxed", label: "Relaxed" },
+	{ id: "balanced", label: "Balanced" },
+	{ id: "aggressive", label: "Aggressive" },
+];
+
+/** Coerce a persisted string into a valid Sensitivity (default "balanced"). */
+export function parseSensitivity(v: string): Sensitivity {
+	return v === "relaxed" || v === "aggressive" ? v : "balanced";
+}
+
+export function confidenceLabel(c: number): string {
+	if (c >= 0.66) return "Strong";
+	if (c >= 0.4) return "Likely";
+	return "Uncertain";
+}
+
+export function confidenceTextClass(c: number): string {
+	if (c >= 0.66) return "text-success";
+	if (c >= 0.4) return "text-warning";
+	return "text-muted-foreground";
+}
+
+export function confidenceBarClass(c: number): string {
+	if (c >= 0.66) return "bg-success";
+	if (c >= 0.4) return "bg-warning";
+	return "bg-muted-foreground/60";
+}
+
+/**
+ * Apply the keep-margin to a silence segment and return the cut bounds, or null
+ * if the padded region would be too short (< 0.2s) to be worth cutting. The pad
+ * is capped at a third of the segment so short silences still cut.
+ */
+export function cutBounds(
+	start: number,
+	end: number,
+	padding = CUT_PADDING,
+): { start: number; end: number } | null {
+	const pad = Math.min(padding, (end - start) / 3);
+	const s = start + pad;
+	const e = end - pad;
+	if (e - s < 0.2) return null;
+	return { start: s, end: e };
+}

--- a/apps/desktop/src/components/layout/CommandPaletteHost.svelte
+++ b/apps/desktop/src/components/layout/CommandPaletteHost.svelte
@@ -17,11 +17,8 @@
   let listRef = $state<HTMLDivElement | null>(null);
   let contentHeight = $state(0);
 
-  // Global registration. Safe to call on every mount because
-  // `registerMany` deduplicates by id. The Mod+K open shortcut itself lives in
-  // the central shortcut registry (`general.palette`), dispatched once from the
-  // root layout — so there is no per-component `window` listener here to leak
-  // under HMR (the "bare Ctrl toggles the palette" ghost is gone for good).
+  // Safe on every mount: registerMany dedupes by id. The Mod+K open shortcut
+  // lives in the central registry (general.palette), not a window listener here.
   onMount(() => {
     commandPalette.registerMany(buildGlobalCommands());
   });
@@ -167,7 +164,6 @@
       role="document"
       transition:scale={{ duration: 220, start: 0.96, easing: cubicOut }}
     >
-      <!-- Header -->
       <div class="flex items-center gap-2 border-b border-border/60 px-3">
         <Search class="size-4 shrink-0 text-muted-foreground/70" />
         <input
@@ -180,7 +176,6 @@
         <Kbd class="hidden sm:inline-flex">Esc</Kbd>
       </div>
 
-      <!-- Animated content area -->
       <div
         class="overflow-hidden transition-[height] duration-300 ease-out"
         style="height: {contentHeight}px"
@@ -268,7 +263,6 @@
         </div>
       </div>
 
-      <!-- Footer -->
       <div
         class="flex items-center justify-between gap-3 border-t border-border/60 bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground"
       >

--- a/apps/desktop/src/components/layout/SearchCommandMenu.svelte
+++ b/apps/desktop/src/components/layout/SearchCommandMenu.svelte
@@ -5,10 +5,8 @@
   import { Kbd } from "@recast/ui/kbd";
   import { cn } from "@recast/ui/utils";
 
-  // Trigger-only. The dialog and the global ⌘K binding live in
-  // CommandPaletteHost.svelte (mounted once at the root layout) so they
-  // remain available on routes that don't include the sidebar — e.g. the
-  // editor route.
+  // Trigger-only; the dialog and ⌘K binding live in CommandPaletteHost
+  // (mounted at the root layout, so it works on sidebar-less routes).
   let { iconOnly } = $props<{ iconOnly?: boolean }>();
 </script>
 

--- a/apps/desktop/src/components/layout/custom-titlebar.svelte
+++ b/apps/desktop/src/components/layout/custom-titlebar.svelte
@@ -15,14 +15,9 @@
 
   let { children, class: className, wrapperClass }: Props = $props();
 
-  // Detected synchronously from the webview UA (same test the shortcuts
-  // registry and the `(app)` shell use) so there's no chrome flash on first
-  // paint; false under SSR.
+  // Synchronous so there's no chrome flash on first paint; false under SSR.
   const isMac = ["darwin", "ios"].includes(platform());
-  // Mirror the `(app)` shell's chrome modes so the editor titlebar follows the
-  // same preference. `os-native` follows the OS — macOS traffic lights lead the
-  // bar on the left, min/max/close sit on the right for Windows/Linux. `recast`
-  // keeps the unified min/max/close cluster on the right, identical on every OS.
+  // os-native on macOS → traffic lights lead left; otherwise min/max/close right.
   const macLights = $derived(layoutMode.current === "os-native" && isMac);
 </script>
 
@@ -38,7 +33,7 @@
     <WindowControls kind="mac" class="px-1.5" />
   {/if}
 
-  <!-- Drag region: only the content area, not the window controls -->
+  <!-- Drag region: content area only, not the window controls. -->
   <div
     class={cn("flex-1 flex items-center min-w-0 h-full font-sans", className)}
     data-tauri-drag-region
@@ -48,8 +43,7 @@
     {/if}
   </div>
 
-  <!-- Keyboard-shortcuts reference. Outside the drag region so the click
-       registers; sits just left of the window controls on every main window. -->
+  <!-- Outside the drag region so the click registers. -->
   <button
     type="button"
     onclick={() => shortcutsDialog.show()}
@@ -61,8 +55,7 @@
     <Keyboard size={15} />
   </button>
 
-  <!-- Windows/Linux (and recast mode on every OS): min/max/close on the right.
-       Outside the drag region so clicks aren't intercepted. -->
+  <!-- Outside the drag region so clicks aren't intercepted. -->
   {#if !macLights}
     <WindowControls kind="win" class="shrink-0" />
   {/if}

--- a/apps/desktop/src/components/layout/window-controls.svelte
+++ b/apps/desktop/src/components/layout/window-controls.svelte
@@ -10,10 +10,8 @@
   import { cn } from "@recast/ui/utils";
   import { onMount } from "svelte";
 
-  // `mac` → faux macOS traffic lights (rendered top-left, in the sidebar).
-  // `win` → minimize / maximize / close stack (rendered top-right, in the
-  // content header). The OS decision is made by the caller via `platform()`
-  // so this component just draws + wires the chosen variant.
+  // `mac` → faux traffic lights (top-left); `win` → min/max/close (top-right).
+  // Caller picks the variant via platform(); this just draws and wires it.
   let { kind, class: className }: { kind: "mac" | "win"; class?: string } =
     $props();
 
@@ -59,13 +57,8 @@
 
 {#if isTauri}
   {#if kind === "mac"}
-    <!--
-      Faux macOS traffic lights. Real system buttons would need the native
-      title bar (a Rust window-config change we deliberately skipped), so these
-      mirror the system look: standard close/minimise/zoom colours with glyphs
-      that fade in on hover of the cluster. Window-chrome mimicry is the one
-      place we use literal OS colours instead of theme tokens — by design.
-    -->
+    <!-- Faux traffic lights (no native titlebar). Literal OS colours instead
+         of theme tokens here are by design — window-chrome mimicry. -->
     <div
       class={cn("group/lights flex items-center gap-2", className)}
       onmousedown={(e) => e.stopPropagation()}

--- a/apps/desktop/src/components/logo.svelte
+++ b/apps/desktop/src/components/logo.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
-  // Logo mark. Colours follow the *resolved* theme via mode-watcher's `mode`
-  // rune (light/dark, "system" already resolved to the active OS theme), so it
-  // updates reactively when the user toggles the theme — the previous version
-  // read `mode-watcher-mode` from storage once on mount and never resolved
-  // "system", so it stuck on one variant in both modes.
+  // Use the *resolved* mode rune (not stored "system") so colours track the
+  // active OS theme and update reactively on toggle.
   import { mode } from "@recast/ui/theme";
   import type { SVGAttributes } from "svelte/elements";
 

--- a/apps/desktop/src/components/recast/PlayerDialog.svelte
+++ b/apps/desktop/src/components/recast/PlayerDialog.svelte
@@ -71,19 +71,12 @@
       </Button>
     </header>
 
-    <!-- autohide={-1} pins the control bar. This is a framed inspect-the-
-         recording dialog, and WebView2 actually honours `autoplay` (a browser
-         blocks the un-muted play and leaves the video paused with controls
-         showing). media-chrome's controller starts in `user-inactive`, so once
-         the clip is playing and the pointer hasn't moved yet the whole bar is
-         hidden — reads as "the player has no controls". -->
-    <!-- preload="auto" (not the player's "metadata" default): exports are
-         written moov-at-end, and over the Tauri asset protocol a metadata-only
-         preload has to range-fetch the tail to find the moov atom before it can
-         decode — which stalls the <video> in NETWORK_LOADING (black frame +
-         "media loading" forever) in release builds. "auto" streams the local
-         file sequentially from byte 0, exactly like the editor preview, which
-         loads the same moov-at-end recordings without issue. -->
+    <!-- autohide={-1}: WebView2 honours autoplay, and media-chrome hides the
+         bar while user-inactive — so an autoplaying clip would look control-less. -->
+    <!-- preload="auto" (not "metadata"): exports are moov-at-end, and a
+         metadata-only preload range-fetches the tail over the asset protocol and
+         stalls in NETWORK_LOADING (black frame) in release. "auto" streams from
+         byte 0. -->
     <RecastPlayer {src} title={entry.filename} preload="auto" autoplay autohide={-1} />
 
     <footer

--- a/apps/desktop/src/components/recast/RecastCard.svelte
+++ b/apps/desktop/src/components/recast/RecastCard.svelte
@@ -74,9 +74,7 @@
 			></div>
 		{:else if item.icon}
 			{@const Icon = item.icon}
-			<!-- Icon-as-hero placeholder. Borrows the editor-tour rail's techy
-			     framing (dot grid + primary glow + glass tile) so a thumbnail-
-			     less recording reads as "ready for a frame" instead of empty. -->
+			<!-- Placeholder for thumbnail-less recordings: dot grid + glow + glass tile. -->
 			<div
 				aria-hidden="true"
 				class="absolute inset-0 opacity-60"
@@ -100,9 +98,7 @@
 			</div>
 		{/if}
 
-		<!-- CRT-style corner brackets. Always-on accent that ties recording
-		     tiles to the marketing rail's visual language. Sized smaller than
-		     the web card because the desktop tile is denser. -->
+		<!-- CRT-style corner brackets (smaller than the web card — denser tile). -->
 		<span aria-hidden="true" class="pointer-events-none absolute left-1.5 top-1.5 z-10 size-2 border-l border-t border-foreground/30"></span>
 		<span aria-hidden="true" class="pointer-events-none absolute right-1.5 top-1.5 z-10 size-2 border-r border-t border-foreground/30"></span>
 		<span aria-hidden="true" class="pointer-events-none absolute bottom-1.5 left-1.5 z-10 size-2 border-b border-l border-foreground/30"></span>

--- a/apps/desktop/src/components/settings/CloudEndpoint.svelte
+++ b/apps/desktop/src/components/settings/CloudEndpoint.svelte
@@ -87,8 +87,8 @@
 				Server endpoint
 			</span>
 			<span class="text-[11px] text-muted-foreground">
-				Self-hosting Recast Cloud? Point the app at your server. Leave blank
-				to use the default. Changing this signs you out of the current server.
+				Self-hosting Recast Cloud? Point the app at your server. Changing
+				this signs you out of the current server.
 			</span>
 		</div>
 

--- a/apps/desktop/src/components/settings/CloudEndpoint.svelte
+++ b/apps/desktop/src/components/settings/CloudEndpoint.svelte
@@ -8,17 +8,11 @@
 	import { getCloudApiConfig, setCloudApiUrl, type CloudApiConfig } from "$lib/ipc";
 
 	/**
-	 * Self-hosting server endpoint. Most users never touch this — Recast Cloud
-	 * points at the bundled default. Self-hosters run their own SvelteKit
-	 * server and need the desktop to target it; this is the only place to set
-	 * that without recompiling.
-	 *
-	 * The Rust resolver (`auth::cloud_api_url`) validates the saved value and
-	 * falls back to the default if it's empty or malformed, so a bad value can
-	 * never brick cloud sign-in. We validate on save too (via `set_cloud_api_url`)
-	 * to give an explicit error instead of a silent revert. Changing the
-	 * endpoint clears the local session token server-side, so we emit
-	 * `cloud:endpoint-changed` to nudge the sign-in card back to signed-out.
+	 * Self-hosting server endpoint override. The Rust resolver
+	 * (`auth::cloud_api_url`) falls back to the default on an empty/malformed
+	 * value, so a bad entry can't brick sign-in; we validate on save too for an
+	 * explicit error. Changing the endpoint invalidates the session, so we emit
+	 * `cloud:endpoint-changed` to reset the sign-in card to signed-out.
 	 */
 	let config = $state<CloudApiConfig | null>(null);
 	let input = $state("");

--- a/apps/desktop/src/components/settings/CloudSignIn.svelte
+++ b/apps/desktop/src/components/settings/CloudSignIn.svelte
@@ -29,17 +29,14 @@
 		type AuthStatus,
 		type AuthUsage,
 	} from "$lib/ipc";
-
-	/** Title-case a workspace role for the badge ("owner" → "Owner"). */
-	function roleLabel(role: string): string {
-		return role ? role[0]!.toUpperCase() + role.slice(1) : "Member";
-	}
-
-	function planLabel(plan: string): string {
-		if (plan === "pro") return "Pro";
-		if (plan === "enterprise") return "Enterprise";
-		return "Free";
-	}
+	import { formatBytes } from "$lib/format/bytes";
+	import {
+		formatMemberSince,
+		formatUserCode,
+		initials,
+		planLabel,
+		roleLabel,
+	} from "./cloud-signin.logic";
 
 	/**
 	 * "Sign in to Recast Cloud" row. Recast Cloud is the Loom-style sharing
@@ -88,36 +85,6 @@
 		};
 	}
 
-	/** "K", "KK", "?" — feeds the avatar fallback. */
-	function initials(name: string | null, email: string | null): string {
-		const source = (name ?? email ?? "").trim();
-		if (!source) return "?";
-		const parts = source.split(/\s+/).filter(Boolean);
-		if (parts.length >= 2) return (parts[0]![0]! + parts[1]![0]!).toUpperCase();
-		return source.slice(0, 2).toUpperCase();
-	}
-
-	/** "1.2 GB", "640 MB", "0 B". */
-	function formatBytes(bytes: number): string {
-		if (!bytes || bytes < 0) return "0 B";
-		const units = ["B", "KB", "MB", "GB", "TB"];
-		let i = 0;
-		let value = bytes;
-		while (value >= 1024 && i < units.length - 1) {
-			value /= 1024;
-			i++;
-		}
-		return `${value.toFixed(value >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
-	}
-
-	/** "May 2026". */
-	function formatMemberSince(iso: string | null): string | null {
-		if (!iso) return null;
-		const d = new Date(iso);
-		if (Number.isNaN(d.getTime())) return null;
-		return d.toLocaleDateString(undefined, { month: "long", year: "numeric" });
-	}
-
 	const dashboardUrl = "https://recast.nexonauts.com/dashboard/settings/profile";
 
 	async function openDashboard() {
@@ -137,13 +104,6 @@
 	const busy = $derived(inFlight !== null);
 	let unlisteners: UnlistenFn[] = [];
 	let destroyed = false;
-
-	function formatUserCode(code: string): string {
-		const clean = code.replace(/-/g, "").toUpperCase();
-		if (clean.length <= 4) return clean;
-		const half = Math.floor(clean.length / 2);
-		return `${clean.slice(0, half)}-${clean.slice(half)}`;
-	}
 
 	async function loadStatus() {
 		try {

--- a/apps/desktop/src/components/settings/CloudSignIn.svelte
+++ b/apps/desktop/src/components/settings/CloudSignIn.svelte
@@ -16,19 +16,9 @@
 	import * as DropdownMenu from "@recast/ui/dropdown-menu";
 	import { toast } from "@recast/ui/sonner";
 	import { cn } from "@recast/ui/utils";
-	import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 	import { openUrl } from "@tauri-apps/plugin-opener";
 	import { onDestroy, onMount } from "svelte";
 	import { cloudShare } from "$lib/stores/cloudShare.svelte";
-	import {
-		authCancel,
-		authSignOut,
-		authStart,
-		authStatus,
-		type AuthPlan,
-		type AuthStatus,
-		type AuthUsage,
-	} from "$lib/ipc";
 	import { formatBytes } from "$lib/format/bytes";
 	import {
 		formatMemberSince,
@@ -37,53 +27,18 @@
 		planLabel,
 		roleLabel,
 	} from "./cloud-signin.logic";
+	import { CloudAuth } from "./cloud-signin.svelte";
 
-	/**
-	 * "Sign in to Recast Cloud" row. Recast Cloud is the Loom-style sharing
-	 * layer (instant share links, viewer analytics, password protection,
-	 * branding) on top of the free local app — the app itself never needs
-	 * an account. Drives the device-authorization flow via the Rust
-	 * `auth_*` commands. State machine:
-	 *
-	 *   loading    → initial auth_status check
-	 *   signed-out → button: "Sign in to Recast Cloud" (triggers auth_start)
-	 *   waiting    → browser open, code on screen, button: "Cancel"
-	 *   signed-in  → rich profile card (avatar, plan, usage, manage)
-	 *   denied     → error msg + retry button
-	 *   expired    → error msg + retry button
-	 */
-	type SignedInProfile = {
-		email: string | null;
-		name: string | null;
-		image: string | null;
-		memberSince: string | null;
-		plan: AuthPlan | null;
-		usage: AuthUsage | null;
-	};
-
-	type ViewState =
-		| { kind: "loading" }
-		| { kind: "signed-out" }
-		| {
-			kind: "waiting";
-			userCode: string;
-			verificationUri: string;
-			expiresAt: number;
-		}
-		| ({ kind: "signed-in" } & SignedInProfile)
-		| { kind: "denied" }
-		| { kind: "expired" };
-
-	function toProfile(s: AuthStatus): SignedInProfile {
-		return {
-			email: s.email ?? null,
-			name: s.name ?? null,
-			image: s.image ?? null,
-			memberSince: s.memberSince ?? null,
-			plan: s.plan ?? null,
-			usage: s.usage ?? null,
-		};
-	}
+	// Recast Cloud sign-in state machine (see cloud-signin.svelte.ts). `view` is
+	// read through a local $derived so discriminated-union narrowing on it keeps
+	// working in the markup below.
+	const auth = new CloudAuth();
+	const view = $derived(auth.view);
+	const busy = $derived(auth.busy);
+	const inFlight = $derived(auth.inFlight);
+	const startSignIn = () => auth.startSignIn();
+	const signOut = () => auth.signOut();
+	const cancelSignIn = () => auth.cancelSignIn();
 
 	const dashboardUrl = "https://recast.nexonauts.com/dashboard/settings/profile";
 
@@ -95,161 +50,8 @@
 		}
 	}
 
-	let view = $state<ViewState>({ kind: "loading" });
-	// Tracks which action is mid-flight so the right button can show its own
-	// spinner + active-verb label ("Signing in…", "Signing out…"). A plain
-	// boolean wouldn't tell us which of the two buttons triggered the
-	// disable. `null` = idle.
-	let inFlight = $state<null | "sign-in" | "sign-out">(null);
-	const busy = $derived(inFlight !== null);
-	let unlisteners: UnlistenFn[] = [];
-	let destroyed = false;
-
-	async function loadStatus() {
-		try {
-			const status = await authStatus();
-			view = status.signedIn
-				? { kind: "signed-in", ...toProfile(status) }
-				: { kind: "signed-out" };
-			// Keep the shared store (which the share flow reads for workspace
-			// targeting) in sync with what we just fetched.
-			void cloudShare.refreshStatus();
-		} catch (e) {
-			toast.error(`Couldn't check sign-in state: ${e}`);
-			view = { kind: "signed-out" };
-		}
-	}
-
-	/** Refetch profile (plan/usage) without leaving the signed-in card. */
-	async function refreshProfile() {
-		try {
-			const status = await authStatus();
-			if (status.signedIn && view.kind === "signed-in") {
-				view = { kind: "signed-in", ...toProfile(status) };
-			}
-		} catch {
-			// Silent — keep stale data on a transient refresh failure.
-		}
-	}
-
-	async function startSignIn() {
-		if (busy) return;
-		inFlight = "sign-in";
-		try {
-			const result = await authStart();
-			view = {
-				kind: "waiting",
-				userCode: result.user_code,
-				verificationUri: result.verification_uri,
-				expiresAt: Date.now() + result.expires_in * 1000,
-			};
-		} catch (e) {
-			toast.error(`Couldn't start sign-in: ${e}`);
-		} finally {
-			inFlight = null;
-		}
-	}
-
-	async function signOut() {
-		if (busy) return;
-		inFlight = "sign-out";
-		try {
-			await authSignOut();
-			toast.success("Signed out of Recast Cloud.");
-			view = { kind: "signed-out" };
-			// Drops the cached workspace list + persisted selection.
-			void cloudShare.refreshStatus();
-		} catch (e) {
-			toast.error(`Couldn't sign out: ${e}`);
-		} finally {
-			inFlight = null;
-		}
-	}
-
-	/**
-	 * Cancel an in-flight sign-in. Two responsibilities:
-	 *
-	 *   1. Tell the Rust poller to stop (`auth_cancel`). Without this the
-	 *      background poller keeps hitting /device/token until the code
-	 *      expires — and if the user approves in the (now-abandoned)
-	 *      browser tab, the next poll would silently sign them in despite
-	 *      the UI showing "signed-out".
-	 *   2. Reset the local view immediately. Don't await `auth_cancel` for
-	 *      the UI transition — the abort is best-effort and instant on the
-	 *      Rust side anyway.
-	 */
-	async function cancelSignIn() {
-		view = { kind: "signed-out" };
-		try {
-			await authCancel();
-		} catch (e) {
-			// Cancel is idempotent on the Rust side; surfacing this would
-			// only confuse the user since the UI already reset.
-			console.warn("auth_cancel failed (non-fatal):", e);
-		}
-	}
-
-	onMount(() => {
-		loadStatus();
-
-		// Background-poller events from Rust. Each event handler ignores the
-		// firing if the view is no longer "waiting" — this is defense in
-		// depth on top of `auth_cancel`'s abort, in case a poll response
-		// landed BETWEEN the user clicking Cancel and the abort taking effect.
-		// Without this gate, a stale "signed-in" event could yank a
-		// signed-out UI into signed-in state without further user action.
-		(async () => {
-			const handles = await Promise.all([
-				listen<AuthStatus>("auth:signed-in", (event) => {
-					if (view.kind !== "waiting") return;
-					const s = event.payload;
-					// The Rust poller already fetched the full profile (it hits
-					// /api/desktop/profile after /device/token returns), so the
-					// payload carries plan + usage — no refetch needed here.
-					view = { kind: "signed-in", ...toProfile(s ?? ({} as AuthStatus)) };
-					// Hydrate the shared store so the workspace selector below and
-					// the share flow both see the freshly-signed-in workspaces.
-					void cloudShare.refreshStatus();
-					toast.success("Signed in to Recast Cloud.");
-				}),
-				listen("auth:denied", () => {
-					if (view.kind !== "waiting") return;
-					view = { kind: "denied" };
-				}),
-				listen("auth:expired", () => {
-					if (view.kind !== "waiting") return;
-					view = { kind: "expired" };
-				}),
-				listen<string>("auth:error", (event) => {
-					if (view.kind !== "waiting") return;
-					toast.error(`Sign-in error: ${event.payload}`);
-					view = { kind: "signed-out" };
-				}),
-				// Self-host endpoint changed (Settings → Cloud → Server endpoint).
-				// The Rust side dropped the old server's token, so re-check status
-				// against the new endpoint — this flips the card back to
-				// signed-out without a full reload.
-				listen("cloud:endpoint-changed", () => {
-					if (view.kind === "waiting") cancelSignIn();
-					view = { kind: "loading" };
-					loadStatus();
-				}),
-			]);
-			// If onDestroy fired while the listens were resolving, we'd leak
-			// these handles forever — call them immediately instead.
-			if (destroyed) {
-				for (const un of handles) un();
-				return;
-			}
-			unlisteners = handles;
-		})();
-	});
-
-	onDestroy(() => {
-		destroyed = true;
-		for (const un of unlisteners) un();
-		unlisteners = [];
-	});
+	onMount(() => auth.start());
+	onDestroy(() => auth.dispose());
 </script>
 
 <div class="px-4 py-3">

--- a/apps/desktop/src/components/settings/DeviceCapabilities.svelte
+++ b/apps/desktop/src/components/settings/DeviceCapabilities.svelte
@@ -32,15 +32,13 @@
   import { cn } from "@recast/ui/utils";
   import { onMount } from "svelte";
 
-  // OS facts (best-effort — each os-plugin getter is wrapped so a blocked
-  // permission or non-Tauri preview degrades to "Unknown" instead of
-  // throwing the whole panel away).
+  // Best-effort: each os-plugin getter is wrapped so a blocked permission or
+  // non-Tauri preview degrades to "Unknown" rather than throwing the panel away.
   let osLabel = $state("Unknown");
   let osVersion = $state("");
   let osArch = $state("");
-  // Raw platform key ("windows" / "macos" / …) kept alongside the display
-  // label so the capture-support row can key off it without string-matching
-  // the localized label. Empty until loadOsInfo resolves.
+  // Raw key ("windows" / "macos" / …) so rows can branch on it without
+  // string-matching the localized label. Empty until loadOsInfo resolves.
   let platform = $state("");
 
   let diagnostics = $state<FfmpegDiagnostics | null>(null);
@@ -125,11 +123,8 @@
     void loadCapture();
   });
 
-  // `os.version()` returns the raw NT version on Windows — "10.0.26200" —
-  // because Windows 11 still reports kernel 10.0; only the build number
-  // (≥22000) distinguishes 11 from 10. Surface the marketing name + build
-  // instead of the bare NT string so the panel reads "Windows 11 (Build
-  // 26200)" rather than the confusing "10.0.26200".
+  // Windows 11 still reports NT kernel 10.0; only build ≥22000 distinguishes it
+  // from 10, so we surface the build instead of the bare "10.0.26200".
   function windowsBuild(v: string): number | null {
     const m = /^\d+\.\d+\.(\d+)/.exec(v);
     return m ? Number(m[1]) : null;
@@ -144,8 +139,7 @@
     return osLabel;
   });
 
-  // Second fact row: the build (Windows) or raw version (kernel/Darwin
-  // elsewhere). Labeled "Build" on Windows since that's the meaningful number.
+  // Build on Windows (the meaningful number), raw version elsewhere.
   const osDetail = $derived.by(() => {
     if (platform === "windows") {
       const build = windowsBuild(osVersion);
@@ -154,9 +148,7 @@
     return osVersion;
   });
 
-  // The "screen" row is the headline verdict — can this machine record its
-  // screen at all? The rest of the matrix (audio, camera, cursor) hangs off
-  // the collapsible list below.
+  // Screen is the headline verdict; audio/camera/cursor hang off the list below.
   const screenCap = $derived(
     captureCaps?.capabilities.find((c) => c.key === "screen") ?? null,
   );
@@ -169,8 +161,7 @@
   });
   let showCapture = $state(false);
 
-  // Per-capability Lucide icon, keyed by the Rust `key`. Falls back to the
-  // screen glyph for any future key the backend adds before the UI does.
+  // Keyed by the Rust `key`; falls back to the screen glyph for unknown keys.
   const CAP_ICON: Record<string, Component> = {
     screen: MonitorPlay,
     window: AppWindow,
@@ -194,9 +185,7 @@
     ].filter((f) => f.value),
   );
 
-  // Group the probed encoders by codec family ("H.264" / "HEVC") so the
-  // matrix renders a labeled section per codec instead of one flat list.
-  // Order follows first-appearance in the probe result (H.264 then HEVC).
+  // Group encoders by codec family for the matrix; order follows first-appearance.
   const encoderGroups = $derived.by(() => {
     const groups: { family: string; items: EncoderAvailability[] }[] = [];
     for (const enc of encoders) {
@@ -210,16 +199,13 @@
     return groups;
   });
 
-  // The plain-language verdict: which encoder the recorder actually picked, and
-  // whether it's a GPU (hardware) path. This is the one thing a non-technical
-  // user needs — the per-codec matrix below is collapsed power-user detail.
+  // Which encoder the recorder actually picked, and whether it's a GPU path.
   const activeEncoder = $derived(encoders.find((e) => e.active) ?? null);
   const isAccelerated = $derived(activeEncoder?.hardware ?? false);
   let showDetails = $state(false);
 </script>
 
 <div class="flex flex-col gap-3">
-  <!-- Platform / engine facts -->
   <div
     class="overflow-hidden rounded-xl border border-border/60 bg-card/70 shadow-(--shadow-craft-inset) backdrop-blur"
   >
@@ -242,9 +228,7 @@
     </dl>
   </div>
 
-  <!-- Capture support — what this device's native APIs can actually record,
-       probed at runtime (DXGI / AVFoundation / PipeWire / X11) rather than
-       hardcoded per platform. -->
+  <!-- Probed at runtime (DXGI / AVFoundation / PipeWire / X11), not hardcoded. -->
   <div
     class="overflow-hidden rounded-xl border border-border/60 bg-card/70 shadow-(--shadow-craft-inset) backdrop-blur"
   >
@@ -268,8 +252,6 @@
         Couldn't check capture support: {captureError}
       </div>
     {:else if captureCaps}
-      <!-- Plain-language verdict: can this machine actually record its screen,
-           and which native API does it use? -->
       <div class="flex items-start gap-3 px-4 py-3.5">
         <div
           class={cn(
@@ -309,9 +291,7 @@
         </div>
       </div>
 
-      <!-- Per-feature support matrix, collapsed by default — each row is the
-           native API behind that capture input on this device. Collapsible
-           gives it a smooth native `slide` (real height) transition. -->
+      <!-- Per-feature matrix, collapsed by default; one row per capture input. -->
       <Collapsible.Root bind:open={showCapture}>
         <Collapsible.Trigger
           class="flex w-full items-center justify-between gap-2 border-t border-border/30 px-4 py-2 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"
@@ -373,7 +353,6 @@
     {/if}
   </div>
 
-  <!-- Hardware acceleration / encoder matrix -->
   <div
     class="overflow-hidden rounded-xl border border-border/60 bg-card/70 shadow-(--shadow-craft-inset) backdrop-blur"
   >
@@ -411,8 +390,6 @@
         </div>
       </div>
     {:else}
-      <!-- Plain-language verdict — the one thing a non-technical user needs:
-           is recording using the graphics card (GPU) or the processor (CPU)? -->
       <div class="flex items-start gap-3 px-4 py-3.5">
         <div
           class={cn(
@@ -458,9 +435,7 @@
         </div>
       </div>
 
-      <!-- Per-codec matrix, collapsed by default — kept for power users and bug
-           reports without making jargon the headline. Collapsible gives it a
-           smooth native `slide` (real height) transition. -->
+      <!-- Per-codec matrix, collapsed by default; power-user / bug-report detail. -->
       <Collapsible.Root bind:open={showDetails}>
         <Collapsible.Trigger
           class="flex w-full items-center justify-between gap-2 border-t border-border/30 px-4 py-2 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"

--- a/apps/desktop/src/components/settings/DiagnosticsPanel.svelte
+++ b/apps/desktop/src/components/settings/DiagnosticsPanel.svelte
@@ -13,7 +13,7 @@
     diagnostics.set(next);
     toast.success(
       next
-        ? "Diagnostic logging on — reproduce the issue, then open the logs folder"
+        ? "Diagnostic logging on. Reproduce the issue, then open the logs folder."
         : "Diagnostic logging off",
     );
   }
@@ -39,8 +39,8 @@
       Diagnostics
     </h2>
     <p class="mt-0.5 text-[11px] text-muted-foreground/80">
-      Detailed logs for troubleshooting. Off by default — turn this on only when
-      reproducing a bug, then send the log folder to support.
+      Detailed logs for troubleshooting. Turn this on while reproducing a bug,
+      then send the log folder to support.
     </p>
   </div>
 

--- a/apps/desktop/src/components/settings/GoogleDriveConnection.svelte
+++ b/apps/desktop/src/components/settings/GoogleDriveConnection.svelte
@@ -22,8 +22,7 @@
   async function handleConnect() {
     try {
       await gdrive.connect();
-      // Success path emits via the gdrive:connected listener — no toast
-      // here. We only toast on failure.
+      // Success surfaces via the gdrive:connected listener; only toast failures.
     } catch (e) {
       toast.error(`Couldn't connect Google Drive: ${e}`);
     }

--- a/apps/desktop/src/components/settings/cloud-signin.logic.test.ts
+++ b/apps/desktop/src/components/settings/cloud-signin.logic.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatUserCode,
+	initials,
+	planLabel,
+	roleLabel,
+} from "./cloud-signin.logic";
+
+describe("roleLabel", () => {
+	it("title-cases, defaults to Member", () => {
+		expect(roleLabel("owner")).toBe("Owner");
+		expect(roleLabel("")).toBe("Member");
+	});
+});
+
+describe("planLabel", () => {
+	it("maps known plans, defaults Free", () => {
+		expect(planLabel("pro")).toBe("Pro");
+		expect(planLabel("enterprise")).toBe("Enterprise");
+		expect(planLabel("anything")).toBe("Free");
+	});
+});
+
+describe("initials", () => {
+	it("uses two name parts, then a prefix, then ?", () => {
+		expect(initials("Kanak Kholwal", null)).toBe("KK");
+		expect(initials("Kanak", null)).toBe("KA");
+		expect(initials(null, "kanak@x.com")).toBe("KA");
+		expect(initials(null, null)).toBe("?");
+	});
+});
+
+describe("formatUserCode", () => {
+	it("splits into two halves", () => {
+		expect(formatUserCode("ABCDEFGH")).toBe("ABCD-EFGH");
+		expect(formatUserCode("ab-cd")).toBe("ABCD"); // <=4 after cleaning
+	});
+});

--- a/apps/desktop/src/components/settings/cloud-signin.logic.ts
+++ b/apps/desktop/src/components/settings/cloud-signin.logic.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure label/formatting helpers for CloudSignIn. The auth state machine (view
+ * state, the `auth_*` command handlers, event listeners) stays in the component.
+ */
+
+/** Title-case a workspace role for the badge ("owner" → "Owner"). */
+export function roleLabel(role: string): string {
+	return role ? role[0]!.toUpperCase() + role.slice(1) : "Member";
+}
+
+/** Plan name for the badge. */
+export function planLabel(plan: string): string {
+	if (plan === "pro") return "Pro";
+	if (plan === "enterprise") return "Enterprise";
+	return "Free";
+}
+
+/** "K", "KK", "?" — feeds the avatar fallback. */
+export function initials(name: string | null, email: string | null): string {
+	const source = (name ?? email ?? "").trim();
+	if (!source) return "?";
+	const parts = source.split(/\s+/).filter(Boolean);
+	if (parts.length >= 2) return (parts[0]![0]! + parts[1]![0]!).toUpperCase();
+	return source.slice(0, 2).toUpperCase();
+}
+
+/** "May 2026" from an ISO date, or null if absent/unparseable. */
+export function formatMemberSince(iso: string | null): string | null {
+	if (!iso) return null;
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return null;
+	return d.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+}
+
+/** Group the device code into two halves for legibility ("ABCD-EFGH"). */
+export function formatUserCode(code: string): string {
+	const clean = code.replace(/-/g, "").toUpperCase();
+	if (clean.length <= 4) return clean;
+	const half = Math.floor(clean.length / 2);
+	return `${clean.slice(0, half)}-${clean.slice(half)}`;
+}

--- a/apps/desktop/src/components/settings/cloud-signin.logic.ts
+++ b/apps/desktop/src/components/settings/cloud-signin.logic.ts
@@ -1,7 +1,4 @@
-/**
- * Pure label/formatting helpers for CloudSignIn. The auth state machine (view
- * state, the `auth_*` command handlers, event listeners) stays in the component.
- */
+/** Pure label/formatting helpers for CloudSignIn. */
 
 /** Title-case a workspace role for the badge ("owner" → "Owner"). */
 export function roleLabel(role: string): string {

--- a/apps/desktop/src/components/settings/cloud-signin.svelte.ts
+++ b/apps/desktop/src/components/settings/cloud-signin.svelte.ts
@@ -1,21 +1,6 @@
 /**
- * The Recast Cloud sign-in state machine, extracted from CloudSignIn.svelte so
- * the component is markup + wiring. Drives the device-authorization flow via the
- * Rust `auth_*` commands and the background-poller events. States:
- *
- *   loading    → initial auth_status check
- *   signed-out → "Sign in to Recast Cloud" (auth_start)
- *   waiting    → browser open, code on screen, "Cancel"
- *   signed-in  → profile card (avatar, plan, usage, manage)
- *   denied / expired → error + retry
- *
- * Lifecycle: the component calls `start()` in onMount and `dispose()` in
- * onDestroy. Reactive state (`view`, `busy`, `inFlight`) is exposed via getters;
- * read them through a local `$derived` in the component so discriminated-union
- * narrowing on `view` keeps working in the markup.
- *
- * This is a rune module (uses `$state`) and imports Tauri/stores, so it isn't
- * unit-tested; the pure formatters live in `cloud-signin.logic.ts` (tested).
+ * Recast Cloud sign-in state machine via the device-authorization flow.
+ * States: loading | signed-out | waiting | signed-in | denied | expired.
  */
 
 import {
@@ -66,8 +51,7 @@ function toProfile(s: AuthStatus): SignedInProfile {
 
 export class CloudAuth {
 	#view = $state<ViewState>({ kind: "loading" });
-	// Which action is mid-flight, so the right button shows its own spinner +
-	// active-verb label. `null` = idle.
+	// Which action is mid-flight, so the right button shows its own spinner. `null` = idle.
 	#inFlight = $state<null | "sign-in" | "sign-out">(null);
 	#unlisteners: UnlistenFn[] = [];
 	#destroyed = false;
@@ -88,8 +72,7 @@ export class CloudAuth {
 			this.#view = status.signedIn
 				? { kind: "signed-in", ...toProfile(status) }
 				: { kind: "signed-out" };
-			// Keep the shared store (which the share flow reads for workspace
-			// targeting) in sync with what we just fetched.
+			// Keep the shared store (read by the share flow) in sync.
 			void cloudShare.refreshStatus();
 		} catch (e) {
 			toast.error(`Couldn't check sign-in state: ${e}`);
@@ -132,35 +115,31 @@ export class CloudAuth {
 	}
 
 	/**
-	 * Cancel an in-flight sign-in: tell the Rust poller to stop (so an approval
-	 * in the abandoned browser tab can't silently sign the user in) and reset
-	 * the view immediately — the abort is best-effort and instant Rust-side.
+	 * Cancel an in-flight sign-in. Stops the Rust poller so an approval in the
+	 * abandoned browser tab can't silently sign the user in.
 	 */
 	async cancelSignIn(): Promise<void> {
 		this.#view = { kind: "signed-out" };
 		try {
 			await authCancel();
 		} catch (e) {
-			// Idempotent on the Rust side; surfacing it would only confuse since
-			// the UI already reset.
+			// Idempotent Rust-side; UI already reset, so don't surface.
 			console.warn("auth_cancel failed (non-fatal):", e);
 		}
 	}
 
-	/** Begin: initial status check + subscribe to the Rust poller events. */
+	/** Initial status check + subscribe to the Rust poller events. */
 	start(): void {
 		this.loadStatus();
 
-		// Each handler ignores the firing if the view is no longer "waiting" —
-		// defense in depth on top of `auth_cancel`, in case a poll response
-		// landed between the user clicking Cancel and the abort taking effect.
+		// Each handler ignores the firing if the view left "waiting" — defense in
+		// depth over `auth_cancel`, in case a poll landed between Cancel and abort.
 		void (async () => {
 			const handles = await Promise.all([
 				listen<AuthStatus>("auth:signed-in", (event) => {
 					if (this.#view.kind !== "waiting") return;
 					const s = event.payload;
-					// The Rust poller already fetched the full profile, so the payload
-					// carries plan + usage — no refetch needed.
+					// Payload already carries the full profile (plan + usage) — no refetch.
 					this.#view = {
 						kind: "signed-in",
 						...toProfile(s ?? ({} as AuthStatus)),
@@ -181,17 +160,15 @@ export class CloudAuth {
 					toast.error(`Sign-in error: ${event.payload}`);
 					this.#view = { kind: "signed-out" };
 				}),
-				// Self-host endpoint changed (Settings → Cloud → Server endpoint):
-				// the Rust side dropped the old token, so re-check against the new
-				// endpoint, flipping the card back to signed-out without a reload.
+				// Self-host endpoint changed: Rust dropped the old token, so re-check
+				// against the new endpoint without a reload.
 				listen("cloud:endpoint-changed", () => {
 					if (this.#view.kind === "waiting") void this.cancelSignIn();
 					this.#view = { kind: "loading" };
 					this.loadStatus();
 				}),
 			]);
-			// If dispose() ran while the listens were resolving, releasing here
-			// avoids leaking the handles forever.
+			// dispose() may have run while the listens were resolving — release now.
 			if (this.#destroyed) {
 				for (const un of handles) un();
 				return;

--- a/apps/desktop/src/components/settings/cloud-signin.svelte.ts
+++ b/apps/desktop/src/components/settings/cloud-signin.svelte.ts
@@ -1,0 +1,209 @@
+/**
+ * The Recast Cloud sign-in state machine, extracted from CloudSignIn.svelte so
+ * the component is markup + wiring. Drives the device-authorization flow via the
+ * Rust `auth_*` commands and the background-poller events. States:
+ *
+ *   loading    → initial auth_status check
+ *   signed-out → "Sign in to Recast Cloud" (auth_start)
+ *   waiting    → browser open, code on screen, "Cancel"
+ *   signed-in  → profile card (avatar, plan, usage, manage)
+ *   denied / expired → error + retry
+ *
+ * Lifecycle: the component calls `start()` in onMount and `dispose()` in
+ * onDestroy. Reactive state (`view`, `busy`, `inFlight`) is exposed via getters;
+ * read them through a local `$derived` in the component so discriminated-union
+ * narrowing on `view` keeps working in the markup.
+ *
+ * This is a rune module (uses `$state`) and imports Tauri/stores, so it isn't
+ * unit-tested; the pure formatters live in `cloud-signin.logic.ts` (tested).
+ */
+
+import {
+	authCancel,
+	authSignOut,
+	authStart,
+	authStatus,
+	type AuthPlan,
+	type AuthStatus,
+	type AuthUsage,
+} from "$lib/ipc";
+import { cloudShare } from "$lib/stores/cloudShare.svelte";
+import { toast } from "@recast/ui/sonner";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+export type SignedInProfile = {
+	email: string | null;
+	name: string | null;
+	image: string | null;
+	memberSince: string | null;
+	plan: AuthPlan | null;
+	usage: AuthUsage | null;
+};
+
+export type ViewState =
+	| { kind: "loading" }
+	| { kind: "signed-out" }
+	| {
+			kind: "waiting";
+			userCode: string;
+			verificationUri: string;
+			expiresAt: number;
+	  }
+	| ({ kind: "signed-in" } & SignedInProfile)
+	| { kind: "denied" }
+	| { kind: "expired" };
+
+function toProfile(s: AuthStatus): SignedInProfile {
+	return {
+		email: s.email ?? null,
+		name: s.name ?? null,
+		image: s.image ?? null,
+		memberSince: s.memberSince ?? null,
+		plan: s.plan ?? null,
+		usage: s.usage ?? null,
+	};
+}
+
+export class CloudAuth {
+	#view = $state<ViewState>({ kind: "loading" });
+	// Which action is mid-flight, so the right button shows its own spinner +
+	// active-verb label. `null` = idle.
+	#inFlight = $state<null | "sign-in" | "sign-out">(null);
+	#unlisteners: UnlistenFn[] = [];
+	#destroyed = false;
+
+	get view(): ViewState {
+		return this.#view;
+	}
+	get inFlight(): null | "sign-in" | "sign-out" {
+		return this.#inFlight;
+	}
+	get busy(): boolean {
+		return this.#inFlight !== null;
+	}
+
+	async loadStatus(): Promise<void> {
+		try {
+			const status = await authStatus();
+			this.#view = status.signedIn
+				? { kind: "signed-in", ...toProfile(status) }
+				: { kind: "signed-out" };
+			// Keep the shared store (which the share flow reads for workspace
+			// targeting) in sync with what we just fetched.
+			void cloudShare.refreshStatus();
+		} catch (e) {
+			toast.error(`Couldn't check sign-in state: ${e}`);
+			this.#view = { kind: "signed-out" };
+		}
+	}
+
+	async startSignIn(): Promise<void> {
+		if (this.busy) return;
+		this.#inFlight = "sign-in";
+		try {
+			const result = await authStart();
+			this.#view = {
+				kind: "waiting",
+				userCode: result.user_code,
+				verificationUri: result.verification_uri,
+				expiresAt: Date.now() + result.expires_in * 1000,
+			};
+		} catch (e) {
+			toast.error(`Couldn't start sign-in: ${e}`);
+		} finally {
+			this.#inFlight = null;
+		}
+	}
+
+	async signOut(): Promise<void> {
+		if (this.busy) return;
+		this.#inFlight = "sign-out";
+		try {
+			await authSignOut();
+			toast.success("Signed out of Recast Cloud.");
+			this.#view = { kind: "signed-out" };
+			// Drops the cached workspace list + persisted selection.
+			void cloudShare.refreshStatus();
+		} catch (e) {
+			toast.error(`Couldn't sign out: ${e}`);
+		} finally {
+			this.#inFlight = null;
+		}
+	}
+
+	/**
+	 * Cancel an in-flight sign-in: tell the Rust poller to stop (so an approval
+	 * in the abandoned browser tab can't silently sign the user in) and reset
+	 * the view immediately — the abort is best-effort and instant Rust-side.
+	 */
+	async cancelSignIn(): Promise<void> {
+		this.#view = { kind: "signed-out" };
+		try {
+			await authCancel();
+		} catch (e) {
+			// Idempotent on the Rust side; surfacing it would only confuse since
+			// the UI already reset.
+			console.warn("auth_cancel failed (non-fatal):", e);
+		}
+	}
+
+	/** Begin: initial status check + subscribe to the Rust poller events. */
+	start(): void {
+		this.loadStatus();
+
+		// Each handler ignores the firing if the view is no longer "waiting" —
+		// defense in depth on top of `auth_cancel`, in case a poll response
+		// landed between the user clicking Cancel and the abort taking effect.
+		void (async () => {
+			const handles = await Promise.all([
+				listen<AuthStatus>("auth:signed-in", (event) => {
+					if (this.#view.kind !== "waiting") return;
+					const s = event.payload;
+					// The Rust poller already fetched the full profile, so the payload
+					// carries plan + usage — no refetch needed.
+					this.#view = {
+						kind: "signed-in",
+						...toProfile(s ?? ({} as AuthStatus)),
+					};
+					void cloudShare.refreshStatus();
+					toast.success("Signed in to Recast Cloud.");
+				}),
+				listen("auth:denied", () => {
+					if (this.#view.kind !== "waiting") return;
+					this.#view = { kind: "denied" };
+				}),
+				listen("auth:expired", () => {
+					if (this.#view.kind !== "waiting") return;
+					this.#view = { kind: "expired" };
+				}),
+				listen<string>("auth:error", (event) => {
+					if (this.#view.kind !== "waiting") return;
+					toast.error(`Sign-in error: ${event.payload}`);
+					this.#view = { kind: "signed-out" };
+				}),
+				// Self-host endpoint changed (Settings → Cloud → Server endpoint):
+				// the Rust side dropped the old token, so re-check against the new
+				// endpoint, flipping the card back to signed-out without a reload.
+				listen("cloud:endpoint-changed", () => {
+					if (this.#view.kind === "waiting") void this.cancelSignIn();
+					this.#view = { kind: "loading" };
+					this.loadStatus();
+				}),
+			]);
+			// If dispose() ran while the listens were resolving, releasing here
+			// avoids leaking the handles forever.
+			if (this.#destroyed) {
+				for (const un of handles) un();
+				return;
+			}
+			this.#unlisteners = handles;
+		})();
+	}
+
+	/** Tear down the event subscriptions. */
+	dispose(): void {
+		this.#destroyed = true;
+		for (const un of this.#unlisteners) un();
+		this.#unlisteners = [];
+	}
+}

--- a/apps/desktop/src/components/skeletons/EditorSkeleton.svelte
+++ b/apps/desktop/src/components/skeletons/EditorSkeleton.svelte
@@ -3,9 +3,7 @@
 </script>
 
 <div class="flex flex-1 min-h-0">
-  <!-- Left column: preview + controls + timeline -->
   <div class="flex-1 flex flex-col min-h-0">
-    <!-- Sub-toolbar -->
     <div class="h-9 flex items-center gap-3 px-4 border-b border-border">
       <Skeleton class="h-6 w-24 rounded-md" />
       <Skeleton class="h-6 w-16 rounded-md" />
@@ -14,12 +12,10 @@
       </div>
     </div>
 
-    <!-- Preview area -->
     <div class="flex-1 flex items-center justify-center p-6">
       <Skeleton class="w-full max-w-225 aspect-video rounded-[24px]" />
     </div>
 
-    <!-- Playback controls -->
     <div class="shrink-0 px-4 py-2 border-t border-border">
       <div class="flex items-center justify-between">
         <Skeleton class="h-5 w-32" />
@@ -32,7 +28,6 @@
       </div>
     </div>
 
-    <!-- Timeline -->
     <div class="shrink-0 px-4 pb-3 pt-2 border-t border-border">
       <div class="flex items-center gap-2 mb-2">
         <Skeleton class="h-6 w-6 rounded" />
@@ -46,7 +41,6 @@
     </div>
   </div>
 
-  <!-- Right column: properties panel -->
   <div class="w-85 shrink-0 border-l border-border">
     <div class="p-4 border-b border-border space-y-3">
       <Skeleton class="h-5 w-24" />

--- a/apps/desktop/src/components/skeletons/SourceSelectorSkeleton.svelte
+++ b/apps/desktop/src/components/skeletons/SourceSelectorSkeleton.svelte
@@ -7,12 +7,10 @@
     <div
       class="group relative overflow-hidden rounded-[24px] border border-border-subtle bg-foreground/[0.02]"
     >
-      <!-- Thumbnail -->
       <div class="relative aspect-[16/10] w-full overflow-hidden bg-foreground/[0.05]">
         <Skeleton class="h-full w-full rounded-none opacity-20" />
       </div>
 
-      <!-- Label -->
       <div class="px-5 py-4.5">
         <Skeleton class="h-3.5 w-3/4 opacity-20" />
         <Skeleton class="mt-1.5 h-3 w-1/3 opacity-20" />

--- a/apps/desktop/src/constants/changelog.ts
+++ b/apps/desktop/src/constants/changelog.ts
@@ -37,6 +37,19 @@ export const KIND_META: Record<
 // RELEASES:START — auto-generated, do not edit by hand
 export const RELEASES: readonly ChangelogRelease[] = [
 	{
+		version: '0.2.8',
+		date: '2026-06-28',
+		highlights: [
+			'**Camera and microphone work on macOS again** — fixed a permissions problem that stopped macOS from capturing your camera and mic.',
+		],
+		changes: [
+			{ kind: 'changed', summary: 'Tightened copy across the desktop app and website. Removed em dashes and over-explanation from settings, experimental-feature, and editor-panel descriptions, and from a few marketing sections, so the text says what a feature does without explaining how it works internally.' },
+			{ kind: 'fixed', summary: 'Website build no longer fails during prerender. A leftover static `robots.txt` was shadowing the dynamic `/robots.txt` route, so the route was never prerendered and the build errored out. The static file is gone; `/robots.txt` and `/sitemap.xml` now come from their routes.' },
+			{ kind: 'fixed', summary: 'Corrected the Loom and Cap comparison on the Features page. Dropped a "pause and resume is paid in Loom" row (it is free), changed Cap\'s "share to your own storage" from "Not supported" to "Pro only" (Cap Pro supports custom S3 and Google Drive), and relabelled per-seat pricing.' },
+			{ kind: 'fixed', summary: 'Fix camera and microphone permissions not working on macOS' },
+		],
+	},
+	{
 		version: '0.2.7',
 		date: '2026-06-28',
 		highlights: [

--- a/apps/desktop/src/lib/analytics/client.ts
+++ b/apps/desktop/src/lib/analytics/client.ts
@@ -1,14 +1,11 @@
 /**
- * The desktop app's analytics singleton.
+ * Desktop analytics singleton.
  *
- * Posture (the hard rule): product analytics are strictly opt-in (default OFF);
- * crash reporting is default opt-in (default ON). The provider is NOT stood up
- * at launch for an errors-only install — `eagerInit` is omitted, so PostHog
- * makes zero network calls until a real crash or an explicit opt-in. When
- * `PUBLIC_POSTHOG_KEY` is blank the whole client is a no-op.
- *
- * The anonymous `distinct_id` is the persistent install id, so a crash reported
- * before sign-in attributes to the same person as later identified events.
+ * Posture: product analytics opt-in (default OFF), crash reporting default ON.
+ * `eagerInit` is omitted, so PostHog makes zero network calls until a real crash
+ * or explicit opt-in. Blank `PUBLIC_POSTHOG_KEY` makes the whole client a no-op.
+ * The anonymous `distinct_id` is the persistent install id, so pre-sign-in crashes
+ * attribute to the same person as later identified events.
  */
 
 import { config } from "$constants/app";

--- a/apps/desktop/src/lib/analytics/identity.ts
+++ b/apps/desktop/src/lib/analytics/identity.ts
@@ -1,19 +1,17 @@
 /**
- * The persistent, anonymous install id — the desktop's analytics `distinct_id`
- * before sign-in. Stored under the same `trace_install_id` localStorage key the
- * `user-store` defines, so the JS analytics client, the Rust crash reporter, and
- * the user store all attribute to the same anonymous person.
+ * Persistent anonymous install id — the analytics `distinct_id` before sign-in.
+ * Shares the `trace_install_id` localStorage key with `user-store` and the Rust
+ * crash reporter so all three attribute to the same anonymous person.
  *
- * Standalone module (no analytics/posthog imports) so both the consent store and
- * the analytics client can read it without an import cycle.
+ * Standalone (no analytics/posthog imports) to avoid an import cycle with the
+ * consent store and analytics client.
  */
 import { safeStorage } from "@recast/ui/persisted-state";
 
 const INSTALL_ID_KEY = "trace_install_id";
 
 export function getInstallId(): string {
-	// Keep the explicit sentinel for the truly storage-less case so the crash
-	// reporter still has a stable id during prerender / no-window contexts.
+	// Stable sentinel for storage-less contexts (prerender / no window).
 	if (typeof window === "undefined") return "anonymous-desktop";
 	let id = safeStorage.get<string>(INSTALL_ID_KEY, "");
 	if (!id) {

--- a/apps/desktop/src/lib/annotations/eval.ts
+++ b/apps/desktop/src/lib/annotations/eval.ts
@@ -1,8 +1,6 @@
 // Pure evaluators for annotation timing and the editor's zoom transform.
-//
-// Extracted from AnnotationOverlay.svelte and TextAnnotationLayer.svelte (where
-// they were duplicated). Owning a single copy means a regression in the math
-// can be caught with a unit test and only one render path needs the fix.
+// Single copy (was duplicated in AnnotationOverlay/TextAnnotationLayer) so the
+// math is unit-testable and fixed in one place.
 
 import { bezierY, type Easing } from "$lib/easing/cubic-bezier";
 import type { Annotation } from "$lib/stores/editor-store.svelte";
@@ -63,14 +61,10 @@ export function evalZoom(zoomRegions: ZoomRegionLike[], t: number): ZoomTransfor
 		const eased = atHold ? 1 : bezierY(curve, phase);
 		return {
 			scale: 1 + (r.scale - 1) * eased,
-			// Focus point is CONSTANT at the target for the whole region — only
-			// the scale eases. This must match VideoPreview's `evaluateZoomAt`
-			// 1:1 (see the long note there): the video shader pins the centre
-			// and dollies straight into the focus, so easing the centre
-			// 0.5→target here made overlays (text, blur, arrows, guides) slide
-			// laterally toward the focus during the ramp while the video stayed
-			// put — annotations drifting off their content pixels until the
-			// hold. Pinning keeps them glued to the same pixels as the frame.
+			// Centre is PINNED at the target for the whole region — only scale
+			// eases. Must match VideoPreview's `evaluateZoomAt` 1:1: the shader
+			// dollies straight in, so easing the centre would slide overlays off
+			// their content pixels during the ramp while the video stays put.
 			cx: cxTarget,
 			cy: cyTarget,
 		};

--- a/apps/desktop/src/lib/annotations/hit.ts
+++ b/apps/desktop/src/lib/annotations/hit.ts
@@ -134,12 +134,9 @@ export function hitTestAnnotation(
 		if (a.hidden) continue;
 		if (a.locked) continue;
 		if (a.kind.kind === "text") continue;
-		// Hit-test against the visibility *window* rather than the per-frame
-		// opacity. The fade-in ramp briefly drops opacity below the old 0.05
-		// threshold right after creation, which previously made fresh
-		// annotations un-selectable until the ramp finished. Skipping by window
-		// keeps selection responsive while still ignoring annotations that
-		// haven't started or have already ended.
+		// Test the visibility window, not per-frame opacity: the fade-in ramp
+		// briefly drops opacity below the old threshold, which made fresh
+		// annotations un-selectable until the ramp finished.
 		if (opts.t < a.start || opts.t > a.end) continue;
 
 		if (a.kind.kind === "arrow") {

--- a/apps/desktop/src/lib/annotations/palette.ts
+++ b/apps/desktop/src/lib/annotations/palette.ts
@@ -1,6 +1,5 @@
-// Shared annotation palette constants — colors, fills, and text typography
-// options. Centralised so the main panel and the appearance sub-panel can't
-// drift out of sync (they previously each declared their own copies).
+// Shared annotation palette constants — centralised so the main panel and the
+// appearance sub-panel can't drift out of sync.
 
 /** Quick stroke / text color swatches. Mirrors the cursor highlight palette. */
 export const STROKE_SWATCHES = [

--- a/apps/desktop/src/lib/annotations/recent-colors.ts
+++ b/apps/desktop/src/lib/annotations/recent-colors.ts
@@ -1,7 +1,6 @@
-// Workspace-scoped LRU of colors recently picked from the annotation color
-// pickers. Bleeds across projects deliberately — the user's preferred palette
-// follows them, not the file. Synced to localStorage on every commit so
-// restarts preserve the list. Capped to 12 entries.
+// Workspace-scoped LRU (max 12) of recently picked annotation colors, synced to
+// localStorage. Bleeds across projects deliberately — the palette follows the
+// user, not the file.
 
 import { safeStorage } from "@recast/ui/persisted-state";
 
@@ -12,8 +11,6 @@ let cache: string[] | null = null;
 
 function read(): string[] {
 	if (cache) return cache;
-	// `safeStorage` handles missing key, no-window, malformed JSON, and the
-	// array-shape guard; we still string-filter + cap defensively.
 	const parsed = safeStorage.get<string[]>(STORAGE_KEY, []);
 	cache = parsed.filter((c) => typeof c === "string").slice(0, MAX);
 	return cache;

--- a/apps/desktop/src/lib/annotations/snap.ts
+++ b/apps/desktop/src/lib/annotations/snap.ts
@@ -1,7 +1,5 @@
-// Snap engine for annotation drag/place. Pure: takes a candidate UV point and
-// a list of anchors, returns the snapped point plus whichever anchors fired
-// (so the overlay can draw guides). Stores no state; the caller decides when
-// to invoke it (e.g. only on move-deltas above a hysteresis threshold).
+// Pure snap engine for annotation drag/place: candidate UV point + anchors →
+// snapped point plus the anchors that fired (so the overlay can draw guides).
 
 export type SnapAxis = "x" | "y";
 

--- a/apps/desktop/src/lib/annotations/uv.ts
+++ b/apps/desktop/src/lib/annotations/uv.ts
@@ -1,7 +1,5 @@
-// Pure UV ↔ canvas geometry helpers shared between the 2D annotation overlay
-// and the HTML text-annotation layer. Both layers must agree on the same math
-// to avoid drift when zoom/padding change — that's the only correctness
-// invariant that matters here.
+// Pure UV ↔ canvas geometry shared by the 2D annotation overlay and the HTML
+// text layer. Both MUST use the same math or they drift when zoom/padding change.
 
 import { computeCanvasGeometry } from "$lib/canvas-geometry";
 import {
@@ -30,15 +28,10 @@ export function compositionWidth(
 }
 
 /**
- * Device-pixel rect of the actual video region inside a canvas/element of
- * dimensions `containerW × containerH`. The container's aspect tracks the
- * configured `outputAspect` (the editor preview keeps the canvas matched
- * to the canvas geometry), so this maps source-pixel offsets through
- * `containerW / canvasW` linearly.
- *
- * `outputAspect` is optional so existing callers that only know the v1
- * "source matches input" model keep working — they pass nothing and get
- * the old uniform-padding behaviour.
+ * Device-pixel rect of the video region inside a `containerW × containerH`
+ * element. The container's aspect tracks `outputAspect`, so source-pixel offsets
+ * map through `containerW / canvasW` linearly. `outputAspect` defaults to the v1
+ * "source matches input" model for callers that don't pass it.
  */
 export function videoRectPx(
 	containerW: number,

--- a/apps/desktop/src/lib/assets.ts
+++ b/apps/desktop/src/lib/assets.ts
@@ -1,18 +1,15 @@
 /**
  * External-asset download/cache helper.
  *
- * Flow on startup:
- *   1. `hydrateCachedAssets()` — synchronous (no network) read of the on-disk
- *      lock file. Populates the store with whatever is already cached so the
- *      UI upgrades past the CSS placeholder the moment it paints, even when
- *      the user is offline.
- *   2. `ensureAssetsInstalled(manifestUrl)` — network fetch of the manifest,
- *      then SHA-256-verified download of missing/mismatched assets. Thumbs
- *      download first (tiny) so the picker grid becomes usable fast.
- *   3. On `window.online` — retry any failed downloads automatically.
+ * Startup flow:
+ *   1. `hydrateCachedAssets()` — offline read of the on-disk lock file, so the
+ *      UI upgrades past the placeholder immediately.
+ *   2. `ensureAssetsInstalled(manifestUrl)` — fetch manifest, SHA-256-verified
+ *      download of missing/mismatched assets (thumbs first so the grid is usable).
+ *   3. On `window.online` — retry failed downloads.
  *
- * Manifest URL comes from `PUBLIC_ASSETS_MANIFEST_URL` (Vite env). Falls back
- * to the main `wallpapers-v1` release so dev builds work out of the box.
+ * Manifest URL from `PUBLIC_ASSETS_MANIFEST_URL`, falling back to the
+ * `wallpapers-v1` release so dev builds work out of the box.
  */
 
 import { isTauriApp } from "$lib/runtime/tauri";
@@ -81,11 +78,9 @@ async function runInstall(): Promise<void> {
 }
 
 /**
- * Decode every wallpaper thumbnail into the WebView image cache so the first
- * opening of the BackgroundPicker grid doesn't have to schedule 6+ decode
- * tasks at once. Runs at idle priority — never blocks a paint frame, never
- * touches the network (URLs point at `http://asset.localhost/...` paths
- * already cached on disk by `ensureAssetsInstalled`).
+ * Pre-decode wallpaper thumbnails into the WebView image cache so first opening
+ * of the BackgroundPicker grid isn't a burst of decodes. Idle priority; URLs are
+ * already-cached `asset.localhost` paths, so no network.
  */
 function warmThumbnailCache() {
 	if (typeof window === "undefined") return;

--- a/apps/desktop/src/lib/camera/browser-devices.ts
+++ b/apps/desktop/src/lib/camera/browser-devices.ts
@@ -1,11 +1,7 @@
-// Browser-side camera enumeration. The Rust ffmpeg/dshow enumeration returns
-// DirectShow friendly names, but the WebView's getUserMedia operates on
-// MediaDevices deviceIds. When those disagree (e.g., Phone Link or other
-// virtual cameras registered ahead of the real webcam), passing a DirectShow
-// name to getUserMedia silently fails and falling back to `video: true` lets
-// the browser pick its own default — which on Windows is often Phone Link.
-//
-// Use this module everywhere the WebView needs to open a specific camera.
+// Browser-side camera enumeration. Rust enumerates DirectShow friendly names but
+// getUserMedia operates on MediaDevices deviceIds; when they disagree, passing a
+// DirectShow name silently fails and `video: true` lets the browser pick its own
+// default (often Phone Link on Windows). Use this module to open a specific camera.
 
 const VIRTUAL_CAMERA_PATTERNS: RegExp[] = [
 	/phone\s*link/i,
@@ -35,15 +31,12 @@ export function isVirtualCameraLabel(label: string): boolean {
 }
 
 /**
- * Why camera enumeration couldn't produce a usable device — but only for the
- * cases that are a *blocker* rather than simply "no hardware":
- *   - `unavailable` → the WebView exposes no MediaDevices API at all (macOS
- *     WKWebView without NSCameraUsageDescription, or Linux WebKitGTK with
- *     media-stream off). A build/permission misconfig, not the user's doing.
- *   - `denied` → a camera exists but the OS/WebView refused capture (the user,
- *     or a policy, blocked access).
- * An empty result with NO error means genuinely no camera is connected;
- * callers distinguish that from these two so the UI can say the right thing.
+ * Why enumeration couldn't produce a usable device — only the *blocker* cases:
+ *   - `unavailable` → no MediaDevices API at all (macOS WKWebView without
+ *     NSCameraUsageDescription, or Linux WebKitGTK with media-stream off).
+ *   - `denied` → a camera exists but capture was refused.
+ * An empty result with NO error means genuinely no camera connected; callers
+ * distinguish that case so the UI can say the right thing.
  */
 export type CameraAccessReason = "unavailable" | "denied";
 
@@ -65,13 +58,10 @@ function isPermissionDenied(e: unknown): boolean {
 }
 
 /**
- * The WebView exposes no `navigator.mediaDevices` at all. On macOS this is
- * what WKWebView does when the bundle declares no `NSCameraUsageDescription`
- * (see src-tauri/Info.plist); on Linux it's WebKitGTK with `enable-media-stream`
- * off (see `enable_webview_media` in lib.rs). The whole MediaDevices API is
- * stripped rather than prompting, so enumerate/getUserMedia would throw the
- * opaque "undefined is not an object" instead of a real error. Surface
- * something the user can act on.
+ * Guard against the WebView stripping `navigator.mediaDevices` entirely (macOS
+ * WKWebView without NSCameraUsageDescription; Linux WebKitGTK with media-stream
+ * off). Without this the API throws an opaque "undefined is not an object"
+ * instead of an actionable error.
  */
 function assertMediaDevices(): MediaDevices {
 	const media = navigator.mediaDevices;
@@ -94,9 +84,8 @@ function assertMediaDevices(): MediaDevices {
 export async function enumerateCameras(): Promise<BrowserCamera[]> {
 	const media = assertMediaDevices();
 	let devices = await media.enumerateDevices();
-	// No videoinput entry at all → no camera is connected. Return empty (the
-	// "none" case) rather than probing — getUserMedia on absent hardware would
-	// either no-op or pop a needless prompt. Callers render "no camera found".
+	// No videoinput → no camera connected. Return empty rather than probing,
+	// which would no-op or pop a needless prompt.
 	if (!devices.some((d) => d.kind === "videoinput")) return [];
 
 	const labelsPopulated = devices.some(
@@ -104,7 +93,7 @@ export async function enumerateCameras(): Promise<BrowserCamera[]> {
 	);
 	if (!labelsPopulated) {
 		// Labels stay blank until capture is authorized once. Probe to unlock
-		// them — and to turn a silent block into an explicit, actionable error.
+		// them, and to surface a silent block as an actionable error.
 		try {
 			const probe = await media.getUserMedia({ video: true });
 			probe.getTracks().forEach((t) => t.stop());
@@ -115,8 +104,7 @@ export async function enumerateCameras(): Promise<BrowserCamera[]> {
 					"Camera access is blocked. Allow it in your system settings, then rescan.",
 				);
 			}
-			// NotReadableError (device busy) and friends are non-fatal: fall
-			// through and return the (still-unlabeled) device so it's visible.
+			// Device-busy and friends are non-fatal: keep the unlabeled device.
 			console.warn("[camera] label probe failed:", e);
 		}
 		devices = await media.enumerateDevices();

--- a/apps/desktop/src/lib/canvas-geometry.ts
+++ b/apps/desktop/src/lib/canvas-geometry.ts
@@ -1,21 +1,15 @@
-// Canvas geometry helper shared by the editor preview and (mirrored in)
-// the Rust export pipeline. Both must agree on canvas dimensions and the
-// position of the source-plus-padding inside that canvas, otherwise
-// preview and exported MP4 disagree on framing.
+// Canvas geometry shared with (mirrored in) the Rust export pipeline. Both MUST
+// agree on canvas dims and comp position or preview and exported MP4 disagree on
+// framing.
 //
-// The model:
-//   1. compW × compH = source video dims plus uniform `padding` on every
-//      side (the v1 "comp" rectangle).
-//   2. If outputAspect is `source`, the final canvas equals comp.
-//   3. Otherwise we extend whichever axis is too short to satisfy the
-//      target aspect ratio. The comp stays centred; the new bars on
-//      either side (horizontal or vertical, never both) get filled by
-//      the chosen background.
+// Model:
+//   1. comp = source dims + uniform `padding` on every side (the v1 rectangle).
+//   2. outputAspect `source` → canvas equals comp.
+//   3. Otherwise extend whichever axis is too short for the target aspect; the
+//      comp stays centred, new bars (one axis only) filled by the background.
 //
-// We never CROP the comp — only extend the canvas around it. That keeps
-// every annotation, cursor, focus region, and shadow in their original
-// source-pixel coordinates, so re-targeting between aspect ratios doesn't
-// invalidate any per-source data.
+// We never CROP the comp — only extend around it — so every annotation, cursor,
+// and focus region keeps its source-pixel coordinates across aspect changes.
 
 import { aspectRatio, type OutputAspect } from "$lib/stores/editor-store.svelte";
 
@@ -51,11 +45,8 @@ export function paddingPxFromPercent(
 }
 
 /**
- * Compute the canvas geometry for a given source size, padding %, and
- * aspect target. Pure — same inputs always produce the same output.
- *
- * Source pixels are integer-aligned because downstream encoders (FFmpeg,
- * the WebGL render buffer) are happier with even integer dims.
+ * Compute canvas geometry for a source size, padding %, and aspect target. Pure.
+ * Dims are even-integer-aligned because downstream encoders require it.
  */
 export function computeCanvasGeometry(
 	srcW: number,
@@ -83,10 +74,8 @@ export function computeCanvasGeometry(
 		}
 	}
 
-	// Even-dim alignment. Some H.264 profiles refuse odd dims, and the
-	// FFmpeg pad filter is happier when the offset is integer. The +1/&~1
-	// rounding lifts to the next even pixel without ever shrinking below
-	// the comp.
+	// Round up to the next even pixel (H.264 refuses odd dims) without ever
+	// shrinking below the comp.
 	canvasW = (canvasW + 1) & ~1;
 	canvasH = (canvasH + 1) & ~1;
 

--- a/apps/desktop/src/lib/capabilities.ts
+++ b/apps/desktop/src/lib/capabilities.ts
@@ -1,14 +1,10 @@
-// Capture-capability gating for feature entry points.
+// Capture-capability gating: caches the `capture_capabilities` probe and turns an
+// unsupported feature into a ready-to-toast verdict, worded by reason:
+//   - `unsupported` → OS / native API can't do it → "not supported on <os>"
+//   - `planned`     → not shipped here yet → "not available yet"
 //
-// The Settings panel renders the full matrix; this module is the *gate* the
-// rest of the app calls before letting a user turn a capture input on. It
-// caches the one `capture_capabilities` probe and turns an unsupported feature
-// into a ready-to-toast verdict whose wording depends on WHY it's off:
-//   - `unsupported` → the OS / native API can't do it → "not supported on <os>"
-//   - `planned`     → we just haven't shipped it here yet → "not available yet"
-//
-// Fails OPEN: if the probe errors or the key is unknown, the verdict is `ok`
-// so a diagnostic hiccup never blocks a feature that might actually work.
+// Fails OPEN: probe errors or unknown keys verdict `ok`, so a diagnostic hiccup
+// never blocks a feature that might actually work.
 
 import { captureCapabilities, type CaptureCapabilities } from "$lib/ipc";
 
@@ -43,8 +39,7 @@ export async function checkCapability(
 	try {
 		caps = await loadCapabilities();
 	} catch {
-		// Couldn't run the probe — don't punish the user for a diagnostic that
-		// failed; let them try and surface the real error at use time.
+		// Probe failed — let them try and surface the real error at use time.
 		return { ok: true };
 	}
 

--- a/apps/desktop/src/lib/commands.ts
+++ b/apps/desktop/src/lib/commands.ts
@@ -20,12 +20,9 @@ import { GithubBrand } from "@recast/ui/brand-icons";
 import { toast } from "@recast/ui/sonner";
 import { setMode } from "@recast/ui/theme";
 
-// Hand external URLs off to the OS via the Tauri opener plugin. Plain
-// `window.open` in WebView2 opens an in-app popup (often blocked) instead
-// of routing to the user's default browser — which is why palette
-// commands silently did nothing before this helper existed. We dynamic-
-// import so this module stays usable from the web build, which doesn't
-// have the plugin and falls back to a regular `window.open`.
+// Open external URLs via the Tauri opener plugin: `window.open` in WebView2
+// pops an in-app (often blocked) window instead of the default browser. Dynamic
+// import keeps this usable from the web build, which falls back to `window.open`.
 async function openExternal(url: string) {
 	try {
 		const { openUrl } = await import("@tauri-apps/plugin-opener");

--- a/apps/desktop/src/lib/cursor/smoothing.ts
+++ b/apps/desktop/src/lib/cursor/smoothing.ts
@@ -1,12 +1,6 @@
-// Post-recording mouse-path smoothing.
-//
-// Raw captured mouse positions contain tremor and quantisation noise — even
-// a steady hand on a trackpad produces 1-3 px of jitter at idle. Dropping a
-// Gaussian window over the trajectory knocks that out while preserving
-// intentional motion. Anchoring the smoothed curve to exact click x/y around
-// mouse-down events keeps press targets pixel-perfect (Screen Studio's
-// signature trick — otherwise smoothing would round the corner through a
-// click and miss the target visibly).
+// Post-recording mouse-path smoothing: Gaussian window kills tremor/quantisation
+// jitter; anchoring to exact click x/y keeps press targets pixel-perfect
+// (otherwise smoothing rounds the corner through a click and misses the target).
 
 export interface CursorSampleLike {
 	timestampUs: number;
@@ -37,12 +31,7 @@ export interface SmoothResult {
 	clickAnchors: ClickAnchor[];
 }
 
-/**
- * Map the UI strength slider (0..100) to a Gaussian σ in ms.
- * 100 → 150 ms σ, which is heavy-handed but still feels responsive;
- * 50 → 75 ms σ, the sweet spot for typical hand tremor;
- * 0 disables smoothing entirely.
- */
+/** Map the UI strength slider (0..100) to a Gaussian σ in ms (0 disables). */
 export function smoothingStrengthToSigmaMs(strength: number): number {
 	return Math.max(0, Math.min(100, strength)) * 1.5;
 }
@@ -56,8 +45,8 @@ export function smoothCursorPath(
 	raw: CursorSampleLike[],
 	opts: SmoothingOptions
 ): SmoothResult {
-	// Detect click-down transitions regardless of smoothing state — callers
-	// use these for the visualisation even when smoothing is disabled.
+	// Detect click-down transitions even when smoothing is off — callers still
+	// use these for the visualisation.
 	const clickAnchors: ClickAnchor[] = [];
 	for (let i = 1; i < raw.length; i++) {
 		const prev = raw[i - 1];
@@ -77,10 +66,8 @@ export function smoothCursorPath(
 	const windowUs = sigmaUs * 3; // ±3σ catches ~99.7% of the weight
 	const snapUs = Math.max(0, opts.snapWindowMs) * 1000;
 
-	// Gaussian smoothing with a sliding window (lo..hi advances monotonically
-	// because samples are time-sorted). Complexity: O(N · w) where w is the
-	// average samples inside ±3σ — for 120 Hz input and σ=75 ms that's ~54,
-	// so a 5-minute recording smooths in well under 100 ms.
+	// Sliding-window Gaussian; lo..hi advance monotonically because samples are
+	// time-sorted. O(N·w) where w = samples inside ±3σ.
 	const smoothed: CursorSampleLike[] = new Array(raw.length);
 	let lo = 0;
 	let hi = 0;
@@ -116,10 +103,8 @@ export function smoothCursorPath(
 		}
 	}
 
-	// Click anchor: cosine ramp from smoothed → click → smoothed inside the
-	// snap window. falloff=1 at the click timestamp, 0 at the window edge,
-	// so the path glides into the exact click x/y and out again without a
-	// visible seam.
+	// Cosine snap ramp: falloff=1 at the click timestamp, 0 at the window edge,
+	// so the path glides into the exact click x/y and out without a seam.
 	if (opts.snapToClicks && snapUs > 0 && clickAnchors.length > 0) {
 		for (const anchor of clickAnchors) {
 			for (let i = 0; i < smoothed.length; i++) {

--- a/apps/desktop/src/lib/cursor/styles.ts
+++ b/apps/desktop/src/lib/cursor/styles.ts
@@ -1,27 +1,12 @@
 /**
- * Curated cursor sprite library. Each style is an SVG so we can recolour and
- * resample at any DPI without bundling pixel assets.
+ * Cursor sprite library. SVGs so we can recolour/resample at any DPI without
+ * pixel assets. Add a variant by dropping an `.svg` into `./sprites/` and
+ * referencing its bare filename via `sprite()` in `CURSOR_STYLES`.
  *
- * The sprite art lives as standalone files under `./sprites/*.svg` and is
- * pulled in at build time via `import.meta.glob` (`?raw`), so adding a new
- * variant is just: drop an `.svg` into `./sprites/`, then add a manifest entry
- * to `CURSOR_STYLES` below referencing it by bare filename through `sprite()`.
- * No string editing, no import bookkeeping.
- *
- * Coordinate system: every sprite is authored at 64×64 with the *click
- * hotspot* at `hotspot` (in sprite-space px). The preview overlay applies
- * `transform: translate(-hotspotX, -hotspotY)` so the cursor's tip lands on
- * the captured pointer position regardless of which sprite is selected.
- * Strokes use round joins/caps and inline filters for soft drop shadows so
- * every variant reads cleanly at the 32–96 px rendered scale users see in
- * playback. Filters are scoped via unique IDs to avoid clashes when multiple
- * sprites end up in the DOM.
- *
- * `dot` is the historical soft-circle path, drawn by the WebGL2 shader and
- * the Rust export overlay. `macos` adds an Apple-style cursor with two
- * sprites: the arrow shown at rest, and the link-pointing hand swapped in
- * while the captured cursor is mid-click. Per-state lookup happens via
- * `cursorStyleDataUrl(id, "press" | "rest")`.
+ * Every sprite is authored at 64×64 with its click hotspot at `hotspot`
+ * (sprite-space px); the overlay translates by `-hotspot` so the tip lands on
+ * the captured pointer position. Drop-shadow filters use unique IDs to avoid
+ * clashing when multiple sprites share the DOM.
  */
 
 import type { CursorStyleId } from "$lib/stores/editor-store.svelte";
@@ -47,19 +32,15 @@ export interface CursorStyle {
   dragHotspot?: { x: number; y: number };
 }
 
-// Eagerly load every sprite as a raw SVG string at build time, keyed by its
-// path (e.g. "./sprites/macos-arrow.svg"). Bundled into the build — no runtime
-// filesystem access, so it works unchanged inside the Tauri WebView.
+// Raw SVG strings inlined at build time (no runtime fs access), keyed by path.
 const spriteModules = import.meta.glob<string>("./sprites/*.svg", {
   query: "?raw",
   import: "default",
   eager: true,
 });
 
-/** Resolve a sprite by its bare filename (no `./sprites/` prefix or `.svg`
- *  extension). Throws loudly at module init if a manifest entry points at a
- *  file that doesn't exist, so a typo surfaces immediately in dev rather than
- *  silently rendering an empty cursor. */
+/** Resolve a sprite by bare filename. Throws at module init on a missing file
+ *  so a typo surfaces immediately instead of rendering an empty cursor. */
 function sprite(name: string): string {
   const svg = spriteModules[`./sprites/${name}.svg`];
   if (!svg) {
@@ -77,15 +58,13 @@ export const CURSOR_STYLES: CursorStyle[] = [
     id: "dot",
     label: "Soft dot",
     description: "Default cursor, used in preview and export.",
-    // The actual `dot` cursor is drawn by the WebGL2 shader; this SVG is
-    // only the picker swatch.
+    // `dot` is drawn by the WebGL2 shader; this SVG is only the picker swatch.
     svg: sprite("dot"),
     hotspot: { x: 32, y: 32 },
   },
   {
-    // System-accurate Apple cursor set. rest=arrow, press=link hand,
-    // rightPress=contextual menu, drag=grab. Hotspots anchored to each
-    // sprite's tip/grab point. See ./sprites/CREDITS.md for attribution.
+    // Apple cursor set: rest=arrow, press=link hand, rightPress=context, drag=grab.
+    // See ./sprites/CREDITS.md for attribution.
     id: "macos-system",
     label: "macOS System",
     description: "Apple cursor set: arrow, link hand, grab, and right-click states.",
@@ -99,9 +78,9 @@ export const CURSOR_STYLES: CursorStyle[] = [
     dragHotspot: { x: 32, y: 32 },
   },
   {
-    // System-accurate Windows cursor set. Windows has no distinct right-click
-    // cursor, so rightPress falls back to press → rest. drag uses the 4-way
-    // move cursor. See ./sprites/CREDITS.md for attribution.
+    // Windows cursor set. No distinct right-click cursor, so rightPress falls
+    // back to press → rest; drag uses the 4-way move cursor.
+    // See ./sprites/CREDITS.md for attribution.
     id: "windows-system",
     label: "Windows System",
     description: "Windows cursor set: arrow, link hand, and move (drag) states.",

--- a/apps/desktop/src/lib/cursor/styles.ts
+++ b/apps/desktop/src/lib/cursor/styles.ts
@@ -76,7 +76,7 @@ export const CURSOR_STYLES: CursorStyle[] = [
   {
     id: "dot",
     label: "Soft dot",
-    description: "Default — used for both preview and export.",
+    description: "Default cursor, used in preview and export.",
     // The actual `dot` cursor is drawn by the WebGL2 shader; this SVG is
     // only the picker swatch.
     svg: sprite("dot"),
@@ -88,7 +88,7 @@ export const CURSOR_STYLES: CursorStyle[] = [
     // sprite's tip/grab point. See ./sprites/CREDITS.md for attribution.
     id: "macos-system",
     label: "macOS System",
-    description: "System-accurate Apple set — arrow, link hand, grab, and right-click states.",
+    description: "Apple cursor set: arrow, link hand, grab, and right-click states.",
     svg: sprite("system-macos-arrow"),
     pressedSvg: sprite("system-macos-pointer"),
     rightPressedSvg: sprite("system-macos-context"),
@@ -104,7 +104,7 @@ export const CURSOR_STYLES: CursorStyle[] = [
     // move cursor. See ./sprites/CREDITS.md for attribution.
     id: "windows-system",
     label: "Windows System",
-    description: "System-accurate Windows set — arrow, link hand, and move (drag) states.",
+    description: "Windows cursor set: arrow, link hand, and move (drag) states.",
     svg: sprite("system-windows-arrow"),
     pressedSvg: sprite("system-windows-hand"),
     dragSvg: sprite("system-windows-move"),

--- a/apps/desktop/src/lib/easing/cubic-bezier.ts
+++ b/apps/desktop/src/lib/easing/cubic-bezier.ts
@@ -1,9 +1,6 @@
-// Unit-interval cubic-bezier evaluator. Given the two middle control points
-// (x1, y1) and (x2, y2) with implicit anchors P0=(0,0) and P3=(1,1), returns
-// y for a given x. Same algorithm as Blink / WebKit: solve x(t)=x via
-// Newton-Raphson with a bisection fallback, then evaluate y(t).
-//
-// y may exceed [0,1] for overshoot curves (e.g. Bounce) — that's intentional.
+// Unit-interval cubic-bezier evaluator (implicit anchors P0=(0,0), P3=(1,1)),
+// returns y for a given x. Same as Blink/WebKit: solve x(t)=x via Newton-Raphson
+// with a bisection fallback. y may exceed [0,1] for overshoot curves (e.g. Bounce).
 
 export interface Easing {
 	x1: number;

--- a/apps/desktop/src/lib/env.ts
+++ b/apps/desktop/src/lib/env.ts
@@ -1,14 +1,10 @@
 /**
- * Build-time env for the desktop frontend. Only `PUBLIC_*` vars are exposed to
- * the webview (see `envPrefix` in vite.config.ts). The `PUBLIC_` prefix is
- * shared with the Rust backend — Rust reads the exact same `PUBLIC_POSTHOG_*`
- * names (telemetry.rs) — and matches the web app's convention. When
- * `PUBLIC_POSTHOG_KEY` is absent the analytics client is a no-op — same
- * "missing config disables it" rule the web app and storage layer use.
+ * Build-time env for the desktop frontend. Only `PUBLIC_*` vars reach the webview
+ * (see `envPrefix` in vite.config.ts). Rust reads the same `PUBLIC_POSTHOG_*` names
+ * (telemetry.rs). Absent `PUBLIC_POSTHOG_KEY` makes the analytics client a no-op.
  */
 export const POSTHOG_KEY: string | undefined = import.meta.env.PUBLIC_POSTHOG_KEY;
-// `||` (not `??`) so an empty string — e.g. an unset CI secret written as
-// `PUBLIC_POSTHOG_HOST=` — still falls back to the default rather than an empty
-// host. Mirrors the Rust side's `filter(|s| !s.is_empty())`.
+// `||` (not `??`) so an empty string (e.g. `PUBLIC_POSTHOG_HOST=`) falls back to
+// the default. Mirrors the Rust side's `filter(|s| !s.is_empty())`.
 export const POSTHOG_HOST: string =
 	import.meta.env.PUBLIC_POSTHOG_HOST || "https://eu.i.posthog.com";

--- a/apps/desktop/src/lib/export/rasterize-cursor.ts
+++ b/apps/desktop/src/lib/export/rasterize-cursor.ts
@@ -1,16 +1,10 @@
 /**
  * Hybrid-raster export path for the SVG cursor sprite.
  *
- * Same pattern as `rasterize-text.ts`: the Rust export pipeline can decode
- * `data:image/png;base64,…` URLs (via `build_image_cache` in cursor_export.rs)
- * but has no SVG renderer. So at export start we rasterize each cursor sprite
- * (rest + optional pressed state) once via an offscreen canvas and ship the
- * resulting PNG data URLs through `RenderState`. Rust composites them per
- * frame at the cursor sample's canvas position.
- *
- * Rasterizing once per export amortises the SVG decode cost across thousands
- * of frames, and reuses the existing PNG decode + alpha-blend path on the
- * Rust side instead of bringing in a new sprite codec.
+ * Same pattern as `rasterize-text.ts`: Rust decodes `data:image/png;base64,…`
+ * URLs but has no SVG renderer, so we rasterize each cursor sprite once via an
+ * offscreen canvas and ship PNG data URLs through `RenderState`. Rust composites
+ * them per frame. Rasterizing once amortises the SVG decode across all frames.
  */
 
 import { resolveCursorSprite } from "$lib/registry";
@@ -39,9 +33,8 @@ export interface CursorSpriteBundle {
 	pixelSize: number;
 }
 
-// Re-rasterizing the same sprite twice in a row is wasted work — the SVG
-// strings and the requested size don't change between consecutive exports
-// of the same project. Key by `${style}:${size}`.
+// Keyed by `${style}:${size}` — SVG strings and size don't change between
+// consecutive exports of the same project.
 const cache = new Map<string, CursorSpriteBundle>();
 
 /**

--- a/apps/desktop/src/lib/export/rasterize-text.ts
+++ b/apps/desktop/src/lib/export/rasterize-text.ts
@@ -1,26 +1,18 @@
 /**
  * Hybrid-raster export path for text annotations.
  *
- * The Rust export pipeline (cursor_export.rs / draw_annotation) does not know
- * how to render text — it has no font rasterizer. To keep the Rust side
- * simple, every text annotation is rendered to a transparent PNG by the
- * WebView (which already has full font support), then sent across IPC as a
- * data URL on a synthetic image-kind annotation.
- *
- * This module is invoked from the export trigger (handleExport) right before
- * the renderState payload reaches `invoke("export_video", ...)`. Non-text
- * annotations pass through untouched.
+ * Rust has no font rasterizer, so each text annotation is rendered to a
+ * transparent PNG by the WebView and sent across IPC as a data URL on a
+ * synthetic image-kind annotation. Invoked from handleExport before the
+ * renderState reaches `invoke("export_video", ...)`; non-text passes through.
  */
 import type { Annotation } from "$lib/stores/editor-store.svelte";
 
 /**
- * Walk the annotations and replace every text annotation with an image
- * annotation whose `path` is a `data:image/png;base64,…` URL containing a
- * pre-rendered transparent PNG of the text.
+ * Replace every text annotation with an image annotation whose `path` is a
+ * `data:image/png;base64,…` URL of the pre-rendered transparent PNG.
  *
- * @param annotations  Annotation list as it would appear in toRenderState.
  * @param canvasWidth  Pixel width of the export canvas (source.width + 2*padding).
- * @param canvasHeight Pixel height of the export canvas.
  */
 export async function expandTextAnnotations<
   T extends Pick<Annotation, "kind">,
@@ -35,8 +27,7 @@ export async function expandTextAnnotations<
     const k = a.kind;
     const dataUrl = await renderTextToDataUrl(k, canvasWidth, canvasHeight);
     if (!dataUrl) {
-      // Drop the annotation rather than fail the export; surface a console
-      // hint so debug builds notice.
+      // Drop the annotation rather than fail the whole export.
       console.warn(
         "rasterize-text: failed to render text annotation, skipping",
         k.content,

--- a/apps/desktop/src/lib/extensions.ts
+++ b/apps/desktop/src/lib/extensions.ts
@@ -35,9 +35,8 @@ export interface RegistryIndexEntry {
 	iconUrl?: string;
 }
 
-/** Compare two `x.y.z` versions. Returns -1 / 0 / 1 (a<b / a==b / a>b). Pack
- *  versions are strict semver per the schema, so a numeric 3-part compare is
- *  enough — pre-release suffixes aren't used. */
+/** Compare two `x.y.z` versions → -1 / 0 / 1. Numeric 3-part compare is enough:
+ *  pack versions are strict semver with no pre-release suffixes. */
 export function compareSemver(a: string, b: string): number {
 	const pa = a.split(".").map((n) => Number.parseInt(n, 10) || 0);
 	const pb = b.split(".").map((n) => Number.parseInt(n, 10) || 0);
@@ -150,9 +149,8 @@ export async function loadRegistryIndex<T = unknown>(): Promise<T | null> {
 	}
 }
 
-/** Fetch a pack's full manifest (contributes + assets) for the details preview
- *  before install. Reuses the URL-allowlisted fetch the registry browse uses, so
- *  the same https/localhost gate applies. Returns null on any failure. */
+/** Fetch a pack's full manifest for the pre-install details preview. Reuses the
+ *  URL-allowlisted registry fetch, so the same https/localhost gate applies. */
 export async function fetchManifestPreview(
 	manifestUrl: string,
 ): Promise<ExtensionManifest | null> {

--- a/apps/desktop/src/lib/feature-flags.ts
+++ b/apps/desktop/src/lib/feature-flags.ts
@@ -1,28 +1,18 @@
 /**
  * Feature flags for in-progress / platform-gated functionality.
  *
- * These flags gate UI surfaces only — the underlying capture, render, and
- * export pipelines remain wired up. Flipping a flag back to `true` should
- * re-enable the feature without any code changes elsewhere.
- *
- * If you're touching one of these, also read the matching design note under
- * `apps/desktop/docs/`.
+ * These gate UI surfaces only — capture/render/export stay wired up, so
+ * flipping a flag back to `true` re-enables the feature without other changes.
+ * See the matching design note under `apps/desktop/docs/`.
  */
 
 /**
- * Editor-side camera overlay UI (properties panel tab + draggable overlay
- * on the preview canvas).
- *
- * Recording with the camera still works — the bubble is captured to a
- * separate track in the .recast bundle exactly as before. This flag only
- * hides the editor controls for re-positioning, mirroring, shape, size,
- * etc. Re-enable plan + per-platform exclusion APIs (the eventual fix for
- * the floating preview window leaking into screen capture) are documented
- * in `apps/desktop/docs/camera-recording-todo.md`.
+ * Editor-side camera overlay UI (properties tab + draggable preview overlay).
+ * Recording with the camera still works; this only hides the editor controls.
+ * Re-enable plan + per-platform exclusion APIs are documented in
+ * `apps/desktop/docs/camera-recording-todo.md`.
  */
 export const CAMERA_OVERLAY_UI_ENABLED = false;
 
-// NOTE: the WebCodecs preview engine toggle moved to the experimental-features
-// store (`experimentalStore.webcodecsPreview`) so users can flip it at runtime
-// from Settings → Experimental and compare it against the classic `<video>`
-// engine. See `$lib/stores/experimental.svelte`.
+// The WebCodecs preview toggle now lives in the experimental-features store
+// (`experimentalStore.webcodecsPreview`) — see `$lib/stores/experimental.svelte`.

--- a/apps/desktop/src/lib/format/bytes.test.ts
+++ b/apps/desktop/src/lib/format/bytes.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { formatBytes } from "./bytes";
+
+describe("formatBytes", () => {
+	it("returns the zero label for falsy/negative", () => {
+		expect(formatBytes(0)).toBe("0 B");
+		expect(formatBytes(undefined)).toBe("0 B");
+		expect(formatBytes(-1)).toBe("0 B");
+		expect(formatBytes(0, "--")).toBe("--");
+	});
+	it("keeps bytes whole and scales up by 1024", () => {
+		expect(formatBytes(512)).toBe("512 B");
+		expect(formatBytes(1024)).toBe("1.0 KB");
+		expect(formatBytes(1536)).toBe("1.5 KB");
+		expect(formatBytes(1048576)).toBe("1.0 MB");
+		expect(formatBytes(1.4 * 1024 ** 3)).toBe("1.4 GB");
+	});
+	it("drops the decimal at/above 10 of a unit", () => {
+		expect(formatBytes(15 * 1024 * 1024)).toBe("15 MB");
+	});
+});

--- a/apps/desktop/src/lib/format/bytes.ts
+++ b/apps/desktop/src/lib/format/bytes.ts
@@ -1,10 +1,6 @@
 /**
- * Human-readable byte size up to TB, e.g. `1.4 GB`, `932 MB`, `84 KB`. Shared by
- * InfoPanel and CloudSignIn (which had identical maths, differing only in the
- * zero/empty placeholder — hence `zeroLabel`).
- *
- * Distinct from `formatSize` in `./files.ts`, which is the MB-capped file-listing
- * variant; keep both.
+ * Human-readable byte size up to TB, e.g. `1.4 GB`. `zeroLabel` is the
+ * zero/empty placeholder. Distinct from the MB-capped `formatSize` in `./files.ts`.
  */
 export function formatBytes(
 	bytes: number | undefined,

--- a/apps/desktop/src/lib/format/bytes.ts
+++ b/apps/desktop/src/lib/format/bytes.ts
@@ -1,0 +1,22 @@
+/**
+ * Human-readable byte size up to TB, e.g. `1.4 GB`, `932 MB`, `84 KB`. Shared by
+ * InfoPanel and CloudSignIn (which had identical maths, differing only in the
+ * zero/empty placeholder — hence `zeroLabel`).
+ *
+ * Distinct from `formatSize` in `./files.ts`, which is the MB-capped file-listing
+ * variant; keep both.
+ */
+export function formatBytes(
+	bytes: number | undefined,
+	zeroLabel = "0 B",
+): string {
+	if (!bytes || bytes < 0) return zeroLabel;
+	const units = ["B", "KB", "MB", "GB", "TB"];
+	let i = 0;
+	let v = bytes;
+	while (v >= 1024 && i < units.length - 1) {
+		v /= 1024;
+		i++;
+	}
+	return `${v.toFixed(v >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+}

--- a/apps/desktop/src/lib/format/files.test.ts
+++ b/apps/desktop/src/lib/format/files.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatShortDate,
+	formatSize,
+	getExtension,
+	relativeDate,
+} from "./files";
+
+describe("formatSize", () => {
+	it("renders bytes below 1 KiB verbatim", () => {
+		expect(formatSize(0)).toBe("0 B");
+		expect(formatSize(512)).toBe("512 B");
+		expect(formatSize(1023)).toBe("1023 B");
+	});
+	it("renders KiB and MiB with one decimal", () => {
+		expect(formatSize(1024)).toBe("1.0 KB");
+		expect(formatSize(1536)).toBe("1.5 KB");
+		expect(formatSize(1048576)).toBe("1.0 MB");
+		expect(formatSize(5 * 1048576)).toBe("5.0 MB");
+	});
+});
+
+describe("getExtension", () => {
+	it("upper-cases the extension after the last dot", () => {
+		expect(getExtension("clip.mp4")).toBe("MP4");
+		expect(getExtension("archive.tar.gz")).toBe("GZ");
+	});
+	it("falls back to FILE when there's no extension", () => {
+		expect(getExtension("README")).toBe("FILE");
+	});
+});
+
+describe("relativeDate", () => {
+	// 2024-01-01T00:00:00Z in epoch seconds, with a fixed `now` reference so the
+	// thresholds are deterministic.
+	const base = Date.UTC(2024, 0, 1) / 1000;
+	const now = (base + 0) * 1000;
+
+	it("returns 'just now' under a minute", () => {
+		expect(relativeDate(base - 30, { now })).toBe("just now");
+	});
+	it("returns minute / hour / day buckets", () => {
+		expect(relativeDate(base - 120, { now })).toBe("2m ago");
+		expect(relativeDate(base - 3 * 3600, { now })).toBe("3h ago");
+		expect(relativeDate(base - 2 * 86400, { now })).toBe("2d ago");
+	});
+	it("falls back to an absolute date past a week", () => {
+		const old = base - 30 * 86400;
+		expect(relativeDate(old, { now })).toBe(formatShortDate(old));
+	});
+});

--- a/apps/desktop/src/lib/format/files.ts
+++ b/apps/desktop/src/lib/format/files.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure formatters for file listings (recordings, exports, the home activity
+ * strips). These were copy-pasted across the library route pages; they live
+ * here now so the behaviour is defined once and is unit-testable.
+ */
+
+/** Human-readable byte size, e.g. `1.5 MB`. Caps at MB (recordings/exports). */
+export function formatSize(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / 1048576).toFixed(1)} MB`;
+}
+
+/** Upper-case file extension, e.g. `MP4`; `FILE` when there's no dot. */
+export function getExtension(filename: string): string {
+	const dot = filename.lastIndexOf(".");
+	return dot >= 0 ? filename.slice(dot + 1).toUpperCase() : "FILE";
+}
+
+/** Absolute short date, e.g. `Apr 10`. `unix` is epoch SECONDS. */
+export function formatShortDate(unix: number): string {
+	return new Date(unix * 1000).toLocaleDateString(undefined, {
+		month: "short",
+		day: "numeric",
+	});
+}
+
+/** Absolute date + time, e.g. `Apr 10, 02:15 PM`. `unix` is epoch SECONDS. */
+export function formatDateTime(unix: number): string {
+	return new Date(unix * 1000).toLocaleDateString(undefined, {
+		month: "short",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}
+
+/**
+ * Relative age: `just now` / `5m ago` / `2h ago` / `3d ago`, then an absolute
+ * date once older than a week. `unix` is epoch SECONDS.
+ *
+ * `now` is the reference epoch in MILLISECONDS (default `Date.now()`); pass a
+ * reactive clock at the call site to make the label tick over time. `withTime`
+ * picks the >1-week fallback format (date+time vs short date) — the two callers
+ * historically differed here, so it's explicit rather than guessed.
+ */
+export function relativeDate(
+	unix: number,
+	opts: { now?: number; withTime?: boolean } = {},
+): string {
+	const now = opts.now ?? Date.now();
+	const diff = now / 1000 - unix;
+	if (diff < 60) return "just now";
+	if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+	if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+	if (diff < 86400 * 7) return `${Math.floor(diff / 86400)}d ago`;
+	return opts.withTime ? formatDateTime(unix) : formatShortDate(unix);
+}

--- a/apps/desktop/src/lib/format/files.ts
+++ b/apps/desktop/src/lib/format/files.ts
@@ -1,8 +1,4 @@
-/**
- * Pure formatters for file listings (recordings, exports, the home activity
- * strips). These were copy-pasted across the library route pages; they live
- * here now so the behaviour is defined once and is unit-testable.
- */
+/** Pure formatters for file listings (recordings, exports, activity strips). */
 
 /** Human-readable byte size, e.g. `1.5 MB`. Caps at MB (recordings/exports). */
 export function formatSize(bytes: number): string {
@@ -36,13 +32,9 @@ export function formatDateTime(unix: number): string {
 }
 
 /**
- * Relative age: `just now` / `5m ago` / `2h ago` / `3d ago`, then an absolute
- * date once older than a week. `unix` is epoch SECONDS.
- *
- * `now` is the reference epoch in MILLISECONDS (default `Date.now()`); pass a
- * reactive clock at the call site to make the label tick over time. `withTime`
- * picks the >1-week fallback format (date+time vs short date) — the two callers
- * historically differed here, so it's explicit rather than guessed.
+ * Relative age (`just now` / `5m ago` / `3d ago`), then an absolute date past a
+ * week. `unix` is epoch SECONDS; `now` is the reference epoch in MILLISECONDS
+ * (default `Date.now()`). `withTime` picks the >1-week fallback format.
  */
 export function relativeDate(
 	unix: number,

--- a/apps/desktop/src/lib/format/time.test.ts
+++ b/apps/desktop/src/lib/format/time.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { clock, clockCentis, clockDecis, compactDuration } from "./time";
+
+describe("clock (M:SS)", () => {
+	it("formats minutes and zero-padded seconds", () => {
+		expect(clock(0)).toBe("0:00");
+		expect(clock(5)).toBe("0:05");
+		expect(clock(65)).toBe("1:05");
+		expect(clock(600)).toBe("10:00");
+	});
+	it("clamps negatives and non-finite to zero", () => {
+		expect(clock(-3)).toBe("0:00");
+		expect(clock(NaN)).toBe("0:00");
+		expect(clock(Infinity)).toBe("0:00");
+	});
+});
+
+describe("clockCentis (M:SS.cc)", () => {
+	it("truncates centiseconds", () => {
+		expect(clockCentis(0)).toBe("0:00.00");
+		expect(clockCentis(5.239)).toBe("0:05.23");
+		expect(clockCentis(65.5)).toBe("1:05.50");
+	});
+	it("renders zero for non-finite (the old ExportDialog guard)", () => {
+		expect(clockCentis(NaN)).toBe("0:00.00");
+		expect(clockCentis(-1)).toBe("0:00.00");
+	});
+});
+
+describe("clockDecis (M:SS.d)", () => {
+	it("formats one decimal of seconds, zero-padded", () => {
+		expect(clockDecis(5.24)).toBe("0:05.2");
+		expect(clockDecis(65)).toBe("1:05.0");
+	});
+});
+
+describe("compactDuration", () => {
+	it("uses seconds at/above 1s and ms below", () => {
+		expect(compactDuration(1.5)).toBe("1.5s");
+		expect(compactDuration(0.5)).toBe("500ms");
+		expect(compactDuration(0.04)).toBe("40ms");
+	});
+});

--- a/apps/desktop/src/lib/format/time.ts
+++ b/apps/desktop/src/lib/format/time.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure timecode formatters for the editor panels. These were reinvented in
+ * half a dozen components (FocusPanel, AnnotationsPanel, AudioPanel, InfoPanel,
+ * SilenceReviewPopover, ExportDialog) with subtle drift; they live here now.
+ *
+ * All take a time in SECONDS, clamp negatives to 0, and treat non-finite input
+ * as 0 (so a `NaN` duration renders the zero clock, not `NaN:NaN`). Minutes are
+ * not rolled into hours — recordings are short and the panels never showed an
+ * hours field.
+ */
+
+function safe(sec: number): number {
+	return Number.isFinite(sec) ? Math.max(0, sec) : 0;
+}
+
+/** `M:SS`, e.g. `1:05`. */
+export function clock(sec: number): string {
+	const t = safe(sec);
+	const m = Math.floor(t / 60);
+	const s = Math.floor(t % 60);
+	return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+/** `M:SS.cc` with centiseconds (truncated), e.g. `1:05.23`. */
+export function clockCentis(sec: number): string {
+	const t = safe(sec);
+	const m = Math.floor(t / 60);
+	const s = Math.floor(t % 60);
+	const cs = Math.floor((t % 1) * 100);
+	return `${m}:${s.toString().padStart(2, "0")}.${cs.toString().padStart(2, "0")}`;
+}
+
+/** `M:SS.d` with deciseconds, e.g. `1:05.4`. */
+export function clockDecis(sec: number): string {
+	const t = safe(sec);
+	const m = Math.floor(t / 60);
+	const rem = t - m * 60;
+	return `${m}:${rem.toFixed(1).padStart(4, "0")}`;
+}
+
+/** Compact duration: `1.5s` at/above a second, else `500ms`. */
+export function compactDuration(sec: number): string {
+	return sec >= 1 ? `${sec.toFixed(1)}s` : `${Math.round(sec * 1000)}ms`;
+}

--- a/apps/desktop/src/lib/format/time.ts
+++ b/apps/desktop/src/lib/format/time.ts
@@ -1,12 +1,7 @@
 /**
- * Pure timecode formatters for the editor panels. These were reinvented in
- * half a dozen components (FocusPanel, AnnotationsPanel, AudioPanel, InfoPanel,
- * SilenceReviewPopover, ExportDialog) with subtle drift; they live here now.
- *
- * All take a time in SECONDS, clamp negatives to 0, and treat non-finite input
- * as 0 (so a `NaN` duration renders the zero clock, not `NaN:NaN`). Minutes are
- * not rolled into hours — recordings are short and the panels never showed an
- * hours field.
+ * Pure timecode formatters for the editor panels. All take SECONDS, clamp
+ * negatives to 0, and treat non-finite as 0 (NaN → zero clock, not `NaN:NaN`).
+ * Minutes are never rolled into hours — recordings are short.
  */
 
 function safe(sec: number): number {

--- a/apps/desktop/src/lib/hooks/use-share.svelte.ts
+++ b/apps/desktop/src/lib/hooks/use-share.svelte.ts
@@ -8,10 +8,8 @@ type ShareData = {
   image?: string;
 };
 
-// Accept a getter function: () => ShareData
 export function useShare(getData: () => ShareData) {
-  // Static capability check — `navigator.share` isn't reactive, so read it once
-  // at call time rather than mirroring it into `$state` via an `$effect`.
+  // `navigator.share` isn't reactive — read it once rather than via `$effect`.
   const isNativeShareSupported =
     typeof navigator !== "undefined" && typeof navigator.share === "function";
 

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -1,11 +1,6 @@
 /**
- * Typed IPC wrappers for Tauri backend commands.
- *
- * All invoke() calls should go through these functions instead of using
- * raw invoke() strings. This gives us:
- * - Type safety for arguments and return values
- * - Single place to update if command signatures change
- * - Better IDE autocomplete
+ * Typed IPC wrappers for Tauri backend commands. All `invoke()` calls route
+ * through here so argument/return types live in one place.
  */
 
 import type { EditorRenderState, VideoMetadata } from "$lib/stores/editor-store.svelte";
@@ -15,20 +10,14 @@ import { listen } from "@tauri-apps/api/event";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { platform } from "@tauri-apps/plugin-os";
 
-// `alwaysOnTop` works fine on Windows (DWM handles z-order cleanly) but on
-// some Linux compositors (notably KWin under Wayland) an undecorated,
-// transparent, always-on-top window can hold input focus in a way the user
-// can't break out of — clicks pass through to it instead of the main window
-// behind, so close/minimize/maximize on the main window stop working. Drop
-// the flag on Linux until we have a proper compositor-side fix.
-// Lazy, not a top-level `const` — calling `platform()` at module-eval time
-// would make ipc.ts unsafe to *import* outside the Tauri webview (web build,
-// SSR analysis). Several stores (gdrive/consent/diagnostics) import this module
-// and guard actual calls behind `isTauriApp()`, so the module itself must be
-// import-safe; `platform()` only runs when a window helper actually needs it.
+// Some Linux compositors (KWin/Wayland) let an undecorated transparent
+// always-on-top window trap input focus, breaking the main window's controls —
+// so drop `alwaysOnTop` on Linux. Lazy, not a top-level `const`: calling
+// `platform()` at module-eval time would make this module unsafe to import
+// outside the Tauri webview (web/SSR builds import it but guard calls).
 const isLinux = () => platform() === "linux";
 
-//  Types matching Rust structs 
+// Types matching Rust structs
 
 export interface DisplayInfo {
 	id: number;
@@ -81,7 +70,7 @@ export interface AutosaveState {
 	editsJson: string;
 }
 
-//  System commands
+// System commands
 
 /** One encoder candidate (H.264 or HEVC) and whether it really initializes
  *  here. Mirrors the Rust `EncoderAvailability` struct (`probe_video_encoders`). */
@@ -216,7 +205,7 @@ export function renameFile(path: string, newName: string): Promise<string> {
 	return invoke<string>("rename_file", { path, newName });
 }
 
-//  Recording commands
+// Recording commands
 
 export interface RecordingOptions {
 	systemAudio?: boolean;
@@ -280,8 +269,7 @@ export function startRecording(
 	options?: RecordingOptions,
 	region?: RegionRect | null,
 ): Promise<RecordingStartResult> {
-	// No-op unless the user opted into product analytics. No PII — source kind,
-	// capture rate, and quality tier only.
+	// No PII — source kind, capture rate, quality tier only.
 	analytics.capture("recording_started", {
 		source_kind: targetType,
 		fps: options?.fps ?? "default",
@@ -354,7 +342,7 @@ export function listExports(): Promise<RecordingEntry[]> {
 	return invoke<RecordingEntry[]>("list_exports");
 }
 
-//  Recast Cloud commands
+// Recast Cloud commands
 
 /** Result of a successful cloud upload + share-link creation. */
 export interface CloudShareResult {
@@ -446,7 +434,7 @@ export function recastCloudForgetUpload(path: string): Promise<void> {
 	return invoke<void>("recast_cloud_forget_upload", { path });
 }
 
-//  Editor commands
+// Editor commands
 
 export function loadEditorDocument(path: string): Promise<EditorDocument> {
 	return invoke<EditorDocument>("load_editor_document", { path });
@@ -524,7 +512,7 @@ export function cancelExport(exportId: string): Promise<void> {
 	return invoke("cancel_export", { exportId });
 }
 
-//  Zoom suggestions (auto-focus) 
+// Zoom suggestions (auto-focus)
 
 export type ZoomSuggestionReason = "click" | "settleAfterMotion";
 
@@ -545,7 +533,7 @@ export function suggestZoomRegions(cursorPath: string): Promise<ZoomSuggestion[]
 	return invoke<ZoomSuggestion[]>("suggest_zoom_regions", { cursorPath });
 }
 
-//  Silence detection
+// Silence detection
 
 /** Tunable thresholds for `detectSilence`; omit any field to use the default. */
 export interface SilenceDetectOptions {
@@ -610,7 +598,7 @@ export function extractWaveform(
 	});
 }
 
-//  Autosave / Recovery commands 
+// Autosave / Recovery commands
 
 export function autosaveProject(projectPath: string, editsJson: string): Promise<void> {
 	return invoke("autosave_project", { projectPath, editsJson });
@@ -632,7 +620,7 @@ export function getRecoverableSessions(): Promise<AutosaveState[]> {
 	return invoke<AutosaveState[]>("get_recoverable_sessions");
 }
 
-//  External asset cache 
+// External asset cache
 
 export interface AssetInstallFailure {
 	id: string;
@@ -667,7 +655,7 @@ export function hydrateCachedAssets(): Promise<HydratedAsset[]> {
 	return invoke<HydratedAsset[]>("hydrate_cached_assets");
 }
 
-//  Declarative asset-pack extensions
+// Declarative asset-pack extensions
 
 /** A manifest-local asset (downloaded + sha256-verified by the installer). */
 export interface ExtensionAssetEntry {
@@ -793,7 +781,6 @@ export function fetchExtensionRegistry<T = unknown>(indexUrl: string): Promise<T
 }
 
 
-// start recording
  export async function launchRecordingPanel() {
     const existing = await WebviewWindow.getByLabel("recording-panel");
     if (existing) {
@@ -823,17 +810,12 @@ export function fetchExtensionRegistry<T = unknown>(indexUrl: string): Promise<T
     panelWin.once("tauri://error", (e) => console.error(e));
   }
 
-// Floating webcam preview window. Mirrors `launchRecordingPanel` — same
-// pattern (label-dedupe + Tauri error listener) so it stays consistent and we
-// don't end up with route-level navigation when WebviewWindow construction
-// fails silently.
+// Floating webcam preview window.
 //
-// IMPORTANT: this window MUST be excluded from screen capture, otherwise
-// DXGI Desktop Duplication captures it as part of the desktop and bakes
-// the camera bubble into the recorded screen video. We invoke
-// `exclude_window_from_capture` (Windows: SetWindowDisplayAffinity with
-// WDA_EXCLUDEFROMCAPTURE) on the `tauri://created` event — earlier than
-// that and the HWND isn't reachable yet.
+// MUST be excluded from screen capture or DXGI Desktop Duplication bakes the
+// camera bubble into the recorded screen video. `exclude_window_from_capture`
+// (Windows: SetWindowDisplayAffinity WDA_EXCLUDEFROMCAPTURE) runs on
+// `tauri://created` — any earlier and the HWND isn't reachable yet.
 export async function openCameraPreviewWindow() {
   const existing = await WebviewWindow.getByLabel("camera-preview");
   if (existing) {
@@ -872,9 +854,7 @@ export async function openCameraPreviewWindow() {
     try {
       await excludeWindowFromCapture("camera-preview");
     } catch (err) {
-      // Non-fatal: the preview will still appear, but its pixels will
-      // leak into screen captures. Surface to the console so users
-      // diagnosing "why is my face in the recording?" can find it.
+      // Non-fatal, but the preview's pixels will leak into screen captures.
       console.warn(
         "Failed to exclude camera-preview from screen capture:",
         err,
@@ -883,12 +863,8 @@ export async function openCameraPreviewWindow() {
   });
 }
 
-//  System tray, diagnostics & misc commands
-//
-// Primitive-typed one-offs that previously called `invoke()` raw from scattered
-// stores/components. Routed here so the whole IPC surface is typed in one place
-// (see the module header). Callers in web-safe stores still guard with
-// `isTauriApp()` before calling — these wrappers don't, they're thin.
+// System tray, diagnostics & misc commands.
+// These wrappers are thin — web-safe callers guard with `isTauriApp()` themselves.
 
 /** Exclude a window (by Tauri label) from screen capture (Windows
  *  `SetWindowDisplayAffinity`). No-op on platforms without an equivalent. */
@@ -946,12 +922,9 @@ export function setDiagnosticLogging(enabled: boolean): Promise<void> {
 	return invoke<void>("set_diagnostic_logging", { enabled });
 }
 
-//  Recast Cloud — account / auth
-//
-// Canonical shapes for the `auth_*` and cloud-endpoint commands. These live
-// here (not in the cloud stores) so the IPC contract has one home; the stores
-// import these types + the wrappers below. All are `#[serde(rename_all =
-// "camelCase")]` on the Rust side EXCEPT `AuthStartResult` (noted inline).
+// Recast Cloud — account / auth.
+// All are `#[serde(rename_all = "camelCase")]` on the Rust side EXCEPT
+// `AuthStartResult` (noted inline).
 
 export interface AuthPlan {
 	id: string;
@@ -1037,11 +1010,8 @@ export function setCloudApiUrl(url: string | null): Promise<CloudApiConfig> {
 	return invoke<CloudApiConfig>("set_cloud_api_url", { url });
 }
 
-//  Google Drive
-//
-// Types + wrappers for the `gdrive_*` commands (OAuth + Drive upload). The
-// gdrive store guards every call with `isTauriApp()` and tracks in-flight UI
-// state itself; these wrappers are thin.
+// Google Drive — `gdrive_*` commands (OAuth + Drive upload). Thin wrappers; the
+// gdrive store guards every call with `isTauriApp()`.
 
 export interface GdriveStatus {
 	connected: boolean;

--- a/apps/desktop/src/lib/library/editor-window.ts
+++ b/apps/desktop/src/lib/library/editor-window.ts
@@ -1,0 +1,54 @@
+/**
+ * Opening a recording/export in the editor — either in the current window or a
+ * dedicated webview. This was duplicated verbatim across the home and recasts
+ * route pages; it lives here so the window label/sizing and the path encoding
+ * stay in one place.
+ */
+
+import { goto } from "$app/navigation";
+import type { RecordingEntry } from "$lib/ipc";
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+
+/** Encode a filesystem path for use as an `/editor/[file]` route segment. */
+export function encodeEditorPath(path: string): string {
+	return encodeURIComponent(btoa(encodeURIComponent(path)));
+}
+
+/**
+ * Open the editor for `entry` in a separate webview window, focusing an
+ * existing one for the same file instead of spawning a duplicate.
+ */
+export async function openInNewWindow(entry: RecordingEntry): Promise<void> {
+	const route = `/editor/${encodeEditorPath(entry.path)}`;
+	const label = `editor-${encodeEditorPath(entry.path)
+		.replace(/[^a-zA-Z0-9]/g, "")
+		.slice(0, 48)}`;
+	const existing = await WebviewWindow.getByLabel(label);
+	if (existing) {
+		await existing.setFocus();
+		return;
+	}
+	new WebviewWindow(label, {
+		url: route,
+		title: `Editor - ${entry.filename}`,
+		width: 1440,
+		height: 960,
+		center: true,
+		decorations: false,
+	});
+}
+
+/**
+ * Open the editor for `entry`, honouring the user's window preference: navigate
+ * the current window, or spawn/focus a dedicated editor window.
+ */
+export async function openInEditor(
+	entry: RecordingEntry,
+	mode: "navigate" | "new-window",
+): Promise<void> {
+	if (mode === "new-window") {
+		await openInNewWindow(entry);
+	} else {
+		goto(`/editor/${encodeEditorPath(entry.path)}`);
+	}
+}

--- a/apps/desktop/src/lib/library/editor-window.ts
+++ b/apps/desktop/src/lib/library/editor-window.ts
@@ -1,8 +1,7 @@
 /**
- * Opening a recording/export in the editor — either in the current window or a
- * dedicated webview. This was duplicated verbatim across the home and recasts
- * route pages; it lives here so the window label/sizing and the path encoding
- * stay in one place.
+ * Opening a recording/export in the editor (current window or a dedicated
+ * webview). Shared by the home and recasts pages so the window label/sizing
+ * and path encoding stay in one place.
  */
 
 import { goto } from "$app/navigation";

--- a/apps/desktop/src/lib/logger/diagnostics.svelte.ts
+++ b/apps/desktop/src/lib/logger/diagnostics.svelte.ts
@@ -1,16 +1,12 @@
 /**
  * Opt-in diagnostic-logging switch, shared across windows.
  *
- * The Rust `AppConfig.diagnostic_logging` flag is the persistent source of
- * truth — it drives the actual runtime log level (see `apply_log_level`), so we
- * adopt its value on startup. `PersistedState` (localStorage) is layered on top
- * purely for instant, cross-window reactivity: flipping the toggle in the
- * Settings window must reach an already-open editor window's logger without a
- * reload, and Tauri webviews share a localStorage origin so a `storage` event
- * does exactly that.
+ * Rust `AppConfig.diagnostic_logging` is the source of truth (it drives the
+ * runtime log level via `apply_log_level`), so we adopt it on startup.
+ * `PersistedState` is layered on for cross-window reactivity — a Settings
+ * toggle reaches an open editor window's logger without a reload.
  *
- * Off by default. When on, verbose backend + editor-interaction logs land in
- * the rotating log file for a support bundle. See `$lib/logger`.
+ * Off by default; when on, verbose logs land in the rotating log file.
  */
 
 import { PersistedState } from "@recast/ui/persisted-state";
@@ -21,9 +17,8 @@ const STORAGE_KEY = "recast-diagnostic-logging";
 function createDiagnosticsStore() {
 	const state = new PersistedState<boolean>(STORAGE_KEY, false);
 
-	// Adopt the backend's persisted value on startup so the toggle reflects the
-	// real log level even after localStorage is cleared. Best-effort — a
-	// non-Tauri preview just keeps the localStorage/default value.
+	// Adopt the backend value so the toggle is correct even after localStorage
+	// is cleared. Best-effort — non-Tauri previews keep the local/default value.
 	void getDiagnosticLogging()
 		.then((backend) => {
 			if (typeof backend === "boolean") state.current = backend;

--- a/apps/desktop/src/lib/logger/index.ts
+++ b/apps/desktop/src/lib/logger/index.ts
@@ -1,28 +1,17 @@
 /**
- * Recast-scoped structured logger for the desktop editor.
+ * Recast-scoped structured logger for the desktop editor. Tags records with the
+ * open recast and fans out to the dev console (debug builds only) and the rotating
+ * log file via `@tauri-apps/plugin-log`, which interleaves with the Rust backend's
+ * logs in one support-bundle file.
  *
- * One place to trace what a user did to a recording — which recast is open,
- * what they selected, which property they changed, what export settings they
- * chose — so a bug report has context instead of "it broke". Records are
- * formatted consistently and tagged with the open recast, then fanned out to:
+ * Gating (see `./diagnostics.svelte`): debug builds log everything; release builds
+ * always persist `warn`/`error`, but `debug`/`info` only when the user enables
+ * Diagnostic logging in Settings.
  *
- *   1. the dev console (debug builds only), and
- *   2. the rotating log file, via `@tauri-apps/plugin-log`, which interleaves
- *      these with the Rust backend's own logs in one file (the support bundle).
+ * High-frequency inputs (slider drags, scrubbing) must use `debounced` to coalesce
+ * into one counted line instead of flooding the file.
  *
- * Gating (see `./diagnostics.svelte`):
- *   - debug builds: everything logs.
- *   - release builds: `warn`/`error` always reach the file (they're not
- *     verbose); `debug`/`info` only when the user has turned on Diagnostic
- *     logging in Settings. So a shipped build is quiet until a user opts in to
- *     reproduce an issue.
- *
- * High-frequency inputs (slider drags, scrubbing) must go through `debounced`
- * so they coalesce into one line with a count instead of flooding the file.
- *
- * This logger is LOCAL only. Sending events to PostHog is handled separately
- * by `$lib/analytics` and is independently consent-gated; nothing here phones
- * home.
+ * LOCAL only — PostHog is handled separately by `$lib/analytics`.
  */
 
 import { diagnostics } from "./diagnostics.svelte";
@@ -47,7 +36,7 @@ function verboseEnabled(): boolean {
 	return IS_DEV || diagnostics.enabled;
 }
 
-// --- formatting -------------------------------------------------------------
+// formatting
 
 function basename(path: string): string {
 	const p = path.replace(/\\/g, "/");
@@ -81,7 +70,7 @@ function format(area: string, event: string, data?: Record<string, unknown>): st
 	return `${head} ${area} · ${event}${safeData(data)}`;
 }
 
-// --- sinks ------------------------------------------------------------------
+// sinks
 
 function toConsole(level: Level, msg: string): void {
 	if (!IS_DEV) return;
@@ -122,7 +111,7 @@ function emit(level: Level, area: string, event: string, data?: Record<string, u
 	void toFile(level, msg);
 }
 
-// --- debounced (high-frequency inputs) --------------------------------------
+// debounced (high-frequency inputs)
 
 interface PendingLog {
 	timer: ReturnType<typeof setTimeout>;
@@ -144,7 +133,7 @@ function flush(key: string): void {
 	emit("debug", entry.area, entry.event, data);
 }
 
-// --- public API -------------------------------------------------------------
+// public API
 
 export const log = {
 	/**

--- a/apps/desktop/src/lib/morph.ts
+++ b/apps/desktop/src/lib/morph.ts
@@ -7,16 +7,12 @@ interface MorphParams {
 }
 
 /**
- * FLIP-with-scale layout animation.
+ * FLIP-with-scale layout animation. Unlike Svelte's built-in `flip` (translate
+ * only) this also tweens scale, so a keyed element changing position *and* size
+ * morphs between shapes (cf. Framer Motion's `layout`).
  *
- * Svelte's built-in `flip` only translates; this also tweens scale, so a
- * keyed element whose position *and* size change between renders (e.g. a
- * card moving from a grid cell to a list row) visibly morphs between the
- * two shapes — the same effect as Framer Motion's `layout` animation.
- *
- * Apply with `animate:morph` on the top-level element of a keyed `{#each}`.
- * The each block must re-run for the animation to fire (toggle a layout
- * flag the iterated value depends on).
+ * Apply with `animate:morph` on a keyed `{#each}` element; the each block must
+ * re-run for the animation to fire.
  */
 export function morph(
   _node: Element,

--- a/apps/desktop/src/lib/openProject.ts
+++ b/apps/desktop/src/lib/openProject.ts
@@ -1,16 +1,9 @@
 /**
- * External-open pipeline for `.recast` files.
+ * External-open pipeline for `.recast` files (today: OS file association).
  *
- * Used whenever a project file arrives from outside the in-app recordings
- * list — today that's only the OS file association (double-click in
- * Explorer/Finder/Files), but the same helper is reusable for future
- * "File → Open…" menu items and drag-onto-app-icon flows.
- *
- * External opens always land in a fresh editor window — they never
- * navigate the main window. That's a deliberate UX contract: the user's
- * library view stays put, and a new project never disturbs unsaved edits
- * in another editor window. Same path opened twice → focus the existing
- * window (label-based dedupe).
+ * External opens always land in a fresh editor window, never navigating the
+ * main window — the library view stays put and unsaved edits elsewhere aren't
+ * disturbed. Same path opened twice → focus the existing window (label dedupe).
  */
 import { analytics } from "$lib/analytics/client";
 import { isRecordingActive, peekRecastProject } from "$lib/ipc";
@@ -58,28 +51,23 @@ export async function openProjectInNewWindow(path: string): Promise<void> {
     center: true,
     decorations: false,
   });
-  // No-op unless product analytics are on. No PII — the path never leaves.
+  // No PII — the path never leaves.
   analytics.capture("editor_opened");
 }
 
 /**
- * Validate, then open. Surfaces a toast and bails on each failure mode
- * the editor route can't recover from:
- *
- *   - Active recording → editor windows kick off FFmpeg thumbnail probes
- *     that compete with the capture pipeline for CPU. Refuse instead of
- *     degrading the recording.
- *   - File missing / unreadable → toast the OS error verbatim.
- *   - Not a valid zip / no metadata.json → "Not a valid Recast project".
- *
- * Always lands in a new editor window (never navigates main).
+ * Validate, then open. Toasts and bails on failure modes the editor can't
+ * recover from:
+ *   - Active recording → editor thumbnail probes would compete with capture
+ *     for CPU; refuse rather than degrade the recording.
+ *   - File missing/unreadable → toast the OS error verbatim.
+ *   - Not a valid project → "Not a valid Recast project".
  */
 export async function openProjectFromExternalPath(
   path: string,
 ): Promise<void> {
-  // Best-effort guard. If the IPC fails for any reason, treat it as
-  // "not recording" rather than blocking the open — the user can always
-  // start the editor anyway from the recasts list if something's wedged.
+  // Best-effort guard — a failed IPC treats it as "not recording" rather than
+  // blocking the open.
   let recording = false;
   try {
     recording = await isRecordingActive();

--- a/apps/desktop/src/lib/playback/audio-engine.ts
+++ b/apps/desktop/src/lib/playback/audio-engine.ts
@@ -2,18 +2,15 @@
  * Web Audio timeline engine — sample-accurate, cut-aware audio playback for the
  * WebCodecs editor preview.
  *
- * Instead of slaving an `<audio>` element to the playhead by seeking (which
- * drifts across cuts, stalls on cold starts, and can cut out), we decode the
- * recording's audio once into `AudioBuffer`s and schedule each KEPT region as
- * its own `AudioBufferSourceNode` on the audio hardware clock. The cuts are
- * simply the gaps between scheduled chunks, so they're silent and exact — no
- * seeking ever happens during playback.
+ * Instead of seeking an `<audio>` element to the playhead (drifts across cuts,
+ * stalls on cold starts, can cut out), we decode the audio once into
+ * `AudioBuffer`s and schedule each KEPT region as its own `AudioBufferSourceNode`
+ * on the audio hardware clock; the cuts are the gaps between chunks, silent and
+ * exact, with no seeking during playback.
  *
- * Lifecycle mirrors the picture clock: `play(regions, outputTime)` schedules
- * everything from the current output time; `pause()` stops it; `reschedule()`
- * re-plans on a seek or an edit-while-playing. Fully fallback-safe: `create`
- * throws if Web Audio is unavailable or nothing decodes, and the caller drops
- * back to the `<audio>`-element path, so the user is never left without audio.
+ * Lifecycle mirrors the picture clock: `play`/`pause`/`reschedule`. Fallback-safe:
+ * `create` throws if Web Audio is unavailable or nothing decodes, and the caller
+ * drops back to the `<audio>`-element path.
  */
 
 import { planAudioSchedule, type Region } from "./audio-schedule";
@@ -37,10 +34,9 @@ export class AudioTimelineEngine {
 	}
 
 	/**
-	 * Create the engine for the given audio source URLs (system + mic; nulls are
-	 * skipped). Fetches and decodes each into an `AudioBuffer`. Throws if Web
-	 * Audio is unavailable or nothing decodes — the caller should then fall back
-	 * to the `<audio>` elements.
+	 * Create the engine for the given audio source URLs (system + mic; nulls
+	 * skipped), decoding each into an `AudioBuffer`. Throws if Web Audio is
+	 * unavailable or nothing decodes — caller falls back to the `<audio>` elements.
 	 */
 	static async create(urls: ReadonlyArray<string | null | undefined>): Promise<AudioTimelineEngine> {
 		const Ctx: typeof AudioContext | undefined =

--- a/apps/desktop/src/lib/playback/audio-schedule.ts
+++ b/apps/desktop/src/lib/playback/audio-schedule.ts
@@ -1,20 +1,15 @@
 /**
- * Pure scheduling math for the Web Audio timeline engine — split out so it can
- * be unit-tested without an `AudioContext`.
+ * Pure scheduling math for the Web Audio timeline engine (no `AudioContext`).
  *
- * The recording's audio (system + mic WAVs) covers the FULL original timeline.
- * To play the EDITED timeline we don't seek a media element around the cuts
- * (fragile, drifts, stalls); instead we schedule each KEPT region as its own
- * `AudioBufferSourceNode` on the audio clock — the cuts become gaps in the
- * schedule, so they're sample-accurate and silent by construction.
- *
- * Two steps, both pure:
- *   1. `keptRegions` — the original-time intervals that survive (trim minus
- *      cuts), cut-bounded (NOT split by editor split points, which don't remove
- *      audio), so adjacent kept audio plays continuously.
+ * The recording's audio covers the FULL original timeline. To play the EDITED
+ * timeline we don't seek a media element around the cuts (fragile, drifts,
+ * stalls); instead we schedule each KEPT region as its own `AudioBufferSourceNode`
+ * on the audio clock, so the cuts become gaps in the schedule — sample-accurate
+ * and silent by construction. Two pure steps:
+ *   1. `keptRegions` — original-time intervals that survive (trim minus cuts),
+ *      cut-bounded (NOT split by editor split points, which don't remove audio).
  *   2. `planAudioSchedule` — given those regions and the current OUTPUT time,
- *      what to start when: each region maps to a `start(when, offset, duration)`
- *      on a source node.
+ *      map each to a `start(when, offset, duration)`.
  */
 
 const EPS = 1e-4;
@@ -28,10 +23,8 @@ export interface Region {
 }
 
 /**
- * Kept original-time audio regions = `[inPoint, outPoint]` minus `cuts`. Cuts
- * are clipped to the trim range, merged, and removed; the surviving gaps are the
- * regions. Self-contained (no dependency on the cut store) so it's trivially
- * testable.
+ * Kept original-time audio regions = `[inPoint, outPoint]` minus `cuts`. Cuts are
+ * clipped to the trim range, merged, and removed; the surviving gaps are the regions.
  */
 export function keptRegions(
 	inPoint: number,

--- a/apps/desktop/src/lib/playback/clock.ts
+++ b/apps/desktop/src/lib/playback/clock.ts
@@ -1,25 +1,18 @@
 /**
- * PlaybackClock — the master timeline clock for the editor preview.
+ * PlaybackClock — master timeline clock for the editor preview.
  *
- * Today the muted `<video>` element is the source of truth for "what time is
- * it": audio elements, the scrubber, loop, and frame-stepping all read
- * `videoEl.currentTime`. That couples the clock to the browser's video decoder,
- * whose seek latency is exactly what makes playback freeze at a cut boundary.
+ * A pure real-time integrator: while playing, `time` advances with wall-clock
+ * at `rate`; paused, it holds. Nothing decodes here — the render loop samples
+ * `time` and asks the video source for the matching frame; audio slaves to it.
+ * Decoupling from `videoEl.currentTime` is the point: the decoder's seek
+ * latency is what made playback freeze at cut boundaries.
  *
- * This clock decouples the two. It is a pure real-time *integrator*: when
- * playing, `time` advances with wall-clock at `rate`; when paused it holds.
- * Nothing decodes here — the render loop samples `time` each frame and asks the
- * video source for the matching frame, and the audio elements slave to it. The
- * clock has no knowledge of cuts or trims; it runs over a single monotonic,
- * gapless **output-time** domain `[0, duration]` (the recording with cuts
- * removed — see ./timeline/cuts.ts). The owner maps output→original time with
- * `outputToOriginal` for the one place that still needs original media time
- * (frame lookup, cursor/zoom eval, audio `currentTime`).
+ * Knows nothing of cuts/trims; runs over a single gapless **output-time**
+ * domain `[0, duration]` (recording with cuts removed — see timeline/cuts.ts).
+ * The owner maps output→original via `outputToOriginal` where original media
+ * time is still needed (frame lookup, cursor/zoom eval, audio `currentTime`).
  *
- * Because reading `time` is a function of `now()` rather than a ticked
- * counter, sampling it from a 120 Hz rAF loop is exact and cheap, and the clock
- * never drifts relative to wall-clock. `now` is injectable so the integrator
- * logic is unit-testable without real time.
+ * `now` is injectable so the integrator is unit-testable without real time.
  */
 
 /** Monotonic millisecond time source. Defaults to `performance.now`. */
@@ -92,15 +85,13 @@ export class PlaybackClock {
 
 	play(): void {
 		if (this.#playing) return;
-		// Starting from the end is a no-op rather than an instant stall.
 		this.#reanchor(this.time);
 		this.#playing = true;
 	}
 
 	pause(): void {
 		if (!this.#playing) return;
-		// Freeze at the current computed time.
-		this.#anchorTime = this.time;
+		this.#anchorTime = this.time; // freeze at the computed time
 		this.#playing = false;
 	}
 

--- a/apps/desktop/src/lib/playback/frame-budget.ts
+++ b/apps/desktop/src/lib/playback/frame-budget.ts
@@ -3,26 +3,18 @@
  *
  * Each decoded `VideoFrame` checks out one of the hardware decoder's limited
  * output surfaces; holding too many starves the pool and the decoder stalls
- * (accepts input, emits nothing → ~8fps). A fixed frame count is therefore
- * wrong across resolutions: 7 frames is fine at 1080p but the same 7 frames at
- * 4K/5K (macOS records full native Retina, no downscale) holds 4–7× the surface
- * memory and re-triggers the stall — made worse now that the scout decoder holds
- * additional pre-warmed frames at the same time.
- *
- * So we scale ALL three holders down together with pixel count, against a fixed
- * surface-memory budget:
- *   - `cacheMax`    — the primary decoded-frame cache (display + lookahead)
- *   - `holdoutMax`  — the protected scout (cross-cut prefetch) holdout
- *   - `decodeAhead` — how far the worker decodes past the playhead
- *
- * At ≤1440p this returns the historical 7 / 4 / 6 (unchanged, known-good); at
- * 4K/5K it tightens to keep the TOTAL held surfaces bounded. Pure + unit-tested.
+ * (accepts input, emits nothing → ~8fps). A fixed count is wrong across
+ * resolutions: 7 frames is fine at 1080p but holds 4–7× the surface memory at
+ * 4K/5K (macOS records full native Retina), re-triggering the stall. So we scale
+ * all three holders (`cacheMax`, `holdoutMax`, `decodeAhead`) down together with
+ * pixel count against a fixed surface-memory budget. At ≤1440p this returns the
+ * historical, known-good 7 / 4 / 6; at 4K/5K it tightens.
  */
 
 /**
- * Bytes assumed per decoded frame per pixel. Raw yuv420p is 1.5 B/px, but
- * hardware decode surfaces are padded/tiled and often NV12/RGBA-backed, so we
- * budget a conservative 4 B/px to stay safely under the real output pool.
+ * Bytes assumed per decoded frame per pixel. Raw yuv420p is 1.5 B/px, but HW
+ * decode surfaces are padded/tiled and often NV12/RGBA-backed, so budget a
+ * conservative 4 to stay under the real output pool.
  */
 const BYTES_PER_PX = 4;
 
@@ -50,7 +42,6 @@ export function frameBudget(width: number, height: number): FrameBudget {
 	const pixels = width > 0 && height > 0 ? width * height : 0;
 	const perFrame = pixels > 0 ? pixels * BYTES_PER_PX : 0;
 
-	// Total surfaces we'll hold across the cache + holdout, bounded.
 	const total =
 		perFrame > 0
 			? Math.min(

--- a/apps/desktop/src/lib/playback/frame-index.ts
+++ b/apps/desktop/src/lib/playback/frame-index.ts
@@ -1,15 +1,11 @@
 /**
- * Frame-index logic for the WebCodecs video source — the pure, decoder-free
- * half of decode scheduling, split out so it can be unit-tested without a real
- * `VideoDecoder` or a real MP4.
+ * Pure, decoder-free frame-index logic for the WebCodecs video source.
  *
  * The index is the demuxed sample table in two orders:
- *   - `chunks`     — encoded samples in DECODE order (how they're fed to the
- *                    decoder; the order mp4box emits them).
+ *   - `chunks`     — encoded samples in DECODE order (the order mp4box emits).
  *   - `presOrder`  — indices into `chunks` sorted by presentation time (cts),
- *                    used to answer "which frame is on screen at time T".
- * Keyframes are decode-order indices of sync samples (valid decode entry
- * points). All times are microseconds.
+ *                    to answer "which frame is on screen at time T".
+ * Keyframes are decode-order indices of sync samples. All times are microseconds.
  */
 
 /** One encoded frame, in DECODE order, with its presentation time. */
@@ -46,8 +42,8 @@ export function buildPresOrder(chunks: ReadonlyArray<ChunkMeta>): number[] {
 
 /**
  * Decode-index of the last sample whose presentation time is ≤ `tUs`. Returns
- * the earliest sample when `tUs` precedes everything (so the screen is never
- * blank). Assumes `presOrder` is non-empty.
+ * the earliest sample when `tUs` precedes everything (screen is never blank).
+ * Assumes `presOrder` is non-empty.
  */
 export function sampleAtOrBefore(
 	chunks: ReadonlyArray<ChunkMeta>,
@@ -91,22 +87,18 @@ export function keyframeAtOrBefore(
 
 /**
  * Whether the decoder must be reset+reconfigured before feeding the GOP at
- * keyframe `kf`, given the keyframe it's currently primed from (`anchorKey`,
- * -1 if never primed) and the next decode-index it would feed (`feedCursor`).
+ * keyframe `kf`, given the keyframe it's primed from (`anchorKey`, -1 if never
+ * primed) and the next decode-index it would feed (`feedCursor`).
  *
- * Reset cases: never primed; jumped BACKWARD to an earlier keyframe; or a
- * forward GOP gap (target keyframe past where we've fed) — BUT only when that
- * forward gap is a genuine discontinuity (`forwardIsJump`): a seek or a cut.
+ * Resets on: never primed; backward jump to an earlier keyframe; or a forward
+ * GOP gap — but only when that gap is a genuine discontinuity (`forwardIsJump`).
  *
- * The `forwardIsJump` guard is essential. The playback clock free-runs at
- * realtime; if decode falls behind on a heavy stretch the playhead outruns the
- * feed cursor and crosses keyframes the decoder hasn't reached yet. Resetting
- * there would seek the decoder forward to each keyframe and SKIP the frames in
- * between — freezing the picture on edit-heavy content. So when the requested
- * time merely advanced smoothly (not a jump) we keep streaming contiguously and
- * let the decoder catch up, decoding every frame. The caller decides whether the
- * request was a jump (a large time delta since the last one). Defaults to true
- * so existing callers keep the old "any forward gap resets" behaviour.
+ * The `forwardIsJump` guard is essential: the playback clock free-runs at
+ * realtime, so if decode falls behind the playhead outruns the feed cursor and
+ * crosses keyframes the decoder hasn't reached. Resetting there would seek
+ * forward and SKIP the frames in between — freezing the picture on edit-heavy
+ * content. The caller flags a jump via a large time delta. Defaults to true so
+ * existing callers keep the old "any forward gap resets" behaviour.
  */
 export function needsReset(
 	anchorKey: number,

--- a/apps/desktop/src/lib/playback/gop-byte-budget.ts
+++ b/apps/desktop/src/lib/playback/gop-byte-budget.ts
@@ -1,18 +1,14 @@
 /**
- * Tier-1 cache accounting for the WebCodecs progressive path: an LRU governed
- * by a BYTE budget over the *encoded* GOP bytes we've fetched.
+ * LRU cache accounting for the WebCodecs progressive path, governed by a BYTE
+ * budget over the *encoded* GOP bytes we've fetched.
  *
- * This is deliberately separate from the decoded-frame cache. Decoded
- * `VideoFrame`s must be bounded by a small COUNT (each checks out one of the
- * hardware decoder's limited output surfaces — too many stalls the decoder).
- * Encoded GOP bytes are cheap CPU RAM with no surface pressure, so they get a
- * generous byte ceiling instead, which is what makes scrubbing back and forth
- * over the same cut free (no re-fetch).
+ * Separate from the decoded-frame cache: decoded `VideoFrame`s must be bounded
+ * by a small COUNT (each holds one of the decoder's limited output surfaces),
+ * whereas encoded GOP bytes are cheap CPU RAM, so a generous byte ceiling lets
+ * scrubbing back and forth over the same cut stay re-fetch-free.
  *
- * This class only does the accounting — it tracks which GOPs are resident and
- * how big they are, and decides which to drop. The caller owns the actual bytes
- * (sample `.data`) and frees them for the keys this returns. Pure and
- * synchronous so it can be unit-tested without any media.
+ * Pure accounting only — the caller owns the actual bytes (sample `.data`) and
+ * frees the keys this returns.
  */
 export class GopByteBudget {
 	/** Resident GOPs keyed by keyframe decode-index → byte size. Insertion order

--- a/apps/desktop/src/lib/playback/mp4-sample-table.ts
+++ b/apps/desktop/src/lib/playback/mp4-sample-table.ts
@@ -1,13 +1,10 @@
 /**
- * Pure MP4 sample-table arithmetic for the WebCodecs source's PROGRESSIVE
- * (HTTP-range) ingestion path — split out so it can be unit-tested without a
- * real `VideoDecoder`, a real MP4, or mp4box's runtime.
+ * Pure MP4 sample-table arithmetic for the WebCodecs progressive (HTTP-range)
+ * path — split out so it's unit-testable without a real decoder/MP4/mp4box.
  *
- * In whole-file mode mp4box hands us every sample's bytes up front. In
- * progressive mode we only fetch the `moov` (the index) first, then fetch each
- * GOP's media bytes on demand. To do that we must reconstruct the full sample
- * map — presentation time, duration, sync flag, and crucially the BYTE
- * offset+size of every sample — from the ISO-BMFF sample tables in `stbl`:
+ * Progressive mode fetches only the `moov` index first, then each GOP's bytes on
+ * demand — which needs the full per-sample map (time, duration, sync flag, and
+ * the byte offset+size) reconstructed from the ISO-BMFF `stbl` tables:
  *
  *   - stsz  → sample sizes (or one constant size)
  *   - stsc  → sample-to-chunk runs (how many samples each chunk holds)
@@ -16,11 +13,7 @@
  *   - ctts  → composition-time offsets (B-frame reordering; run-length, signed)
  *   - stss  → which samples are sync samples (keyframes); absent ⇒ all are
  *
- * The arithmetic here is the same the demuxer does internally; we redo it from
- * the parsed box arrays (which mp4box exposes via the same box tree the worker
- * already reads for the codec description) so the byte map is available without
- * holding any media bytes. All output times are microseconds, samples are in
- * DECODE order (matching how they're fed to the decoder).
+ * Output times are microseconds; samples are in DECODE order.
  */
 
 /** The raw `stbl` arrays we read off the parsed mp4box boxes. */
@@ -195,11 +188,9 @@ export function gopByteRange(
 }
 
 /**
- * Default size threshold (bytes) above which the source switches from loading
- * the whole file into memory to progressive HTTP-range ingestion. Whole-file is
- * simpler and gives zero-network steady-state playback; progressive trades that
- * for a flat memory footprint on multi-GB 4K/5K recordings that would otherwise
- * blow the WebView's heap. ~500 MB by default; telemetry can tune it later.
+ * Size threshold (bytes) above which the source switches from whole-file load to
+ * progressive HTTP-range ingestion — progressive trades whole-file's simplicity
+ * for a flat memory footprint on multi-GB recordings that would blow the heap.
  */
 export const PROGRESSIVE_THRESHOLD_BYTES = 500 * 1024 * 1024;
 

--- a/apps/desktop/src/lib/playback/webcodecs-protocol.ts
+++ b/apps/desktop/src/lib/playback/webcodecs-protocol.ts
@@ -1,7 +1,7 @@
 /**
  * Message protocol between the main thread (`webcodecs-source.ts`) and the
- * decode worker (`webcodecs-worker.ts`). Kept in its own module so both sides
- * share one definition and neither has to import the other's runtime code.
+ * decode worker (`webcodecs-worker.ts`). Own module so both sides share one
+ * definition without importing the other's runtime code.
  */
 
 /** Main → worker. */
@@ -31,10 +31,9 @@ export type FromWorker =
 			fps: number;
 	  }
 	/**
-	 * A decoded frame, transferred (listed in the postMessage transfer list).
-	 * `fromScout` marks frames produced by the prefetch (scout) decoder for an
-	 * upcoming post-cut GOP — the main side parks those in a small protected
-	 * holdout so the primary's eviction can't drop them before the cut is reached.
+	 * A decoded frame, transferred. `fromScout` marks frames from the prefetch
+	 * decoder for an upcoming post-cut GOP — the main side parks those in a
+	 * protected holdout so the primary's eviction can't drop them before the cut.
 	 */
 	| { type: "frame"; frame: VideoFrame; fromScout?: boolean }
 	| { type: "error"; message: string };

--- a/apps/desktop/src/lib/playback/webcodecs-source.ts
+++ b/apps/desktop/src/lib/playback/webcodecs-source.ts
@@ -1,51 +1,41 @@
 /**
  * WebCodecsVideoSource — frame-accurate video decode for the editor preview.
  *
- * This is the piece that fixes "playback freezes at a cut". The old preview
- * used an HTML `<video>` element as its frame source, so jumping over a cut
- * meant `video.currentTime = cut.end` — a native seek whose latency (decode
- * from the nearest keyframe) is the visible stall. We can't control that seek.
+ * Fixes "playback freezes at a cut". The old `<video>`-element preview crossed a
+ * cut via `video.currentTime = cut.end`, a native seek whose decode-from-keyframe
+ * latency is the visible stall and which we can't control. Here we own the decode
+ * pipeline instead:
+ *   - mp4box.js demuxes into encoded samples + the codec config, with a
+ *     presentation-time index.
+ *   - a WebCodecs `VideoDecoder` decodes on demand into `VideoFrame`s that WebGL
+ *     uploads directly (`texImage2D(..., videoFrame)`).
+ *   - decoded frames live in a bounded cache so frames around the playhead — and
+ *     across an upcoming cut — are already in memory; a "seek" becomes a cache
+ *     lookup + a short decode scheduled ahead of time, not a black-box stall.
  *
- * Here we own the decode pipeline instead, the way Cap does in Rust:
- *   - mp4box.js demuxes the recording into encoded H.264 samples + the avcC
- *     config, with a presentation-time index.
- *   - a WebCodecs `VideoDecoder` decodes on demand into `VideoFrame`s, which
- *     WebGL can upload directly (`texImage2D(..., videoFrame)`), same as a
- *     `<video>` element but without the element.
- *   - decoded frames live in a bounded cache (cf. Cap's 90-frame cache) so the
- *     frames around the playhead — and across an upcoming cut — are already in
- *     memory. A "seek" becomes a cache lookup + a short decode from the
- *     keyframe, scheduled ahead of time, not a black-box stall.
+ * Threading: demux, decoder, and decode-ahead all run in `webcodecs-worker.ts`.
+ * This class is the main-thread proxy: it owns the bounded decoded-frame cache
+ * (frames transferred from the worker), answers the render loop synchronously,
+ * and tells the worker where the playhead is.
  *
- * Threading: the demux, decoder, and decode-ahead scheduling all run in a
- * dedicated worker (`webcodecs-worker.ts`). This class is the main-thread
- * proxy — it owns the bounded decoded-frame cache (frames are transferred from
- * the worker) and answers the render loop synchronously, while telling the
- * worker where the playhead is so it can decode ahead. That keeps the WebView
- * main thread doing only the cheap work: the cache lookup + the WebGL upload.
- *
- * Ownership: `frameAt()` returns a frame owned by the cache. The caller uploads
- * it synchronously and must NOT close it. Frames are closed on eviction and on
- * `dispose()`. `VideoFrame`s are GPU-backed and refcounted — leaking them
- * exhausts the decoder, so every cached frame has exactly one close path.
+ * Ownership: `frameAt()` returns a frame owned by the cache — upload it
+ * synchronously, do NOT close it. `VideoFrame`s are GPU-backed and refcounted;
+ * leaking them exhausts the decoder, so every cached frame has exactly one close
+ * path (eviction or `dispose()`).
  */
 
 import { frameBudget } from "./frame-budget";
 import { chooseIngestion } from "./mp4-sample-table";
 import type { FromWorker, ToWorker } from "./webcodecs-protocol";
 
-// The cache caps (primary `#cacheMax`, scout `#holdoutMax`) are RESOLUTION-
-// ADAPTIVE — set per source from `frameBudget(width, height)`. Each held
-// VideoFrame keeps one of the hardware decoder's limited output surfaces
-// checked out; at 4K/5K those surfaces are 4–7× larger, so holding the 1080p
-// count would starve the pool and stall the decoder. The scout holdout is kept
-// SEPARATE from the main cache so the primary's eviction (which anchors on the
-// pre-cut display frame and drops the farthest-ahead first) can't throw away
-// the pre-warmed post-cut frames before playback reaches the cut. See
-// `frame-budget.ts` for the sizing and `#evict` for the retention policy.
+// The cache caps (primary `#cacheMax`, scout `#holdoutMax`) are resolution-
+// adaptive (see `frame-budget.ts`): each held VideoFrame keeps a decoder output
+// surface checked out, and at 4K/5K those are 4–7× larger, so the 1080p count
+// would starve the pool. The scout holdout is SEPARATE from the main cache so
+// the primary's eviction can't drop the pre-warmed post-cut frames before
+// playback reaches the cut. See `#evict` for the retention policy.
 
-/** Dev-only diagnostics (throughput + first-frame geometry). Silent in
- * production; kept for debugging decode regressions. */
+/** Dev-only diagnostics (throughput + first-frame geometry). */
 const DIAG = import.meta.env.DEV;
 
 export class WebCodecsVideoSource {
@@ -86,14 +76,10 @@ export class WebCodecsVideoSource {
 		| ((s: { avgFps: number; minFps: number; maxLateMs: number }) => void)
 		| null = null;
 
-	// First-frame geometry log is dev-only (DIAG). The throughput counters below
-	// run ALWAYS — they're a few integer adds per frame — and feed the one
-	// aggregate `onStats` emit on dispose. The dev console log reuses them.
 	#loggedDims = false;
-	// Aggregate decode throughput, accumulated over 1s windows of playback. Idle
-	// windows (scrub/pause, ≈0 fps) are dropped so the average reflects real
-	// playback. `#perfMaxLateMs` = worst frame lateness vs the clock (large at
-	// high res ⇒ throughput-bound). Emitted once via `onStats` on dispose.
+	// Aggregate decode throughput over 1s windows. Idle windows (scrub/pause,
+	// ≈0 fps) are dropped so the average reflects real playback. `#perfMaxLateMs`
+	// = worst frame lateness vs the clock. Emitted once via `onStats` on dispose.
 	#perfFrames = 0;
 	#perfWindowStart = 0;
 	#perfWindowFrames = 0;
@@ -213,9 +199,7 @@ export class WebCodecsVideoSource {
 						`format=${f.format} declaredMeta=${this.width}x${this.height}`,
 				);
 			}
-			// Throughput sampling (always on — a handful of int ops per frame).
-			// Per-second windows; idle/scrub windows (≈0 fps) are dropped so the
-			// aggregate reflects real playback. Emitted once on dispose via onStats.
+			// Throughput sampling (always on — a few int ops per frame).
 			this.#perfFrames++;
 			this.#perfMaxLateMs = Math.max(
 				this.#perfMaxLateMs,
@@ -302,14 +286,12 @@ export class WebCodecsVideoSource {
 	}
 
 	/**
-	 * Best cached frame to show at `tUs`: the greatest timestamp in
-	 * [floorUs, tUs]. `floorUs` is the start of the current kept segment — frames
-	 * before it belong to an earlier segment (inside a removed cut) and must NOT
-	 * be shown, or the picture steps BACK into deleted content right after a cut.
-	 * Within the segment we always return the closest frame at-or-before the
-	 * playhead (never null just because it's a little stale), so normal playback
-	 * stays smooth; null only when no in-segment frame is decoded yet, in which
-	 * case the caller holds the last frame.
+	 * Best cached frame to show at `tUs`: the greatest timestamp in [floorUs, tUs].
+	 * `floorUs` is the start of the current kept segment — frames before it are in
+	 * a removed cut and must NOT be shown, or the picture steps BACK into deleted
+	 * content right after a cut. Returns the closest at-or-before frame even if a
+	 * little stale; null only when no in-segment frame is decoded yet (caller holds
+	 * the last frame).
 	 */
 	#bestCached(tUs: number, floorUs: number): VideoFrame | null {
 		let best: VideoFrame | null = null;
@@ -333,16 +315,13 @@ export class WebCodecsVideoSource {
 	}
 
 	/**
-	 * Evict around the frame that should currently be ON SCREEN — never by a
-	 * fixed time window. The display frame is the greatest timestamp at-or-before
-	 * the playhead; it is NEVER evicted, even if it arrived "late". This matters
-	 * because the playback clock free-runs at realtime while decode does not: a
-	 * costly frame (a Figma canvas edit, a dropdown opening — a large P-frame)
-	 * decodes slower, so it lands behind the clock. The old window-based eviction
-	 * dropped exactly those frames on arrival (ts < playhead − 100ms), which is
-	 * why heavy on-screen changes silently vanished while static playback stayed
-	 * smooth. Now a late frame is simply newer than the last displayed frame, so
-	 * it becomes the display frame and is shown (a touch late) rather than lost.
+	 * Evict around the on-screen frame, never by a fixed time window. The display
+	 * frame (greatest timestamp at-or-before the playhead) is NEVER evicted, even
+	 * if it arrived late. This is the fix for the old window-based eviction that
+	 * dropped late frames on arrival (ts < playhead − 100ms): the clock free-runs
+	 * at realtime while a costly frame (a large P-frame) decodes slower and lands
+	 * behind, so heavy on-screen changes silently vanished. Now a late frame just
+	 * becomes the newest display frame and is shown a touch late rather than lost.
 	 */
 	#evict(): void {
 		// The frame we'd show right now.

--- a/apps/desktop/src/lib/playback/webcodecs-worker.ts
+++ b/apps/desktop/src/lib/playback/webcodecs-worker.ts
@@ -2,19 +2,15 @@
 /**
  * WebCodecs decode worker — the off-main-thread half of the preview engine.
  *
- * Per the WebCodecs best-practices guide, the actual decode already runs on the
- * browser's internal threads; what we move here is everything *around* it that
- * would otherwise run on the WebView's main thread: the mp4box demux, the
- * sample-index build, the per-frame decoder `output()` callback, and the
- * decode-ahead scheduling. The main thread is left with just the WebGL upload
- * and the existing compositor.
+ * The decode itself runs on the browser's internal threads; what we move here is
+ * everything around it that would otherwise hit the WebView's main thread: the
+ * mp4box demux, the sample-index build, the decoder `output()` callback, and the
+ * decode-ahead scheduling. The main thread is left with the WebGL upload.
  *
- * The worker owns no decoded frames: each frame is transferred to the main
- * thread the instant it's decoded (transfer neuters the worker's handle, so we
- * never double-own or leak). The main side keeps the bounded cache and answers
- * the render loop synchronously. The worker only owns the encoded samples + the
- * decoder, and schedules feeding based on the playhead time the main thread
- * sends it.
+ * The worker owns no decoded frames: each is transferred to the main thread the
+ * instant it's decoded (transfer neuters the worker's handle, so no double-own
+ * or leak). The worker owns the encoded samples + the decoder and schedules
+ * feeding from the playhead time the main thread sends.
  */
 
 import {
@@ -44,20 +40,18 @@ import {
 } from "./mp4-sample-table";
 import type { FromWorker, ToWorker } from "./webcodecs-protocol";
 
-/** Samples (decode order) to keep decoded ahead of the playhead. Small so we
- * don't keep many decoder output surfaces checked out (which stalls HW decode).
- * RESOLUTION-ADAPTIVE: set from `frameBudget` at init so 4K/5K decodes fewer
- * frames ahead (fewer large surfaces in flight). Defaults to the 1080p value. */
+/** Samples (decode order) kept decoded ahead of the playhead. Small so we don't
+ * hold many output surfaces (stalls HW decode). Resolution-adaptive: set from
+ * `frameBudget` at init so 4K/5K decodes fewer ahead. Defaults to the 1080p value. */
 let decodeAhead = 6;
 /** Cap on the decoder's in-flight queue so we don't overfeed during a burst. */
 const QUEUE_MAX = 4;
 /**
  * A forward jump in requested time bigger than this (µs) is treated as a seek or
- * a cut — the only case where we reset the decoder to a downstream keyframe and
- * skip ahead. A smaller forward step is normal playback (≈ one frame) or, on a
- * heavy stretch, the clock outrunning a lagging decoder; there we keep streaming
- * contiguously rather than resetting, so no on-screen content is skipped. (A cut
- * shorter than this just streams through its handful of removed frames, which the
+ * cut — the only case where we reset the decoder to a downstream keyframe and
+ * skip ahead. A smaller forward step is normal playback or a lagging decoder;
+ * there we keep streaming contiguously so no on-screen content is skipped. (A
+ * cut shorter than this streams through its removed frames, which the
  * compositor's segment floor hides anyway.)
  */
 const SEEK_JUMP_US = 300_000;
@@ -69,16 +63,15 @@ const MOOV_FETCH_CHUNK = 256 * 1024;
 /**
  * Tier-1 budget (bytes) for the progressive path's cache of *encoded* GOP bytes.
  * Generous because encoded bytes are cheap CPU RAM with no decoder-surface
- * pressure (that's the separate, count-bounded decoded-frame cache). This is
- * what makes scrubbing back over a cut free. 256 MB holds a lot of encoded GOPs.
+ * pressure (that's the separate, count-bounded decoded-frame cache); this is what
+ * makes scrubbing back over a cut free.
  */
 const TIER1_BUDGET_BYTES = 256 * 1024 * 1024;
 
 const ctx = self as unknown as DedicatedWorkerGlobalScope;
 
-// DIAGNOSTICS: decoder output rate, queue depth, reset count — to tell whether
-// the decoder itself is slow vs. frames arriving late on main. Dev-only: silent
-// in production builds, kept around for debugging regressions.
+// Dev-only diagnostics: decoder output rate, queue depth, reset count — to tell
+// whether the decoder is slow vs. frames arriving late on main.
 const DIAG = import.meta.env.DEV;
 let diagDecoded = 0;
 let diagResets = 0;
@@ -97,7 +90,7 @@ let currentUs = 0;
 let lastScheduleUs = -1;
 let disposed = false;
 
-// --- Progressive (HTTP-range) ingestion state. Unused in whole-file mode. ---
+// Progressive (HTTP-range) ingestion state. Unused in whole-file mode.
 /** True once `init-progressive` set up a lazy, range-fetched sample table. */
 let progressive = false;
 /** Asset URL to range-fetch GOP media bytes from. */
@@ -117,11 +110,10 @@ let currentGen = 0;
 /** Last schedule() target, so a completed GOP fetch can resume feeding. */
 let lastTarget = 0;
 
-// --- Scout decoder (cross-cut decode-ahead). Purely additive: pre-decodes the
-// first displayable frame(s) of an upcoming post-cut GOP into the main cache so
-// crossing the cut doesn't freeze while the primary re-decodes from a keyframe.
-// If anything here fails it self-disables and playback falls back to the
-// primary-only "hold last frame until the post-cut GOP decodes" behaviour. ---
+// Scout decoder (cross-cut decode-ahead): pre-decodes the first displayable
+// frame(s) of an upcoming post-cut GOP into the main cache so crossing the cut
+// doesn't freeze while the primary re-decodes from a keyframe. Self-disables on
+// any error, falling back to the primary-only "hold last frame" behaviour.
 let scoutDecoder: VideoDecoder | null = null;
 /** Keyframe decode-index the scout is currently warming (dedup). -1 = idle. */
 let scoutAnchorKf = -1;
@@ -145,9 +137,8 @@ async function init(ab: ArrayBuffer): Promise<void> {
 		const file = createFile();
 		const collected: ChunkMeta[] = [];
 
-		// Resolve with track + config so they reach the linear flow as properly
-		// typed non-null locals — TS can't see assignments made inside these
-		// mp4box callbacks, and would otherwise narrow them to `never`.
+		// Resolve with track + config so they reach the linear flow as non-null
+		// locals — TS can't see assignments inside these mp4box callbacks.
 		const ready = new Promise<{ track: Track; cfg: VideoDecoderConfig }>((resolve, reject) => {
 			let track: Track | null = null;
 			let cfg: VideoDecoderConfig | null = null;
@@ -165,12 +156,12 @@ async function init(ab: ArrayBuffer): Promise<void> {
 				cfg = {
 					codec: vtrack.codec,
 					description: extractDescription(file, vtrack.id),
-					// Editor playback wants THROUGHPUT, not low latency. A
-					// latency-optimised decoder serialises and can tank to single-
-					// digit fps; prefer hardware and let it pipeline.
+					// Editor playback wants throughput, not low latency: a
+					// latency-optimised decoder serialises and can tank to
+					// single-digit fps. Prefer hardware and let it pipeline.
 					hardwareAcceleration: "prefer-hardware",
 					optimizeForLatency: false,
-					// codedWidth/Height intentionally omitted: the container reports
+					// codedWidth/Height omitted: the container reports
 					// the DISPLAY size (1920x1080) but the coded size is padded
 					// (1920x1088); a mismatched hint can confuse the decoder. It
 					// derives the true size from the SPS in `description`.
@@ -230,8 +221,8 @@ async function init(ab: ArrayBuffer): Promise<void> {
 	}
 }
 
-/** Build the shared VideoDecoder (same output/error wiring for both ingestion
- * paths): transfer each decoded frame to the main thread, log throughput in DEV. */
+/** The shared VideoDecoder (same wiring for both ingestion paths): transfer each
+ * decoded frame to the main thread, log throughput in DEV. */
 function makeDecoder(): VideoDecoder {
 	return new VideoDecoder({
 		output: (frame) => {
@@ -251,17 +242,16 @@ function makeDecoder(): VideoDecoder {
 					diagLastLogMs = nowMs;
 				}
 			}
-			// Transfer ownership to the main thread; do NOT close after — the
-			// transfer detaches our handle.
+			// Transfer to main; do NOT close after — transfer detaches our handle.
 			post({ type: "frame", frame }, [frame]);
 		},
 		error: (e) => post({ type: "error", message: String(e) }),
 	});
 }
 
-/** The scout decoder: same frame transfer, but it only forwards frames at/after
- * `scoutTargetTs` (the displayable post-cut frame onward) tagged `fromScout`, and
- * on ANY error it disables scouting rather than disturbing playback. */
+/** The scout decoder: forwards only frames at/after `scoutTargetTs` (the
+ * displayable post-cut frame onward) tagged `fromScout`, and disables scouting on
+ * any error rather than disturbing playback. */
 function makeScoutDecoder(): VideoDecoder {
 	return new VideoDecoder({
 		output: (frame) => {
@@ -344,10 +334,9 @@ function extractSampleTables(file: ISOFile, trackId: number): RawSampleTables {
 }
 
 /**
- * Progressive ingestion: fetch only the `moov` index up front via Range
- * requests (driven by mp4box's returned next-byte position, which skips a
- * front mdat to reach a tail moov), build the full sample byte-map, then leave
- * media bytes to be range-fetched per GOP on demand.
+ * Progressive ingestion: fetch only the `moov` index up front via Range requests
+ * (driven by mp4box's next-byte position, which skips a front mdat to reach a
+ * tail moov), build the sample byte-map, then range-fetch media per GOP on demand.
  */
 async function initProgressive(url: string, sizeBytes: number): Promise<void> {
 	if (typeof VideoDecoder === "undefined") {
@@ -365,9 +354,9 @@ async function initProgressive(url: string, sizeBytes: number): Promise<void> {
 			info = movie;
 		};
 
-		// Feed ranges until mp4box has parsed the moov (onReady). appendBuffer
-		// returns the next file position it needs; for a tail moov that jumps past
-		// the mdat payload so we don't download the media to find the index.
+		// Feed ranges until mp4box parses the moov. appendBuffer returns the next
+		// position it needs; for a tail moov that jumps past the mdat payload so
+		// we don't download media to find the index.
 		let pos = 0;
 		while (!info && pos < sizeBytes) {
 			const end = Math.min(pos + MOOV_FETCH_CHUNK, sizeBytes) - 1;
@@ -500,16 +489,14 @@ function schedule(target: number): void {
 	if (!decoder || !config) return;
 	lastTarget = target;
 	const kf = keyframeAtOrBefore(keyframes, target);
-	// A forward GOP gap only counts as a reset-worthy seek/cut when the requested
-	// time actually JUMPED. If it advanced smoothly (≈ a frame) or the decoder is
-	// just behind on a heavy stretch, we keep streaming so no frames are skipped.
+	// A forward GOP gap is a reset-worthy seek/cut only if the time JUMPED; a
+	// smooth advance or a lagging decoder streams on (see needsReset).
 	const forwardIsJump =
 		lastScheduleUs < 0 || Math.abs(currentUs - lastScheduleUs) > SEEK_JUMP_US;
 	lastScheduleUs = currentUs;
 	if (needsReset(anchorKey, feedCursor, kf, forwardIsJump)) {
-		// A reset abandons the old position: cancel in-flight GOP fetches so their
-		// late bytes (for a place we're no longer at) are dropped. Resident GOP
-		// bytes stay cached — that's what makes scrubbing back over a cut free.
+		// Cancel in-flight GOP fetches so their late bytes are dropped; resident
+		// GOP bytes stay cached (that's what makes scrubbing back over a cut free).
 		if (progressive) cancelInflight();
 		decoder.reset();
 		decoder.configure(config); // reset() drops the config

--- a/apps/desktop/src/lib/profiles.ts
+++ b/apps/desktop/src/lib/profiles.ts
@@ -27,14 +27,9 @@ export interface RecordingProfile {
 	/** Browser MediaDevices id — what the camera-preview window consumes. */
 	cameraDeviceId: string | null;
 	/**
-	 * Per-profile countdown override (seconds) before capture starts. `null`
-	 * or absent means "inherit the global Settings → Recording countdown";
-	 * `0` explicitly disables the countdown for this profile. Lets a "quick
-	 * capture" profile start instantly while a "presentation" profile waits.
-	 * Part of the capability fingerprint (`capSig`) and the combination cap —
-	 * the pre-roll is a real differentiator, so "Screen, instant" and
-	 * "Screen, 5s" are two valid profiles that share devices but differ by
-	 * countdown. The option space is `COUNTDOWN_OPTIONS`.
+	 * Per-profile countdown override (seconds). `null`/absent = inherit the
+	 * global countdown; `0` = off. Part of `capSig`, so two profiles can share
+	 * devices but differ by pre-roll. Option space: `COUNTDOWN_OPTIONS`.
 	 */
 	countdown?: number | null;
 	isDefault: boolean;
@@ -53,25 +48,19 @@ interface RecordingProfileV1 {
 export const PROFILES_STORAGE_KEY = "recast-recording-profiles";
 export const PROFILES_ENABLED_STORAGE_KEY = "recast-profiles-enabled";
 
-// ---------- Global capture quality + frame rate ----------
-//
-// Capture rate and quality are capture-WIDE preferences (like the global
-// countdown), not per-device-combo settings, so they live outside the
-// profile records — this keeps them clear of the profile capability
-// fingerprint (`capSig`) and combination cap. Persisted globally and applied
-// to every recording regardless of which profile is active.
+// Global capture quality + frame rate. Capture-WIDE preferences (like the
+// global countdown), so they live outside profile records — kept clear of
+// `capSig` and the combination cap, applied to every recording.
 
 export const RECORDING_QUALITY_STORAGE_KEY = "recast-recording-quality";
 export const RECORDING_FPS_STORAGE_KEY = "recast-recording-fps";
 
-/** Capture quality tier sent to the recorder. `"auto"` (the default) lets the
- *  backend pick against the detected encoder — hardware → high, software →
- *  balanced. The explicit tiers mirror the Rust `RecordingQuality` enum. */
+/** Capture quality tier. `"auto"` lets the backend pick against the detected
+ *  encoder (hardware → high, software → balanced). Tiers mirror the Rust
+ *  `RecordingQuality` enum. */
 export type RecordingQuality = "auto" | "balanced" | "high" | "pristine";
 
-/** Read the persisted capture quality tier. Defaults to "auto" — the backend
- *  resolves it to High on a GPU encoder (sharp master) or Balanced on the
- *  software fallback. Any unrecognized value falls back to "auto" too. */
+/** Read the persisted capture quality tier. Unrecognized values → "auto". */
 export function loadRecordingQuality(): RecordingQuality {
 	const v = safeStorage.get<string>(RECORDING_QUALITY_STORAGE_KEY, "auto");
 	return v === "balanced" || v === "high" || v === "pristine" ? v : "auto";
@@ -92,19 +81,15 @@ export function persistRecordingFps(fps: number | null): void {
 	safeStorage.set(RECORDING_FPS_STORAGE_KEY, fps);
 }
 
-/** Sentinel slot for "use system default at recording time" — distinct from
- *  any specific device id, and distinct from "off". */
+// Slot sentinels — distinct from any specific device id and from each other.
 const DEFAULT_SLOT = "default";
 const OFF_SLOT = "off";
 
 /**
- * Per-profile countdown override option space — the single source of truth
- * shared by the editor UI, the dedup key (`capSig`), and the combination cap
- * (`maxCombinations` / `firstFreeCombo` / `freeSlots`). `null` = inherit the
- * global countdown; `0` = off; the rest pin an explicit pre-roll. Each value
- * is a distinct slot, so two profiles may share devices yet differ by
- * countdown alone. Keep `null` first so the auto-pick walk exhausts every
- * device combo at "inherit" before introducing pinned countdowns.
+ * Countdown override option space — single source of truth for the editor UI,
+ * `capSig`, and the combination cap. `null` = inherit global; `0` = off; rest
+ * pin an explicit pre-roll. Keep `null` first so the auto-pick walk exhausts
+ * every device combo at "inherit" before introducing pinned countdowns.
  */
 export const COUNTDOWN_OPTIONS: readonly (number | null)[] = [
 	null,
@@ -146,27 +131,19 @@ function camSlot(
 }
 
 /**
- * Capability fingerprint — uniqueness key for dedup, **including** device
- * identity. Two profiles with the same on/off shape but different mic/cam
- * IDs are intentionally distinct presets (e.g. "Studio" with the Yeti vs
- * "Mobile" with AirPods is two valid profiles).
- *
- * Slot vocabulary: `off` (capability disabled), `default` (enabled but no
- * specific device pinned — runtime picks the system default), or a literal
- * device id. The trailing segment is the countdown slot (`inherit` or the
- * literal seconds) so profiles can differ by pre-roll alone — see
- * `COUNTDOWN_OPTIONS`.
+ * Capability fingerprint — dedup key, **including** device identity (same
+ * on/off shape with different mic/cam ids are intentionally distinct presets).
+ * Slots: `off`, `default` (runtime picks system default), or a literal device
+ * id; trailing segment is the countdown slot. See `COUNTDOWN_OPTIONS`.
  */
 export function capSig(p: RecordingProfile): string {
 	return `${+p.systemAudio}|${micSlot(p)}|${camSlot(p)}|${countdownToken(p.countdown)}`;
 }
 
 /**
- * Total possible profile slots given currently-attached devices.
- * Math: `#countdowns × 2 (sysAudio) × (2 + #mics) × (2 + #cams)` — each kind's
- * slot space is { off, default, ...each specific device }, multiplied by the
- * per-profile countdown override options (`COUNTDOWN_OPTIONS`). With 0 mics
- * and 0 cams this is `#countdowns × 8` (5 × 8 = 40 for the default options).
+ * Total possible profile slots given currently-attached devices:
+ * `#countdowns × 2 (sysAudio) × (2 + #mics) × (2 + #cams)`, where each device
+ * kind's slot space is { off, default, ...each specific device }.
  */
 export function maxCombinations(micCount: number, camCount: number): number {
 	return COUNTDOWN_OPTIONS.length * 2 * (2 + micCount) * (2 + camCount);
@@ -182,17 +159,13 @@ interface CameraLite {
 }
 
 /**
- * First combo (walking the full cartesian product of currently-attached
- * devices) that no profile in `list` already uses. Returns null when every
- * attainable slot is taken.
+ * First combo in the cartesian product of attached devices that no profile in
+ * `list` already uses, or null when every attainable slot is taken.
  *
- * Walk order is intentional: the first new profile a user creates gets a
- * "system audio + default mic + default cam" template, then "+ off cam",
- * etc. Specific device ids come last so a fresh user with one mic doesn't
- * land on the literal-id slot before exhausting the off/default slots.
- * Countdown is the outermost dimension with `inherit` first, so the whole
- * device cartesian is exhausted at "inherit the global countdown" before any
- * pinned pre-roll is auto-assigned.
+ * Walk order is intentional: off/default slots before specific device ids
+ * (so a one-mic user doesn't land on a literal-id slot first), and countdown
+ * outermost with `inherit` first (exhaust the device cartesian before pinning
+ * a pre-roll).
  */
 export function firstFreeCombo(
 	list: RecordingProfile[],
@@ -254,9 +227,7 @@ export function ensureExactlyOneDefault(
 	});
 }
 
-/** Hand-build the seed set for first launch. Three profiles covering the
- *  most common shapes so users see the value of the system without having
- *  to click "New profile" before recording. */
+/** Seed set for first launch: three profiles covering the common shapes. */
 export function seedProfiles(): RecordingProfile[] {
 	const id = () => crypto.randomUUID();
 	return [
@@ -328,8 +299,8 @@ function isV2(p: unknown): p is RecordingProfile {
  * unparseable, or every entry was unrecognizable. Never throws.
  */
 export function loadProfiles(): RecordingProfile[] {
-	// `safeStorage` returns [] for missing key / no-window / malformed JSON /
-	// non-array data — every empty-ish case funnels into the seed below.
+	// `safeStorage` returns [] for missing key / no-window / malformed JSON,
+	// so every empty-ish case funnels into the seed below.
 	const parsed = safeStorage.get<unknown[]>(PROFILES_STORAGE_KEY, []);
 	if (!Array.isArray(parsed) || parsed.length === 0) return seedProfiles();
 
@@ -349,7 +320,7 @@ export function loadProfiles(): RecordingProfile[] {
 			});
 			continue;
 		}
-		// Drop unrecognized rows silently — better than throwing on the whole list.
+		// Drop unrecognized rows rather than throwing on the whole list.
 	}
 
 	if (migrated.length === 0) return seedProfiles();
@@ -361,9 +332,7 @@ export function persistProfiles(list: RecordingProfile[]): void {
 	safeStorage.set(PROFILES_STORAGE_KEY, list);
 }
 
-/** Read the on/off flag for the whole profile system. Defaults to enabled.
- *  The `true` fallback drives the boolean serializer, which reads the existing
- *  raw "true"/"false" values and returns true when the key is unset. */
+/** Read the on/off flag for the whole profile system. Defaults to enabled. */
 export function loadProfilesEnabled(): boolean {
 	return safeStorage.get<boolean>(PROFILES_ENABLED_STORAGE_KEY, true);
 }
@@ -372,8 +341,8 @@ export function persistProfilesEnabled(enabled: boolean): void {
 	safeStorage.set(PROFILES_ENABLED_STORAGE_KEY, enabled);
 }
 
-/** Pick the user's default profile, or the first one if no default flag is
- *  set. Returns null only when the list is empty. */
+/** The default profile, or the first one if no default flag is set; null only
+ *  when the list is empty. */
 export function findDefaultProfile(
 	list: RecordingProfile[],
 ): RecordingProfile | null {
@@ -381,7 +350,7 @@ export function findDefaultProfile(
 	return list.find((p) => p.isDefault) ?? list[0];
 }
 
-// ---------- Device resolution ----------
+// Device resolution
 
 export type DeviceResolution<T> =
 	| { kind: "matched"; device: T }
@@ -402,9 +371,7 @@ export type DeviceResolution<T> =
  *   3. System default exists → fallback (saved device gone).
  *   4. Nothing available → missing.
  *
- * Pure function — never reads from the store and never toasts. Callers
- * surface the result however the calling surface needs (panel toasts,
- * editor inline warnings, etc.).
+ * Pure — never reads the store or toasts; callers surface the result.
  */
 export function resolveMic(
 	profile: RecordingProfile,

--- a/apps/desktop/src/lib/registry/resolve.ts
+++ b/apps/desktop/src/lib/registry/resolve.ts
@@ -1,10 +1,6 @@
-/**
- * Registry resolvers — turn a *stored* id/value into what a consumer needs,
- * with graceful fallback when an extension-contributed id is missing (pack
- * uninstalled). Resolvers NEVER throw: a missing `ext:` id degrades to a
- * built-in default and logs a warning, so export/preview can't crash on a
- * removed pack.
- */
+// Registry resolvers: stored id/value → what a consumer needs. Resolvers never
+// throw — a missing `ext:` id (pack uninstalled) degrades to a built-in default
+// and logs, so export/preview can't crash on a removed pack.
 
 import { log } from "$lib/logger";
 import { registry } from "./registry.svelte";
@@ -21,10 +17,9 @@ import {
 const FALLBACK_BACKGROUND = "#111111";
 
 /**
- * Resolve a stored `backgroundValue` to the string the render pipeline
- * consumes. Built-in values (hex, gradient, `asset:<id>`) pass through
- * unchanged — identity. Only `ext:<extId>:<localId>` references hit the
- * registry, mapping to the pack's hydrated absolute file path.
+ * Resolve a stored `backgroundValue` to the string the render pipeline consumes.
+ * Built-in values (hex, gradient, `asset:<id>`) pass through unchanged; only
+ * `ext:` references hit the registry for the pack's hydrated absolute path.
  */
 export function resolveBackgroundWireValue(value: string): string {
 	if (!isExtId(value)) return value;
@@ -35,9 +30,8 @@ export function resolveBackgroundWireValue(value: string): string {
 }
 
 /**
- * Resolve a stored cursor style id to its sprite payload (svg + hotspots).
- * Returns `null` when the id can't be resolved — callers treat that as "fall
- * back to the soft-dot cursor" rather than failing the export.
+ * Resolve a stored cursor style id to its sprite payload (svg + hotspots), or
+ * null when unresolvable (callers fall back to the soft-dot cursor).
  */
 export function resolveCursorSprite(id: string): CursorValue | null {
 	const entry = registry.get("cursor", id);
@@ -77,14 +71,13 @@ export function cursorSpriteHotspot(v: CursorValue, state: CursorState): Hotspot
 	}
 }
 
-/** Cached `data:image/svg+xml,…` URLs (one per id+state) so the preview
- *  overlay `<img>` doesn't re-encode the SVG every frame. */
+/** SVG data URLs cached per id+state so the preview overlay doesn't re-encode
+ *  every frame. */
 const cursorDataUrlCache = new Map<string, string>();
 
 /**
- * Resolve a stored cursor id + state to a preview-ready SVG data URL, for
- * both built-ins and `ext:` packs. Returns null when unresolvable (caller
- * hides the overlay rather than rendering a broken image).
+ * Resolve a stored cursor id + state to a preview-ready SVG data URL, or null
+ * when unresolvable (caller hides the overlay).
  */
 export function resolveCursorDataUrl(
 	id: string,

--- a/apps/desktop/src/lib/registry/types.ts
+++ b/apps/desktop/src/lib/registry/types.ts
@@ -1,18 +1,12 @@
 /**
- * Asset registry — shared types.
+ * Asset registry shared types — Tier 0 of the extensions architecture: one
+ * addressable catalog for the editor's visual assets (cursors, backgrounds,
+ * gradients, colours, easing, smoothing presets).
  *
- * Tier 0 of the extensions architecture: a single addressable catalog for the
- * editor's visual assets (cursors, backgrounds, gradients, colours, easing and
- * cursor-smoothing presets). Built-in catalogs register their entries here at
- * load; installed extension packs (Tier 1) register theirs after hydration.
- *
- * Storage ids:
- *  - Built-ins keep their *exact legacy* storage form (a bare local id like
- *    `macos`, or a literal value such as a hex/gradient string for kinds that
- *    were historically stored inline). This guarantees old project files keep
- *    resolving with no migration.
- *  - Extension entries are addressed as `ext:<extId>:<localId>` so they never
- *    collide with built-ins and degrade gracefully when the pack is removed.
+ * Storage ids: built-ins keep their exact legacy form (bare local id, or a
+ * literal hex/gradient for inline-stored kinds) so old project files resolve
+ * with no migration. Extension entries are `ext:<extId>:<localId>` so they
+ * never collide with built-ins and degrade gracefully when the pack is removed.
  */
 
 import type { Easing } from "$lib/easing/cubic-bezier";

--- a/apps/desktop/src/lib/service-worker.ts
+++ b/apps/desktop/src/lib/service-worker.ts
@@ -1,20 +1,15 @@
-// Disables access to DOM typings like `HTMLElement` which are not available
-// inside a service worker and instantiates the correct globals
+// Swap DOM typings for worker globals.
 /// <reference no-default-lib="true"/>
 /// <reference lib="esnext" />
 /// <reference lib="webworker" />
-
-// Ensures that the `$service-worker` import has proper type definitions
 /// <reference types="@sveltejs/kit" />
 
 import { build, files, version } from '$service-worker';
 
-// This gives `self` the correct types
 const self = globalThis.self as unknown as ServiceWorkerGlobalScope;
 const isTauri =
     (self.location.protocol.includes('tauri') ||
     self.location.hostname.includes('tauri.localhost'));
-// Create a unique cache name for this deployment
 const CACHE = `recast.nexonauts.cache-${version}`;
 
 const ASSETS = [
@@ -23,7 +18,6 @@ const ASSETS = [
 ];
 
 self.addEventListener('install', (event) => {
-    // Create a new cache and add all files to it
     async function addFilesToCache() {
         const cache = await caches.open(CACHE);
         return await cache.addAll(ASSETS);
@@ -33,7 +27,6 @@ self.addEventListener('install', (event) => {
 });
 
 self.addEventListener('activate', (event) => {
-    // Remove previous cached data from disk
     async function deleteOldCaches() {
         for (const key of await caches.keys()) {
             if (key !== CACHE) await caches.delete(key);
@@ -44,7 +37,6 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
-    // ignore POST requests etc
     if (event.request.method !== 'GET') return;
 
     // Only handle http/https — ignore chrome-extension://, blob://, data://, etc.
@@ -56,7 +48,7 @@ self.addEventListener('fetch', (event) => {
         const url = new URL(event.request.url);
         const cache = await caches.open(CACHE);
 
-        // 1. INTERNAL ASSETS: `build`/`files` can always be served from the cache
+        // Internal assets (build/files) always come from cache.
         if (ASSETS.includes(url.pathname)) {
             const response = await cache.match(url.pathname);
             if (response) {
@@ -64,8 +56,7 @@ self.addEventListener('fetch', (event) => {
             }
         }
 
-        // 2. HEAVY EXTERNAL ASSETS: Cache-First strategy
-        // Add domains or file extensions you want to load instantly from cache after the first download
+        // Heavy external assets: cache-first.
         const isHeavyExternalAsset =
             url.hostname === 'unpkg.com' ||
             url.hostname === 'cdn.jsdelivr.net' ||
@@ -75,12 +66,11 @@ self.addEventListener('fetch', (event) => {
         if (isHeavyExternalAsset) {
             const cachedResponse = await cache.match(event.request);
             if (cachedResponse) {
-                return cachedResponse; // Serve instantly from disk!
+                return cachedResponse;
             }
 
             try {
                 const networkResponse = await fetch(event.request);
-                // Only cache successful, non-opaque responses
                 if (networkResponse.status === 200) {
                     cache.put(event.request, networkResponse.clone());
                 }
@@ -90,7 +80,7 @@ self.addEventListener('fetch', (event) => {
             }
         }
 
-        // 3. EVERYTHING ELSE: Network-First fallback (API calls, HTML pages, etc.)
+        // Everything else: network-first, fall back to cache.
         try {
             const response = await fetch(event.request);
 

--- a/apps/desktop/src/lib/services/analysis.ts
+++ b/apps/desktop/src/lib/services/analysis.ts
@@ -1,14 +1,8 @@
 /**
- * Analysis service — orchestration for the "understand this recording and
- * suggest edits" operations. Today that's smart auto-zoom (detect clicks +
- * motion settle → place focus regions); silence detection lives alongside it.
- *
- * Like the export service, this owns NO UI state (no toasts, no run-guards).
- * It performs the IPC + computation + persistence and returns a structured
- * outcome; the caller decides how to surface it. This is the surface a future
- * MCP "auto-edit" tool will call.
- *
- * See ./README.md for how this fits the overall headless-core layering.
+ * Analysis service — "understand this recording and suggest edits" orchestration
+ * (currently smart auto-zoom). Owns NO UI state: does IPC + computation +
+ * persistence and returns a structured outcome; the caller surfaces it. This is
+ * the surface a future MCP "auto-edit" tool calls. See ./README.md for layering.
  */
 
 import { autosaveProject, suggestZoomRegions } from "$lib/ipc";
@@ -29,13 +23,10 @@ export interface GenerateAutoZoomOptions {
 }
 
 /**
- * Detect focus candidates from a cursor track and place focus regions on the
- * project. Pushes a single coalesced undo entry covering all placed regions.
- *
- * Sets the persisted `autoZoomApplied` latch (it's part of the project
- * document) before the autosave so a crash can't trigger a re-run on reopen.
- * Returns an outcome describing what happened; it does NOT toast or guard
- * against concurrent runs — those are UI concerns the caller owns.
+ * Detect focus candidates from a cursor track and place focus regions, under a
+ * single coalesced undo entry. Sets the persisted `autoZoomApplied` latch before
+ * autosave so a crash can't re-run on reopen. Does NOT toast or guard concurrent
+ * runs — those are the caller's concern.
  */
 export async function generateAutoZoom(
 	store: EditorStore,
@@ -56,12 +47,10 @@ export async function generateAutoZoom(
 		return { applied: 0, reason: "bad-bounds" };
 	}
 
-	// Single coalesced undo entry covering all auto-applied regions.
 	store.pushUndoState();
 	const result = applyAutoZooms(store, suggestions, bounds, w, h);
-	// Latch BEFORE the autosave below so the persisted document records that
-	// auto-zoom already ran — otherwise a crash before the next 30s autosave
-	// tick would re-run auto-zoom on reopen and double up regions.
+	// Latch BEFORE autosave so a crash before the next tick can't re-run and
+	// double up regions on reopen.
 	store.autoZoomApplied = true;
 
 	if (opts.documentPath) {

--- a/apps/desktop/src/lib/services/export.ts
+++ b/apps/desktop/src/lib/services/export.ts
@@ -1,15 +1,8 @@
 /**
- * Export service — orchestration for turning an editor project into a rendered
- * file. This layer sits between the UI (the editor route) and the Rust export
- * pipeline, and is the agent-facing surface a future MCP server will call.
- *
- * It deliberately owns NO UI state (no progress rings, toasts, or dialog
- * phases). Callers feed in a project (the `EditorStore`) and receive either a
- * ready-to-render payload (`buildExportRenderState`) or the final file path
- * (`runExport`). Progress is surfaced through an optional `onState` callback so
- * the editor route can drive its own UI without this layer knowing about it.
- *
- * See ./README.md for how this fits the overall headless-core layering.
+ * Export service — turns an editor project into a rendered file. Sits between
+ * the UI and the Rust pipeline; the agent-facing surface a future MCP server
+ * calls. Owns NO UI state — progress is surfaced via an optional `onState`
+ * callback. See ./README.md for the headless-core layering.
  */
 
 import { rasterizeCursorSprites } from "$lib/export/rasterize-cursor";
@@ -48,13 +41,10 @@ export interface ExportRenderStatePayload {
 }
 
 /**
- * Build the exact render payload the Rust pipeline consumes from a project.
- *
- * This is the heart of "export" as an operation: it runs the two hybrid-raster
- * passes (text annotations → PNG, cursor → sprite sheet) and honors the
- * per-lane enable toggles (focus / annotations / cuts) without mutating the
- * store. The result is fully serializable, so an agent can build it, inspect
- * it, and pass it straight to {@link runExport}.
+ * Build the render payload the Rust pipeline consumes from a project: runs the
+ * two hybrid-raster passes (text → PNG, cursor → sprite sheet) and honors the
+ * per-lane enable toggles (focus/annotations/cuts) without mutating the store.
+ * Fully serializable, so an agent can build, inspect, and pass it to {@link runExport}.
  */
 export async function buildExportRenderState(
 	store: EditorStore,
@@ -72,10 +62,8 @@ export async function buildExportRenderState(
 	hooks?.onText?.(hasText ? "running" : "done");
 	hooks?.onCursor?.(hasStyledCursor ? "running" : "done");
 
-	// Run the two hybrid-raster passes in parallel — they don't depend on each
-	// other and the cursor SVG decode is non-trivial on cold boot (Image()
-	// onload is async even for inline blobs). This trims perceived "Preparing…"
-	// time roughly in half on projects with text.
+	// Run both hybrid-raster passes in parallel — independent, and the cursor SVG
+	// decode is non-trivial on cold boot (Image() onload is async even for blobs).
 	const [expandedAnnotations, cursorSprites] = await Promise.all([
 		expandTextAnnotations(renderState.annotations, canvasW, canvasH).then(
 			(r) => {
@@ -93,18 +81,13 @@ export async function buildExportRenderState(
 	]);
 
 	hooks?.onSending?.("running");
-	// Honor the per-lane "enable" toggles. The underlying data is preserved on
-	// the store; here we just hand the export pipeline the active set, so
-	// toggling a lane off bypasses its effect in the rendered file.
+	// Hand the pipeline only the active set per lane toggle; store data is preserved.
 	const finalRenderState: EditorRenderState = {
 		...renderState,
 		annotations: store.annotationsGloballyHidden ? [] : expandedAnnotations,
 		zoomRegions: store.focusEnabled ? renderState.zoomRegions : [],
-		// `effectiveCuts` already reflects what actually applies: manual splits/
-		// ripple deletes are always-on, auto silence still requires the
-		// `silenceDetection` opt-in, and both honor the cuts-lane toggle. Cuts that
-		// don't apply are preserved on the store but never reach the Rust pipeline,
-		// so the export matches the previewed edit.
+		// `effectiveCuts` = the flag-gated, lane-enabled subset, so the export
+		// matches the previewed edit. Inactive cuts stay on the store, not here.
 		cuts: store.effectiveCuts,
 		cursorSpriteRest: cursorSprites?.rest,
 		cursorSpritePress: cursorSprites?.press,
@@ -140,11 +123,9 @@ export interface RunExportOptions {
 
 /**
  * Run an export end to end: register the progress listener, invoke the Rust
- * pipeline, and tear the listener down when finished. Resolves to the output
- * file path; rejects (or emits an `error`/`cancelled` state event) on failure.
- *
- * UI lifecycle (isExporting flags, result overlays, ETA) stays with the caller
- * — this only owns the IPC round-trip and listener lifetime.
+ * pipeline, tear the listener down when finished. Resolves to the output path;
+ * rejects (or emits an `error`/`cancelled` event) on failure. UI lifecycle
+ * stays with the caller — this owns only the IPC round-trip and listener.
  */
 export async function runExport(opts: RunExportOptions): Promise<string> {
 	const unlisten = opts.onState

--- a/apps/desktop/src/lib/share.ts
+++ b/apps/desktop/src/lib/share.ts
@@ -1,17 +1,10 @@
 /**
  * Native OS share-sheet helpers, backed by `tauri-plugin-sharekit`.
  *
- * Replaces the earlier `navigator.share` path — Web Share Level 2 in
- * WebView2 rejects `video/*` file payloads via `canShare`, so sharing
- * a recording from Recast was effectively unsupported. Sharekit bridges
- * to the real native share sheets (Windows DataTransferManager, macOS
- * NSSharingServicePicker, mobile share panes), which accept any file.
- *
- * Public API is unchanged: callers still see `shareFile`, `shareLink`,
- * `shareRecording`, `isShareSupported`, and a `ShareResult` discriminated
- * union. Errors never throw — they come back through `ShareResult` so
- * callers can branch on `cancelled` vs. `unsupported` vs. `error` without
- * try/catch boilerplate.
+ * Replaces `navigator.share`: Web Share Level 2 in WebView2 rejects `video/*`
+ * file payloads via `canShare`. Sharekit bridges to the real native share sheets,
+ * which accept any file. Errors never throw — they return via `ShareResult` so
+ * callers can branch on cancelled/unsupported/error without try/catch.
  */
 
 import {
@@ -66,9 +59,7 @@ function deriveMimeType(fileName: string): string {
   }
 }
 
-// Sharekit's `shareFile` example uses the `file://` URI form. Windows
-// absolute paths (`C:\…`) need to be normalized to `file:///C:/…`;
-// POSIX absolute paths get a `file://` prefix.
+// Sharekit needs `file://` URIs: Windows `C:\…` → `file:///C:/…`, POSIX → `file://…`.
 function toFileUri(path: string): string {
   if (/^file:\/\//i.test(path)) return path;
   const normalized = path.replace(/\\/g, "/");
@@ -81,9 +72,7 @@ function toFileUri(path: string): string {
   return normalized;
 }
 
-// Sharekit's commands reject with a string when the platform/runtime
-// can't service the request. Detect cancellation vs. real-unsupported
-// vs. opaque failure so the UI can give a useful toast.
+// Distinguish cancellation vs. real-unsupported vs. opaque failure for the toast.
 function classify(e: unknown): ShareResult {
   const message = e instanceof Error ? e.message : String(e ?? "");
   const lower = message.toLowerCase();
@@ -100,9 +89,7 @@ function classify(e: unknown): ShareResult {
   return { ok: false, reason: "error", message };
 }
 
-// With the plugin wired up on every desktop + mobile platform we ship,
-// support is effectively static — keep the function so call sites that
-// gate their UI on it don't have to change.
+// Static true — kept so UI-gating call sites don't change.
 export function isShareSupported(): boolean {
   return true;
 }
@@ -112,8 +99,7 @@ export function isFileShareSupported(): boolean {
 }
 
 export async function shareLink(payload: ShareTextPayload): Promise<ShareResult> {
-  // `shareText` takes a single string — compose title/text/url into one
-  // payload so the OS share sheet has something meaningful to show.
+  // `shareText` takes a single string — compose title/text/url into one.
   const parts = [payload.title, payload.text, payload.url].filter(
     (s): s is string => typeof s === "string" && s.length > 0,
   );
@@ -151,10 +137,8 @@ export async function shareFile(payload: ShareFilePayload): Promise<ShareResult>
 }
 
 /**
- * Share a recording with a sensible fallback chain: try the file first,
- * then a link (e.g. a Drive webViewLink) if the runtime can't share files.
- * Used by both list pages and the export-complete dialog so they get the
- * same behavior.
+ * Share a recording: try the file first, then fall back to a link (e.g. a Drive
+ * webViewLink) if the runtime can't share files.
  */
 export async function shareRecording(opts: {
   path: string;

--- a/apps/desktop/src/lib/shortcuts/registry.svelte.ts
+++ b/apps/desktop/src/lib/shortcuts/registry.svelte.ts
@@ -1,24 +1,20 @@
 /**
- * Central keyboard-shortcut registry — the single source of truth for every
- * shortcut in the app.
+ * Central keyboard-shortcut registry — single source of truth for every shortcut.
  *
  * Two jobs:
- *   1. DOCUMENTATION. `shortcutDefs` lists every shortcut (categorised) so the
- *      Shortcuts dialog can render a complete, always-accurate reference. Add a
- *      shortcut once, here, and it shows up in the dialog automatically.
- *   2. DISPATCH. A single window listener (`dispatchShortcut`, wired in the root
- *      layout) handles the app/editor-level *mod-combo* shortcuts. Components
- *      attach their state-dependent handlers via `registerShortcutHandlers`; the
- *      dispatcher routes a matching keydown to the registered handler. Because
- *      there is exactly one dispatcher and one def per chord, two shortcuts can
- *      never both fire from one press — the class of "Ctrl triggers everything"
- *      bug this registry was created to kill.
+ *   1. `shortcutDefs` documents every shortcut so the Shortcuts dialog renders an
+ *      always-accurate reference.
+ *   2. A single window listener (`dispatchShortcut`) handles app/editor mod-combo
+ *      shortcuts; components attach state-dependent handlers via
+ *      `registerShortcutHandlers`. One dispatcher + one def per chord means two
+ *      shortcuts can never fire from one press (the "Ctrl triggers everything" bug
+ *      this was built to kill).
  *
- * Plain-key / focus-scoped shortcuts (annotation tools, timeline JKL transport,
- * arrow nudge, mute) are intentionally NOT centrally dispatched — they reuse
- * letters across contexts and rely on element focus / panel state to
- * disambiguate. They live in their components (each on its own `<svelte:window>`
- * so HMR can't leak them) and are listed here as `central: false` for the dialog.
+ * Plain-key / focus-scoped shortcuts (annotation tools, timeline JKL, nudge, mute)
+ * are deliberately NOT centrally dispatched — they reuse letters across contexts
+ * and rely on focus/panel state to disambiguate. They live in their components
+ * (each on its own `<svelte:window>` so HMR can't leak them) and appear here as
+ * `central: false` for the dialog.
  */
 
 import { commandPalette } from "$lib/stores/command-palette.svelte";
@@ -84,7 +80,6 @@ function canonical(mod: boolean, shift: boolean, alt: boolean, key: string): str
 }
 
 function chordFromEvent(e: KeyboardEvent): string {
-	// "Mod" unifies the platform primary modifier: ⌘ on macOS, Ctrl elsewhere.
 	const mod = IS_MAC ? e.metaKey : e.ctrlKey;
 	return canonical(mod, e.shiftKey, e.altKey, e.key);
 }
@@ -280,10 +275,8 @@ for (const def of shortcutDefs) {
 const handlers = new Map<string, Handler>();
 
 /**
- * Register handlers for one or more central shortcuts. Call from a component's
- * `onMount` and return the disposer (run on destroy) so the binding lives
- * exactly as long as the component. Deletion is identity-checked so a remount
- * race can't unregister a newer handler.
+ * Register handlers for central shortcuts; returns a disposer to run on destroy.
+ * Deletion is identity-checked so a remount race can't unregister a newer handler.
  */
 export function registerShortcutHandlers(map: Record<string, Handler>): () => void {
 	const entries = Object.entries(map);
@@ -313,7 +306,6 @@ function isEditableTarget(t: EventTarget | null): boolean {
  */
 export function dispatchShortcut(e: KeyboardEvent): void {
 	if (e.defaultPrevented || e.repeat) return;
-	// A bare modifier press is never a shortcut.
 	if (MODIFIER_KEYS.has(e.key)) return;
 	const def = centralByChord.get(chordFromEvent(e));
 	if (!def) return;

--- a/apps/desktop/src/lib/stores/assets-store.svelte.ts
+++ b/apps/desktop/src/lib/stores/assets-store.svelte.ts
@@ -1,13 +1,11 @@
 /**
- * Reactive state for the external-asset cache. Tracks two tiers per asset id:
- *  - `paths[id]`       — the full-resolution cached file (preferred)
- *  - `thumbPaths[id]`  — the low-res WebP thumbnail (used until full-res lands)
+ * Reactive state for the external-asset cache. Two tiers per asset id:
+ * `paths[id]` (full-res, preferred) and `thumbPaths[id]` (thumbnail until
+ * full-res lands).
  *
- * The corresponding WebView-loadable URLs (`urls`/`thumbUrls`) are cached the
- * moment a path is set so consumers don't recompute `convertFileSrc` on every
- * re-render. URL identity is stable across reads, which is what lets
- * `$derived(src)` short-circuit and stop wallpaper grids from re-creating
- * their `<img>` decode work on every tab toggle.
+ * WebView URLs (`urls`/`thumbUrls`) are precomputed when a path is set so
+ * consumers don't re-run `convertFileSrc` per render; stable URL identity lets
+ * `$derived(src)` short-circuit and avoid redundant `<img>` decodes.
  */
 
 import { convertFileSrc } from "@tauri-apps/api/core";

--- a/apps/desktop/src/lib/stores/cloudShare.svelte.ts
+++ b/apps/desktop/src/lib/stores/cloudShare.svelte.ts
@@ -14,16 +14,11 @@ import {
 export type { CloudWorkspace };
 
 /**
- * Recast Cloud share store.
- *
- * Sibling of {@link import("./gdrive.svelte").gdrive} — a `$state`-backed
- * module singleton the UI binds to. Holds sign-in state (mirrored from the
- * `auth_status` command), an `uploads` map of in-flight shares keyed by the
- * local export path, and the persisted `uploadHistory` (the manifest from
- * `commands/cloud.rs`).
- *
- * STRICTLY ADDITIVE: nothing here runs unless the user explicitly triggers a
- * share, and everything degrades to a no-op in the web build (no Tauri).
+ * Recast Cloud share store — sibling of {@link import("./gdrive.svelte").gdrive}.
+ * A `$state`-backed singleton holding sign-in state (from `auth_status`), an
+ * `uploads` map of in-flight shares keyed by export path, and the persisted
+ * `uploadHistory` manifest from `commands/cloud.rs`. Nothing runs unless the
+ * user triggers a share; everything no-ops in the web build.
  */
 
 export type CloudPhase = "preparing" | "uploading" | "finalizing" | "sharing";
@@ -55,12 +50,10 @@ export type CloudAuth = {
 
 
 /**
- * localStorage key for the user's preferred upload workspace. The value is
- * the org id; it's validated against the live membership list on every
- * status refresh and dropped if the user no longer belongs to it (e.g. they
- * left the team, or signed into a different account). This is a desktop-local
- * preference — it never mutates the server session's active org, which keeps
- * the desktop's upload target independent of what the web dashboard shows.
+ * Preferred upload workspace (org id). Validated against live membership on
+ * each status refresh and dropped if the user no longer belongs. Desktop-local
+ * — never mutates the server session's active org, so the desktop's upload
+ * target stays independent of the web dashboard.
  */
 const WORKSPACE_PREF_KEY = "recast-cloud-workspace";
 
@@ -77,8 +70,8 @@ function writeWorkspacePref(id: string | null): void {
 		if (id) globalThis.localStorage?.setItem(WORKSPACE_PREF_KEY, id);
 		else globalThis.localStorage?.removeItem(WORKSPACE_PREF_KEY);
 	} catch {
-		// Private mode / disabled storage — selection just won't persist
-		// across launches. Non-fatal; the in-memory choice still holds.
+		// Private mode / disabled storage — selection won't persist across
+		// launches, but the in-memory choice still holds.
 	}
 }
 
@@ -87,9 +80,8 @@ function createCloudShareStore() {
 	let planName = $state<string | undefined>(undefined);
 	let usage = $state<CloudAuth["usage"] | undefined>(undefined);
 
-	// Workspace targeting. `workspaces` + `defaultWorkspaceId` come from the
-	// server on each status refresh; `selectedWorkspaceId` is the desktop's
-	// persisted preference (validated against `workspaces` below).
+	// `workspaces` + `defaultWorkspaceId` come from the server each refresh;
+	// `selectedWorkspaceId` is the desktop's persisted, validated preference.
 	let workspaces = $state<CloudWorkspace[]>([]);
 	let defaultWorkspaceId = $state<string | null>(null);
 	let selectedWorkspaceId = $state<string | null>(readWorkspacePref());
@@ -97,9 +89,8 @@ function createCloudShareStore() {
 	const uploads = $state<Record<string, CloudUpload>>({});
 	const uploadHistory = $state<Record<string, CloudUploadRecord>>({});
 
-	// Flips true after the first `init()` completes. The share flow uses it to
-	// avoid a blocking network round-trip on every click — once hydrated, the
-	// cached workspace list opens the picker instantly.
+	// True after the first `init()`. Lets the share flow open the picker from
+	// the cached workspace list instead of a blocking round-trip per click.
 	let initialized = $state(false);
 	let listenersAttached = false;
 
@@ -183,11 +174,9 @@ function createCloudShareStore() {
 	}
 
 	/**
-	 * Reconcile the workspace list + server default with the persisted local
-	 * preference. Signing out (or into an account that lacks the previously
-	 * chosen workspace) clears the stale selection so we never upload into a
-	 * team the user no longer belongs to — the server would reject it anyway,
-	 * but dropping it here keeps the UI honest.
+	 * Reconcile the server workspace list + default with the local preference,
+	 * dropping a stale selection (e.g. signed out, or into an account lacking
+	 * that workspace) so the picker never points at a team the user left.
 	 */
 	function applyWorkspaces(list: CloudWorkspace[], serverDefault: string | null) {
 		workspaces = list;
@@ -240,10 +229,9 @@ function createCloudShareStore() {
 		title: string,
 		workspaceId?: string,
 	): Promise<CloudShareResult> {
-		// Seed the in-flight entry SYNCHRONOUSLY (before any await) so the
-		// corner "Preparing…" card renders the instant the user clicks Share —
-		// otherwise the awaits below (Tauri probe + dynamic import) leave the
-		// screen looking frozen for a beat.
+		// Seed SYNCHRONOUSLY (before any await) so the "Preparing…" card renders
+		// the instant Share is clicked — the awaits below would otherwise leave
+		// the screen looking frozen for a beat.
 		const fileName = path.split(/[\\/]/).pop() ?? path;
 		uploads[path] = {
 			sourcePath: path,
@@ -255,15 +243,14 @@ function createCloudShareStore() {
 		};
 		if (!(await isTauriApp())) throw new Error("not running in Tauri");
 		await attachListeners();
-		// Explicit target wins; otherwise the resolved active workspace (local
-		// pick or server default). `undefined` lets the Rust side fall back to
-		// /api/desktop/profile's defaultWorkspaceId as a last resort.
+		// Explicit target wins, else the resolved active workspace; `undefined`
+		// lets Rust fall back to the server profile's defaultWorkspaceId.
 		const target = workspaceId ?? resolveActiveWorkspaceId() ?? undefined;
 		try {
 			return await recastCloudUpload(path, title, target);
 		} catch (e) {
-			// The Rust side emitted `recast-cloud:error`; ensure the card
-			// reflects it even if the event was missed, then re-throw.
+			// Rust emitted `recast-cloud:error`; ensure the card reflects it even
+			// if the event was missed, then re-throw.
 			const existing = uploads[path];
 			if (existing && existing.status !== "error") {
 				uploads[path] = { ...existing, status: "error", error: String(e) };

--- a/apps/desktop/src/lib/stores/consent.svelte.ts
+++ b/apps/desktop/src/lib/stores/consent.svelte.ts
@@ -2,16 +2,13 @@
  * Desktop telemetry consent, persisted to localStorage AND mirrored into the
  * Rust `AppConfig` so the native crash reporter can read the `errors` flag.
  *
- * Defaults encode the hard rule agreed with the user:
- *   - `product` (behaviour / engagement analytics): OFF — strictly opt-in.
- *   - `errors`  (crash / error reporting):          ON  — default opt-in, with
- *     an explicit toggle to turn it off.
+ * Defaults:
+ *   - `product` (behaviour analytics): OFF — strictly opt-in.
+ *   - `errors`  (crash reporting):     ON  — default opt-in, toggle to disable.
  *
- * Backed by the shared `PersistedState` primitive (`@recast/ui/persisted-state`)
- * for localStorage persistence + cross-window `storage` sync (Tauri v2 webviews
- * share a localStorage origin, so flipping a toggle in the settings window
- * reaches open editor windows without a reload), with the Rust mirror layered
- * on top in the setters.
+ * `PersistedState` gives cross-window `storage` sync (Tauri v2 webviews share a
+ * localStorage origin, so a toggle in Settings reaches open editor windows
+ * without a reload); the Rust mirror is layered on in the setters.
  */
 
 import { PersistedState, safeStorage } from "@recast/ui/persisted-state";
@@ -29,22 +26,19 @@ const STORAGE_KEY = "recast-telemetry-consent";
 const SEEN_KEY = "recast-consent-seen";
 
 /**
- * Mirror consent into Rust so the panic hook / error reporter can read
- * `errors` and attribute crashes to the same anonymous install id as JS
- * events. Called on every explicit toggle (not on cross-window re-reads — the
- * window that made the change already mirrored it to the shared backend).
+ * Mirror consent into Rust so the panic hook can read `errors` and attribute
+ * crashes to the same install id as JS events. Called only on explicit toggles
+ * (cross-window re-reads were already mirrored by the originating window).
  */
 function mirrorToRust(consent: DesktopConsent) {
 	void setTelemetryConsent(consent.product, consent.errors, getInstallId()).catch(() => {
-		// Non-Tauri preview or pre-command build — JS-side gating still applies.
+		// Non-Tauri preview — JS-side gating still applies.
 	});
 }
 
 function createConsentStore() {
-	// localStorage-backed reactive consent with cross-window `storage` sync:
-	// flipping a toggle in the settings window reaches open editor windows
-	// without a reload. The JSON value is merged over DEFAULTS, so a consent
-	// key added in a future build keeps its default for existing users.
+	// Merged over DEFAULTS, so a consent key added in a future build keeps its
+	// default for existing users.
 	const consent = new PersistedState<DesktopConsent>(STORAGE_KEY, DEFAULTS);
 
 	return {
@@ -56,8 +50,7 @@ function createConsentStore() {
 		},
 		/** Has the first-run privacy moment been shown + dismissed yet? */
 		get hasSeenFirstRun() {
-			// During SSR / no-window previews, treat as seen so the prompt never
-			// flashes before storage is readable.
+			// SSR/no-window: treat as seen so the prompt never flashes pre-hydration.
 			if (typeof window === "undefined") return true;
 			return safeStorage.get<string>(SEEN_KEY, "") === "1";
 		},

--- a/apps/desktop/src/lib/stores/editor-store.svelte.ts
+++ b/apps/desktop/src/lib/stores/editor-store.svelte.ts
@@ -17,13 +17,8 @@ export type BackgroundType = 'wallpaper' | 'image' | 'color' | 'gradient';
 
 
 export interface WallpaperOption {
-	/**
-	 * Stable identifier — matches the `id` in `assets/manifest.json`. Stored
-	 * in `backgroundValue` as `asset:<id>` so both preview and export can
-	 * resolve against the downloaded cache. No bundled thumbnail — the
-	 * LazyExternalImage component reads thumbs from the same downloaded
-	 * cache, with a CSS placeholder while nothing is available yet.
-	 */
+	/** Matches the `id` in `assets/manifest.json`. Stored in `backgroundValue`
+	 *  as `asset:<id>` so preview and export resolve against the downloaded cache. */
 	id: string;
 	label: string;
 }
@@ -71,11 +66,8 @@ export interface ShadowSettings {
 	color: string; // hex
 }
 
-//  Annotations 
-//
-// Position / size live in video UV space (0..1) so annotations follow zoom
-// and crop transforms without re-projection. `kind` is a discriminated union
-// so arrows / polygons / text / image slot in without churn later.
+// Annotations. Position/size live in video UV space (0..1) so they follow zoom
+// and crop transforms without re-projection. `kind` is a discriminated union.
 
 export type AnnotationStrokeStyle = "solid" | "dashed" | "dotted";
 
@@ -212,17 +204,10 @@ export const DEFAULT_ANNOTATION_STROKE: AnnotationStroke = {
 };
 export const DEFAULT_ANNOTATION_FILL = "rgba(59,130,246,0.20)";
 
-/**
- * Cursor style id — matches an entry in `lib/cursor/styles.ts`.
- *  - `dot`: the legacy soft white circle (rendered by the WebGL2 shader and
- *    the Rust export overlay; what users see by default).
- *  - Anything else: an SVG cursor sprite drawn by `CursorOverlayLayer` over
- *    the preview. Preview-only today; export currently falls back to `dot`.
- */
-// Bundled built-in cursor styles. The soft `dot` (default, shader-drawn) plus
-// the two system-accurate sets. The original macos/windows/outline/target
-// styles moved into the installable "Classic Cursors" pack and are addressed
-// as `ext:classic-cursors:<id>` once installed.
+// Bundled built-in cursor styles. `dot` is the default soft circle (drawn by
+// the WebGL2 shader and the Rust export overlay); the system sets are SVG
+// sprites. The legacy macos/windows/outline/target styles moved into the
+// installable "Classic Cursors" pack (`ext:classic-cursors:<id>`).
 export type CursorStyleId = 'dot' | 'macos-system' | 'windows-system';
 
 /**
@@ -623,12 +608,8 @@ export interface GradientSpec {
 export const MAX_GRADIENT_STOPS = 8;
 
 /**
- * Curated, product-grade gradient presets. Authored as full
- * `linear-gradient(<deg>, <stop>…)` strings — the exact source of truth that
- * the preview shader and the export rasteriser both parse, so what's shown is
- * what's rendered. Picked for richer contrast and saturation than the old
- * adjacent-tone ramps (which read as washed-out two-tone blends because only
- * the first two stops were ever sampled).
+ * Curated gradient presets, authored as full `linear-gradient(...)` strings —
+ * the exact source of truth the preview shader and export rasteriser both parse.
  */
 export const GRADIENT_PRESETS: { label: string; value: string }[] = [
 	{ label: 'Indigo', value: 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 50%, #d946ef 100%)' },
@@ -731,14 +712,11 @@ export function createEditorStore() {
 	let audioPath = $state<string | null>(null);
 	let microphonePath = $state<string | null>(null);
 	let metadata = $state<VideoMetadata | null>(null);
-	// Large, replace-only arrays use `$state.raw` — they're swapped wholesale by
-	// their async loaders and never mutated element-wise, so deep-proxying every
-	// element (thousands of entries) would be pure overhead. Only the array
-	// identity needs to be reactive. See AGENTS.md §4 (`$state.raw` for large
-	// immutable blobs).
+	// `$state.raw` for large replace-only arrays: swapped wholesale, never
+	// mutated element-wise, so deep-proxying thousands of entries is pure
+	// overhead — only the array identity needs reactivity. See AGENTS.md.
 	let thumbnailStrip = $state.raw<string[]>([]);
-	// Audio peak envelope (0..1 per bucket) for the timeline waveform.
-	// Transient — recomputed on document load, never persisted.
+	// Audio peak envelope (0..1 per bucket) for the timeline waveform. Transient.
 	let waveform = $state.raw<number[]>([]);
 
 	// Playback
@@ -798,12 +776,9 @@ export function createEditorStore() {
 	// effect. Cleared when the user resets back to source.
 	let lastAppliedPresetId = $state<string | null>(null);
 
-	// Raw cursor samples, shared between the preview (which runs the actual
-	// compositor) and the Cursor panel (which needs them for the trajectory
-	// minimap). Set by VideoPreview on load; read-only elsewhere.
-	// Cursor track — up to tens of thousands of sample objects for a long
-	// recording. Replace-only (swapped wholesale on load), so `$state.raw` avoids
-	// deep-proxying every sample. The name was already "Raw"; now it actually is.
+	// Raw cursor samples shared by the preview compositor and the Cursor panel's
+	// trajectory minimap. Set by VideoPreview on load; read-only elsewhere.
+	// `$state.raw`: tens of thousands of samples, replace-only on load.
 	let cursorSamplesRaw = $state.raw<CursorSampleLike[]>([]);
 
 	// Annotations + active tool (for the preview canvas's place-mode).
@@ -895,9 +870,8 @@ export function createEditorStore() {
 
 	// Export
 	let exportFormat = $state<ExportFormat>('mp4');
-	// Default to the recording's own resolution — for a screen recorder, the
-	// source is usually 1080p+ and downscaling to a fixed "HD" needlessly
-	// softens sharp text/UI. Users can still pick Small/HD/4K in the dialog.
+	// Default to source resolution — downscaling a 1080p+ screen recording to a
+	// fixed "HD" needlessly softens sharp text/UI.
 	let exportQuality = $state<ExportQuality>('source');
 	let exportSpeed = $state<ExportSpeed>('balanced');
 	// Output frame rate for MP4/WebM. `null` = keep the source recording's rate
@@ -1565,8 +1539,6 @@ export function createEditorStore() {
 		}
 		cuts = merged;
 	}
-
-	//
 
 	/** The clip's effective kept bounds [start, end] in original seconds. */
 	function clipBounds(): { start: number; end: number } {

--- a/apps/desktop/src/lib/stores/experimental.svelte.ts
+++ b/apps/desktop/src/lib/stores/experimental.svelte.ts
@@ -1,13 +1,7 @@
 /**
- * Experimental-features flags, shared across the settings page and any
- * surface that gates a feature behind one. Persisted to localStorage so the
- * choice survives reload; off by default so first-run users don't see
- * unfinished UI.
- *
- * Add a new flag by extending `ExperimentalFlag`, adding it to `DEFAULTS`,
- * and exposing a getter/setter pair on the store. The settings page reads
- * the registry via `FLAG_META` to render a row per flag without manual
- * wiring.
+ * Experimental-feature flags, persisted to localStorage and off by default.
+ * Add one by extending `ExperimentalFlag` + `DEFAULTS`; the settings page
+ * renders a row per flag from `FLAG_META`.
  */
 
 import { PersistedState } from "@recast/ui/persisted-state";
@@ -44,11 +38,6 @@ export const FLAG_META: FlagMeta[] = [
 	},
 ];
 
-// NOTE: timeline split/cut editing (formerly the `timelineEditing` flag) has
-// GRADUATED to an always-on feature — its cut math is parity-tested against the
-// Rust export (see cut-parity fixtures) and the timeline collapses cuts in
-// output time. It no longer has a flag. Silence detection + WebCodecs stay
-// opt-in until they clear their own validation gates.
 const DEFAULTS: Record<ExperimentalFlag, boolean> = {
 	silenceDetection: false,
 	webcodecsPreview: false,
@@ -58,11 +47,9 @@ const DEFAULTS: Record<ExperimentalFlag, boolean> = {
 const STORAGE_KEY = "recast-experimental-flags";
 
 function createExperimentalStore() {
-	// Backed by the shared PersistedState primitive: synchronous first read,
-	// JSON storage merged over DEFAULTS (so adding a flag later doesn't wipe a
-	// user's saved choices), and cross-window `storage` sync. Tauri v2 webviews
-	// share a localStorage origin, so flipping a flag in the settings window is
-	// reflected in any open editor windows without a reload.
+	// Merges saved JSON over DEFAULTS so adding a flag later keeps existing
+	// choices. Tauri v2 webviews share a localStorage origin, so a flip in the
+	// settings window reaches open editor windows without a reload.
 	const flags = new PersistedState<Record<ExperimentalFlag, boolean>>(STORAGE_KEY, DEFAULTS);
 
 	return {

--- a/apps/desktop/src/lib/stores/experimental.svelte.ts
+++ b/apps/desktop/src/lib/stores/experimental.svelte.ts
@@ -28,19 +28,19 @@ export const FLAG_META: FlagMeta[] = [
 		key: "silenceDetection",
 		label: "Silence detection & cuts",
 		description:
-			"Detect dead air (quiet audio + still cursor) and skip it during playback/export. Hidden when off.",
+			"Find quiet stretches with no cursor movement and skip them on playback and export.",
 	},
 	{
 		key: "webcodecsPreview",
 		label: "WebCodecs preview engine",
 		description:
-			"Decode the editor preview with WebCodecs and a custom playback clock instead of the HTML <video> element. Removes the freeze when playback crosses a cut/split. On unsupported hardware it falls back to the <video> path automatically. Toggle to compare smoothness against the classic engine.",
+			"Smoother editor playback across cuts and splits. Falls back to the standard player where it isn't supported.",
 	},
 	{
 		key: "selfHosting",
 		label: "Self-hosting server endpoint",
 		description:
-			"Point the app at your own Recast Cloud server. Recast Cloud isn't ready yet, so this is for early self-hosters only — leave off to use the default.",
+			"Point the app at your own Recast Cloud server. Cloud isn't ready yet, so this is for early self-hosters only.",
 	},
 ];
 

--- a/apps/desktop/src/lib/stores/gdrive.svelte.ts
+++ b/apps/desktop/src/lib/stores/gdrive.svelte.ts
@@ -12,17 +12,9 @@ import {
 } from "$lib/ipc";
 
 /**
- * Google Drive store.
- *
- * Mirrors the shape of {@link import("./updater.svelte").updater} — a small
- * `$state`-backed module singleton that the UI binds to directly. Holds the
- * current connection state, the connected account's email (best-effort
- * populated from Google's userinfo endpoint), and an `uploads` map keyed by
- * `uploadId`. The store is a thin shell over Tauri commands and events; the
- * actual OAuth + Drive REST plumbing lives in `commands/gdrive.rs`.
- *
- * Lazy imports keep this module safe to load in the web build, where the
- * Tauri runtime doesn't exist.
+ * Google Drive store — a `$state`-backed singleton the UI binds to. Thin shell
+ * over Tauri commands/events; the OAuth + Drive REST plumbing lives in
+ * `commands/gdrive.rs`. Lazy imports keep it safe to load in the web build.
  */
 
 export type GdriveUploadStatus = "uploading" | "complete" | "error" | "cancelled";
@@ -96,9 +88,8 @@ function createGdriveStore() {
 					webViewLink: payload.webViewLink,
 				};
 			}
-			// Merge into the persistent history so the exports list flips
-			// its action from "Upload" to "Copy link / Re-upload" without
-			// a roundtrip to disk. Re-uploads overwrite the prior entry.
+			// Merge into history so the exports list flips its action without a
+			// disk roundtrip. Re-uploads overwrite the prior entry.
 			uploadHistory[payload.sourcePath] = {
 				fileId: payload.fileId,
 				name: payload.name,
@@ -137,7 +128,7 @@ function createGdriveStore() {
 		if (!(await isTauriApp())) return;
 		try {
 			const records = await gdriveListUploads();
-			// Wipe then refill so deletions made elsewhere propagate.
+			// Wipe then refill so deletions elsewhere propagate.
 			for (const key of Object.keys(uploadHistory)) {
 				delete uploadHistory[key];
 			}
@@ -150,10 +141,8 @@ function createGdriveStore() {
 	}
 
 	/**
-	 * Start the OAuth flow. The Rust side opens the browser, awaits the
-	 * loopback callback, exchanges the code, persists the refresh token,
-	 * and emits `gdrive:connected` on success. We just need to flip
-	 * `connecting` while it's in flight.
+	 * Start the OAuth flow. The Rust side handles the browser/callback/token
+	 * exchange and emits `gdrive:connected`; we just flip `connecting`.
 	 */
 	async function connect() {
 		if (!(await isTauriApp())) return;
@@ -161,7 +150,7 @@ function createGdriveStore() {
 		connecting = true;
 		try {
 			await gdriveConnect();
-			// Success path: the `gdrive:connected` listener flips state.
+			// Success: the `gdrive:connected` listener flips state.
 		} catch (e) {
 			connecting = false;
 			console.error("[gdrive] connect failed", e);
@@ -181,11 +170,9 @@ function createGdriveStore() {
 	}
 
 	/**
-	 * Kick off an upload. Returns the synthetic upload id so callers can
-	 * pair UI state (toast cards, progress bars) to the same key the
-	 * store and Rust side use. The Promise resolves with the result or
-	 * rejects on failure — but the corner-card UI usually relies on the
-	 * `uploads` map updating via events, not on awaiting this Promise.
+	 * Kick off an upload. Resolves with the result or rejects on failure, but
+	 * the corner-card UI usually relies on the `uploads` map updating via
+	 * events rather than awaiting this.
 	 */
 	async function upload(path: string): Promise<GdriveUploadResult> {
 		if (!(await isTauriApp())) throw new Error("not running in Tauri");
@@ -203,9 +190,8 @@ function createGdriveStore() {
 		try {
 			return await gdriveUpload(path, uploadId);
 		} catch (e) {
-			// The Rust side already emitted `gdrive:upload-error` for the
-			// corner-card UI; re-throw for any caller that awaits the
-			// Promise (e.g. for inline error toasts).
+			// Rust already emitted `gdrive:upload-error` for the card; re-throw
+			// for callers that await (e.g. inline error toasts).
 			throw e;
 		}
 	}
@@ -223,11 +209,8 @@ function createGdriveStore() {
 		delete uploads[uploadId];
 	}
 
-	/**
-	 * Drop a path from upload history. Call when a local file is deleted
-	 * so its row stops claiming it was uploaded. The Drive file itself
-	 * isn't touched.
-	 */
+	/** Drop a path from upload history (e.g. local file deleted). The Drive
+	 *  file itself isn't touched. */
 	async function forgetUpload(localPath: string) {
 		delete uploadHistory[localPath];
 		if (!(await isTauriApp())) return;
@@ -243,20 +226,14 @@ function createGdriveStore() {
 		return uploadHistory[localPath];
 	}
 
-	/**
-	 * Look up an in-flight upload by its source file path. Used by list
-	 * views to render per-row progress without forcing every row to
-	 * scan the uploads map on every keystroke. Returns the most recently
-	 * started match if (somehow) multiple uploads target the same path.
-	 */
+	/** In-flight upload for a source path, most-recent first if several match. */
 	function getActiveUploadForPath(
 		localPath: string,
 	): GdriveUpload | undefined {
 		const list = Object.values(uploads).filter(
 			(u) => u.sourcePath === localPath && u.status === "uploading",
 		);
-		// Most recent uploadId wins (uploadIds are timestamp-prefixed in
-		// `upload()`, so lexicographic max = most recent).
+		// uploadIds are timestamp-prefixed, so lexicographic max = most recent.
 		list.sort((a, b) => b.uploadId.localeCompare(a.uploadId));
 		return list[0];
 	}

--- a/apps/desktop/src/lib/stores/layout-mode.svelte.ts
+++ b/apps/desktop/src/lib/stores/layout-mode.svelte.ts
@@ -21,12 +21,9 @@ export const LAYOUT_MODES: {
 ];
 
 /**
- * App-shell chrome preference. Pure UI state (no Rust round-trip), exposed as a
- * single shared `PersistedState` so the Settings toggle and the `(app)` shell
- * read and react to the same reactive value within the window. Persists in
- * localStorage and broadcasts across windows that share the origin.
- *
- * Default `os-native` keeps the shipped chrome; `recast` is the opt-in classic.
+ * App-shell chrome preference. Pure UI state, shared via `PersistedState` so the
+ * Settings toggle and the `(app)` shell react to the same value; persists in
+ * localStorage and broadcasts across same-origin windows.
  */
 export const layoutMode = new PersistedState<LayoutMode>(
   "recast-layout-mode",

--- a/apps/desktop/src/lib/stores/profiles.svelte.ts
+++ b/apps/desktop/src/lib/stores/profiles.svelte.ts
@@ -1,10 +1,7 @@
 /**
- * Reactive recording-profiles store, shared across the profiles page,
- * settings page, and the recording panel.
- *
- * Pure logic (types, migration, capability signatures, device resolution)
- * lives in `$lib/profiles`. This module wraps that logic in $state so that
- * mutations in one route propagate to others without an event bus.
+ * Reactive recording-profiles store, shared across the profiles/settings pages
+ * and the recording panel. Pure logic lives in `$lib/profiles`; this wraps it
+ * in $state so mutations in one route propagate to others without an event bus.
  */
 
 import {
@@ -49,14 +46,10 @@ function createProfilesStore() {
 		persistProfiles(profiles);
 		hydrated = true;
 
-		// Cross-window sync. Tauri v2 webviews share a localStorage origin, so a
-		// save from a sibling window (e.g. editing a profile's countdown/devices
-		// on the Profiles page) fires a `storage` event here. Without this, the
-		// long-lived recording panel kept its first-hydrate snapshot and ignored
-		// edits made elsewhere — per-profile countdowns and device swaps silently
-		// didn't apply. Mirrors how `recordingCountdown` (PersistedState) already
-		// stays in sync. Same-window writes don't fire `storage`, so this never
-		// double-loads our own `persist()`.
+		// Cross-window sync: Tauri webviews share a localStorage origin, so a save
+		// from a sibling window fires `storage` here. Without this the long-lived
+		// recording panel ignored edits made elsewhere. Same-window writes don't
+		// fire `storage`, so this never double-loads our own `persist()`.
 		if (typeof window !== "undefined") {
 			window.addEventListener("storage", (e) => {
 				if (e.key === null || e.key === PROFILES_STORAGE_KEY) {

--- a/apps/desktop/src/lib/stores/recording-countdown.svelte.ts
+++ b/apps/desktop/src/lib/stores/recording-countdown.svelte.ts
@@ -1,15 +1,11 @@
 /**
- * The "count down before capture starts" setting, shared between the Settings →
- * Recording panel (where it's chosen) and the recording panel window (where it's
- * applied). Backed by the shared `PersistedState` primitive so the two windows
- * stay in sync: Tauri v2 webviews share a localStorage origin, so changing the
- * value in Settings reaches an already-open panel live via the `storage` event,
- * no relaunch — the panel no longer needs its own listener.
+ * Pre-capture countdown setting, shared between Settings → Recording and the
+ * recording panel window via `PersistedState`. Tauri v2 webviews share a
+ * localStorage origin, so a Settings change reaches an open panel live via the
+ * `storage` event.
  *
- * Stored as a raw number string (e.g. `"3"`), matching the historical on-disk
- * format; `PersistedState`'s number serializer reads it back and falls back to
- * the default on `NaN`. `value` additionally coerces to a known option so a
- * stale / out-of-range stored number can never reach the UI.
+ * Stored as a raw number string (historical format); `value` coerces to a known
+ * option so a stale / out-of-range number can never reach the UI.
  */
 
 import { PersistedState } from "@recast/ui/persisted-state";

--- a/apps/desktop/src/lib/stores/updater.svelte.ts
+++ b/apps/desktop/src/lib/stores/updater.svelte.ts
@@ -2,17 +2,12 @@ import type { Update } from "@tauri-apps/plugin-updater";
 import { isTauriApp } from "$lib/runtime/tauri";
 
 /**
- * Auto-updater store.
+ * Auto-updater store. On boot, compares the running build against `latest.json`;
+ * if newer, surfaces a non-blocking corner card. Download and install+relaunch
+ * are both explicit user actions, not automatic.
  *
- * Flow: on app boot we ask the Tauri updater plugin to compare the running
- * build against the `latest.json` manifest published with each GitHub release.
- * If a newer version exists we surface a non-blocking corner card offering to
- * download — the download itself does NOT start until the user clicks the
- * download action. Once downloaded, install + relaunch is deferred until they
- * explicitly click "Restart to update".
- *
- * All updater/process APIs are imported lazily so the module is safe to load
- * in the browser (web build) where the Tauri plugins don't exist.
+ * Updater/process APIs are imported lazily so the module loads safely in the
+ * web build where the Tauri plugins don't exist.
  */
 export type UpdaterStatus =
 	| "idle"
@@ -65,12 +60,8 @@ function createUpdaterStore() {
 	}
 
 	async function runCheck() {
-		// Production-only. `tauri dev` ships an unsigned, unpublished build —
-		// the updater plugin can't compare against `latest.json` in any
-		// meaningful way, and surfacing the corner card during local
-		// development just confuses contributors. Vite sets `import.meta.env.DEV`
-		// from the running mode, so this short-circuits cleanly for
-		// `tauri dev` while staying live for `tauri build` artefacts.
+		// Production-only: `tauri dev` ships an unsigned, unpublished build with
+		// nothing to compare against `latest.json`.
 		if (import.meta.env.DEV) return;
 		if (!(await isTauriApp())) return;
 		if (status === "checking" || status === "downloading") return;
@@ -89,10 +80,7 @@ function createUpdaterStore() {
 			version = found.version;
 			notes = found.body ?? null;
 			dismissed = false;
-			// Don't auto-download — surface the corner card and wait for the
-			// user to opt in via the Download button. Saves bandwidth for
-			// users on metered connections and matches the explicit-consent
-			// behavior users expect.
+			// Don't auto-download — wait for explicit opt-in (metered connections).
 			status = "update-available";
 		} catch (e) {
 			console.error("[updater] check failed", e);

--- a/apps/desktop/src/lib/stores/user-store.svelte.ts
+++ b/apps/desktop/src/lib/stores/user-store.svelte.ts
@@ -1,32 +1,27 @@
 import { safeStorage } from "@recast/ui/persisted-state";
 
 export type User = {
-    // --- Identification & Telemetry ---
     installId: string;     // Persistent UUID generated on first run
     sessionId: string;     // Ephemeral UUID regenerated each app launch
     deviceId: string;      // Hardware-linked device ID (if available via Tauri)
-    
-    // --- Account Info ---
+
     userId: string | null; // Database user ID (null for anonymous users)
     username: string | null;
 
     user_type: 'anonymous' | 'registered';
     user_plan: 'oss' | 'pro';
-    
-    // --- Context properties ---
+
     userAgent: string;
     appVersion: string;
     osPlatform: string;
 
-    // --- App state ---
-    // Whether the user has seen the "What's New" modal for the current version.
+    // Versions for which the user has seen the "What's New" modal.
     seen_whats_new: string[];
 };
 
 export function createUserStore() {
-    // Attempt to load an existing install ID to track returning anonymous users,
-    // or generate a new persistent one. Shares the `trace_install_id` key with
-    // `analytics/identity` and the Rust crash reporter.
+    // Shares the `trace_install_id` key with `analytics/identity` and the Rust
+    // crash reporter so returning anonymous users get a stable id.
     const storedInstallId = safeStorage.get<string>('trace_install_id', '');
     const installId = storedInstallId || crypto.randomUUID();
 
@@ -52,10 +47,7 @@ export function createUserStore() {
         get user() { return user; },
         set user(v) { user = v; },
         
-        /**
-         * Helper to grab stripped-down, safe identification payload 
-         * for analytics & telemetry services.
-         */
+        /** Stripped-down, safe identity payload for analytics/telemetry. */
         getTelemetryIdentity() {
             return {
                 installId: user.installId,

--- a/apps/desktop/src/lib/stores/whats-new.svelte.ts
+++ b/apps/desktop/src/lib/stores/whats-new.svelte.ts
@@ -4,9 +4,7 @@ import { LATEST_RELEASE } from "$constants/changelog";
 
 const STORAGE_KEY = "recast-last-seen-version";
 
-// Stored as a raw version string (not JSON) — `safeStorage` infers the
-// string serializer from the "" fallback, preserving the existing on-disk
-// format and returning "" (never equal to a real version) when unset.
+// Raw version string (not JSON); the "" fallback also doubles as "unset".
 function readSeen(): string {
 	return safeStorage.get<string>(STORAGE_KEY, "");
 }
@@ -16,10 +14,9 @@ function writeSeen(v: string) {
 }
 
 function createWhatsNewStore() {
-	// The full-screen center dialog. Now only used by manual entry points
-	// (sidebar, settings, command palette) — no longer auto-opened on boot.
+	// Full-screen dialog, manual entry points only (no longer auto-opened on boot).
 	let open = $state(false);
-	// The non-blocking bottom-right corner card shown after a version bump.
+	// Non-blocking corner card shown after a version bump.
 	let cardVisible = $state(false);
 
 	return {
@@ -34,30 +31,25 @@ function createWhatsNewStore() {
 			return cardVisible;
 		},
 
-		// Called once on app boot. When the running build is newer than the
-		// last version the user acknowledged, surface the corner card instead
-		// of interrupting them with a centered modal.
+		// On boot: surface the corner card (not a modal) when the build is newer
+		// than the last acknowledged version.
 		evaluateOnBoot(): void {
 			const seen = readSeen();
 			if (seen === config.appVersion) return;
 			cardVisible = true;
 		},
 
-		// Open the full dialog on demand without touching the seen marker, so
-		// revisiting from the sidebar/command palette doesn't reset state.
+		// Open on demand without touching the seen marker.
 		show() {
 			open = true;
 		},
 
-		// Close the dialog (and card) and mark this version as seen.
 		dismiss() {
 			open = false;
 			cardVisible = false;
 			writeSeen(config.appVersion);
 		},
 
-		// Dismiss just the corner card — e.g. the user clicked through to the
-		// changelog page, or hit its close button.
 		dismissCard() {
 			cardVisible = false;
 			writeSeen(config.appVersion);

--- a/apps/desktop/src/lib/timeline/cuts.ts
+++ b/apps/desktop/src/lib/timeline/cuts.ts
@@ -1,13 +1,11 @@
 /**
  * Timeline cut model + time mapping.
  *
- * A `TimelineCut` is a removed range expressed on the **original-recording**
- * timeline (the same coordinate space zoom regions and annotations use). The
- * exported / played-back result is the recording minus the union of all cuts.
- *
- * Because cuts remove time from the middle, mapping between original time and
- * output (post-cut) time is piecewise — these helpers own that arithmetic so
- * the playhead, scrubber, and preview all agree.
+ * A `TimelineCut` is a removed range on the **original-recording** timeline
+ * (the same space zoom regions and annotations use); output = recording minus
+ * the union of all cuts. Mapping original↔output time is piecewise because cuts
+ * remove time from the middle — these helpers own that arithmetic so playhead,
+ * scrubber, and preview agree.
  */
 
 export type CutSource = "silence" | "manual";

--- a/apps/desktop/src/lib/timeline/segments.ts
+++ b/apps/desktop/src/lib/timeline/segments.ts
@@ -1,16 +1,11 @@
 /**
  * Timeline segment model — the basis for split + ripple-delete editing.
  *
- * The clip's kept content is `[trimStart, trimEnd]` minus the union of `cuts`
- * (removed ranges). `splitPoints` are user-placed division markers, in
- * original-recording seconds, that subdivide that kept content into
- * individually addressable **segments** WITHOUT removing anything. A split is
- * purely an editor convenience — it has no effect on playback or export until
- * one of the resulting segments is deleted (which becomes a `manual` cut).
- *
- * All functions here are pure so they can be unit-tested in isolation; the
- * store and timeline UI are thin wrappers over them. See ./cuts.ts for the
- * time-remapping arithmetic that closes the gaps left by deletes.
+ * Kept content = `[trimStart, trimEnd]` minus the union of `cuts`. `splitPoints`
+ * (original-recording seconds) subdivide that kept content into addressable
+ * **segments** without removing anything — a split only matters once one of the
+ * segments is deleted (which becomes a `manual` cut). All functions are pure.
+ * See ./cuts.ts for the time-remapping that closes gaps left by deletes.
  */
 
 import { normalizeCuts, type TimelineCut } from "./cuts";
@@ -95,10 +90,9 @@ export interface Seam {
 }
 
 /**
- * Derive the seams between adjacent kept segments — i.e. every place a cut was
- * ripple-removed, collapsing two segments together. A pure boundary between
- * segments that merely *touch* (a split, no removed time) yields no seam. Pure
- * so the timeline's seam markers are unit-tested independently of the DOM.
+ * Derive the seams between adjacent kept segments — every place a cut was
+ * ripple-removed, collapsing two segments together. Segments that merely *touch*
+ * (a split, no removed time) yield no seam.
  */
 export function deriveSeams(segments: Segment[]): Seam[] {
 	const seams: Seam[] = [];

--- a/apps/desktop/src/lib/zoom/auto-apply.ts
+++ b/apps/desktop/src/lib/zoom/auto-apply.ts
@@ -13,20 +13,15 @@ import type { CursorSampleLike } from "$lib/cursor/smoothing";
 import type { ZoomSuggestion } from "$lib/ipc";
 import type { EditorStore } from "$lib/stores/editor-store.svelte";
 
-// A zoom reads well when it is *already* at full scale by the time the
-// action happens and then holds long enough for the viewer to register it.
-// So the window around a trigger is asymmetric: a short lead-in before the
-// trigger, a long hold after. With the default 0.35 s ramps that leaves a
-// comfortable ~2 s plateau at full zoom — a 1 s symmetric window only held
-// ~0.3 s and read as a nervous flicker.
-export const ZOOM_LEAD_IN = 0.6; // seconds of window before the trigger
-export const ZOOM_HOLD = 2.4; // seconds of window after the trigger
-// Shrinks if a neighbour forces it, but never below this — anything shorter
-// barely clears the ramps and reads as a flicker.
+// Asymmetric window: short lead-in, long hold. With the default 0.35 s ramps
+// this leaves a ~2 s plateau at full zoom; a symmetric 1 s window held only
+// ~0.3 s and read as a flicker.
+export const ZOOM_LEAD_IN = 0.6; // before the trigger
+export const ZOOM_HOLD = 2.4; // after the trigger
+// Floor when a neighbour forces a shrink — shorter barely clears the ramps.
 export const MIN_REGION_DURATION = 1.2;
 export const MIN_GAP = 0.08; // guardband so adjacent regions don't visually touch
-// Default scale for auto-placed zooms. 1.8× crops aggressively and feels
-// claustrophobic; ~1.6× keeps surrounding context visible.
+// 1.8× crops too aggressively; ~1.6× keeps surrounding context visible.
 export const AUTO_ZOOM_SCALE = 1.6;
 
 export interface Interval {
@@ -83,8 +78,8 @@ export function planPlacement(
  * a given playback time. Falls back to the canvas centre when there's no
  * usable sample (e.g. cursor data isn't loaded yet, or screen-only capture).
  *
- * `samples` x/y are in source-video pixel space — the same as `metadata.width/
- * height` — so we just normalise. Binary-search nearest by timestamp.
+ * `samples` x/y are in source-video pixel space (same as `metadata.width/
+ * height`), so we normalise and binary-search nearest by timestamp.
  */
 export function resolveZoomCenter(
 	samples: CursorSampleLike[] | null | undefined,
@@ -96,7 +91,6 @@ export function resolveZoomCenter(
 		return { x: 0.5, y: 0.5 };
 	}
 	const targetUs = atTimeSec * 1_000_000;
-	// Binary search for the nearest sample.
 	let lo = 0;
 	let hi = samples.length - 1;
 	while (lo < hi) {

--- a/apps/desktop/src/routes/(app)/+layout.svelte
+++ b/apps/desktop/src/routes/(app)/+layout.svelte
@@ -22,23 +22,19 @@
     routeKey === "/" ? "Home" : routeKey.replace(/^\//, "").split("/")[0],
   );
 
-  // Detected synchronously from the webview UA (same test the shortcuts
-  // registry uses) so there's no chrome flash on first paint; false under SSR.
+  // Detected synchronously from the UA so there's no chrome flash on first
+  // paint; false under SSR.
   const isMac =
     typeof navigator !== "undefined" &&
     /mac|iphone|ipad/i.test(navigator.platform || navigator.userAgent || "");
 
-  // The sidebar is always the inset (rounded panel) layout. Only the titlebar
-  // differs: `os-native` lifts a real, full-width window titlebar to the very
-  // top — outside the sidebar/content shell — with OS-placed controls (macOS
-  // traffic lights top-left, min/max/close top-right on Windows/Linux). `recast`
-  // keeps the unified titlebar embedded in the content header, same on every OS.
+  // Only the titlebar differs by mode: `os-native` lifts a full-width window
+  // titlebar above the shell with OS-placed controls; `recast` embeds it in the
+  // content header.
   let osNative = $derived(layoutMode.current === "os-native");
 
   onMount(() => {
-    // Surface "What's new" once per release (skip if we landed on the changelog
-    // already) and kick off the background update check — both non-blocking
-    // bottom-right cards.
+    // Surface "What's new" once per release (skip if already on the changelog).
     if (page.url.pathname.startsWith("/whats-new")) {
       whatsNew.markSeen();
     } else {
@@ -48,8 +44,7 @@
   });
 </script>
 
-<!-- Sidebar + content. Identical in both modes; in `recast` it also carries the
-     embedded unified titlebar at the top of the content area. -->
+<!-- In `recast` mode this also carries the embedded titlebar at the top. -->
 {#snippet shell()}
   <AppSidebar variant="inset" />
   <Sidebar.Inset
@@ -102,15 +97,10 @@
 {/snippet}
 
 {#if osNative}
-  <!--
-    True window titlebar: full-width, topmost. It lives *inside* the provider so
-    the sidebar trigger gets its context, but is `fixed top-0` so it still
-    renders as a real window titlebar above the shell (a fixed ancestor doesn't
-    trap a fixed child). macOS traffic lights on the left; min/max/close on the
-    right for Windows/Linux. The whole bar is a drag region; the buttons opt
-    out. The `.os-native-shell` rule in app.css offsets the viewport-fixed
-    sidebar down by the titlebar height.
-  -->
+  <!-- Inside the provider so the sidebar trigger has context, but `fixed top-0`
+       so it renders as a real window titlebar above the shell. The whole bar is
+       a drag region; buttons opt out. `.os-native-shell` (app.css) offsets the
+       fixed sidebar down by the titlebar height. -->
   <Sidebar.Provider
     class="os-native-shell fixed inset-x-0 bottom-0 top-10 min-h-0"
   >

--- a/apps/desktop/src/routes/(app)/+page.svelte
+++ b/apps/desktop/src/routes/(app)/+page.svelte
@@ -11,6 +11,8 @@
     type RecordingEntry,
   } from "$lib/ipc";
   import { commandPalette } from "$lib/stores/command-palette.svelte";
+  import { formatSize, relativeDate } from "$lib/format/files";
+  import { openInEditor as openEditorWindow } from "$lib/library/editor-window";
   import {
     AppWindow,
     ArrowRight,
@@ -90,51 +92,12 @@
 
 
 
-  function formatSize(bytes: number) {
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
-    return `${(bytes / 1048576).toFixed(1)} MB`;
-  }
+  // Reactive wrapper: closes over `now` so the relative label re-renders as the
+  // clock ticks. The >1-week fallback here is a short date (no time).
+  const formatDate = (unix: number) => relativeDate(unix, { now });
 
-  function formatDate(unix: number) {
-    const diff = now / 1000 - unix;
-    if (diff < 60) return "just now";
-    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-    if (diff < 86400 * 7) return `${Math.floor(diff / 86400)}d ago`;
-    return new Date(unix * 1000).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-    });
-  }
-
-  function encodeEditorPath(path: string) {
-    return encodeURIComponent(btoa(encodeURIComponent(path)));
-  }
-
-  async function openInEditor(entry: RecordingEntry) {
-    const route = `/editor/${encodeEditorPath(entry.path)}`;
-    if (editorWindow === "new-window") {
-      const label = `editor-${encodeEditorPath(entry.path)
-        .replace(/[^a-zA-Z0-9]/g, "")
-        .slice(0, 48)}`;
-      const existing = await WebviewWindow.getByLabel(label);
-      if (existing) {
-        await existing.setFocus();
-        return;
-      }
-      new WebviewWindow(label, {
-        url: route,
-        title: `Editor - ${entry.filename}`,
-        width: 1440,
-        height: 960,
-        center: true,
-        decorations: false,
-      });
-    } else {
-      goto(route);
-    }
-  }
+  const openInEditor = (entry: RecordingEntry) =>
+    openEditorWindow(entry, editorWindow);
 
   async function showOutputFolder() {
     try {

--- a/apps/desktop/src/routes/(app)/+page.svelte
+++ b/apps/desktop/src/routes/(app)/+page.svelte
@@ -92,8 +92,7 @@
 
 
 
-  // Reactive wrapper: closes over `now` so the relative label re-renders as the
-  // clock ticks. The >1-week fallback here is a short date (no time).
+  // Closes over `now` so the relative label re-renders as the clock ticks.
   const formatDate = (unix: number) => relativeDate(unix, { now });
 
   const openInEditor = (entry: RecordingEntry) =>
@@ -128,8 +127,7 @@
     });
   }
 
-  // Recording modes — each launches the panel; the panel honors the last
-  // chosen source. The mode hint is purely visual prompting today.
+  // Each mode launches the panel; the hint is visual prompting only today.
   const modes = [
     {
       id: "screen",
@@ -157,7 +155,6 @@
     },
   ] as const;
 
-  // Quick actions surfaced as chips below the modes.
   type QuickAction = {
     id: string;
     label: string;

--- a/apps/desktop/src/routes/(app)/exports/+page.svelte
+++ b/apps/desktop/src/routes/(app)/exports/+page.svelte
@@ -83,13 +83,9 @@
 
   onMount(() => {
     fetchExports();
-    // Hydrate Drive upload history so each row's dropdown can pick the
-    // right action ("Upload to Drive" vs. "Copy link / Open / Forget")
-    // without a per-row roundtrip. The store caches across mounts so
-    // subsequent visits are instant.
+    // Hydrate upload history so each row's dropdown picks the right action
+    // (upload vs. copy-link/manage) without a per-row roundtrip.
     void gdrive.init();
-    // Same for Recast Cloud — hydrates sign-in state + the share manifest so
-    // each row shows "Share to Cloud" vs. "Copy link / Manage".
     void cloudShare.init();
     view = safeStorage.get<"grid" | "list">("exports-view", view);
   });
@@ -165,26 +161,21 @@
       const { [entry.path]: _, ...rest } = thumbnails;
       thumbnails = rest;
     }
-    // The file is gone — drop its Drive-upload record so the row doesn't
-    // come back next session claiming it was uploaded. The Drive file
-    // itself is left alone; users can still find it in their Drive.
+    // Local file is gone — drop its upload records so the row doesn't return
+    // next session claiming a copy. The remote objects are left untouched.
     void gdrive.forgetUpload(entry.path);
-    // Same for the Recast Cloud manifest — the local file is gone, so the row
-    // shouldn't keep claiming a cloud copy. The cloud object is left alone.
     void cloudShare.forget(entry.path);
     toast.success(`Moved "${entry.filename}" to trash`);
   }
 
   /**
-   * Share an export to Recast Cloud: uploads the MP4 and creates a public
-   * link, then copies it. Routes to Settings if not signed in — the device
-   * sign-in opens a browser tab and shouldn't happen inline from a menu.
-   * Progress is surfaced via the corner-notification stack.
+   * Share an export to Recast Cloud: upload, create a public link, copy it.
+   * Routes to Settings when signed out — device sign-in opens a browser tab
+   * and shouldn't happen inline from a menu.
    */
   async function shareToCloud(entry: RecordingEntry) {
-    // Only block on the network the very first time (before the store has
-    // hydrated). Afterwards the cached workspace list opens the picker
-    // instantly — no frozen screen. A loading toast covers that first wait.
+    // Only block on the network before the store has hydrated; a loading toast
+    // covers that first wait. Afterwards the cached workspace list is instant.
     if (!cloudShare.initialized) {
       const tid = toast.loading("Connecting to Recast Cloud…");
       await cloudShare.init();
@@ -196,8 +187,7 @@
       return;
     }
     const title = entry.filename.replace(/\.[^.]+$/, "");
-    // Belongs to more than one workspace → let them confirm the target before
-    // the upload commits. A single workspace (or none) needs no prompt.
+    // Multiple workspaces → confirm the target before the upload commits.
     if (cloudShare.workspaces.length > 1) {
       workspacePick = { path: entry.path, title, fileName: entry.filename };
       // Freshen plan/recast counts in the background while they choose.
@@ -250,9 +240,8 @@
   }
 
   /**
-   * Drive upload from the exports list. Routes to Settings if Drive isn't
-   * connected yet — the consent flow opens a browser tab and shouldn't
-   * happen inline from a dropdown menu.
+   * Drive upload from the exports list. Routes to Settings when Drive isn't
+   * connected — the consent flow opens a browser tab, not inline.
    */
   async function uploadToDrive(entry: RecordingEntry) {
     await gdrive.init();
@@ -263,7 +252,6 @@
     }
     try {
       await gdrive.upload(entry.path);
-      // Progress is surfaced via the corner-notification stack.
     } catch (e) {
       toast.error(`Drive upload failed: ${e}`);
     }
@@ -274,9 +262,8 @@
   const shareSupported = isShareSupported();
 
   /**
-   * Open the OS share sheet for an export. Tries the file payload first
-   * (Web Share Level 2) and falls back to sharing the recorded Drive link
-   * if the runtime can't share files.
+   * Open the OS share sheet for an export. Tries the file payload (Web Share
+   * Level 2), falling back to the recorded Drive link if files can't be shared.
    */
   async function shareEntry(entry: RecordingEntry) {
     const fallbackLink = gdrive.getRecordForPath(entry.path)?.webViewLink;
@@ -299,11 +286,7 @@
     }
   }
 
-  /**
-   * Copy the previously-recorded Drive link for this export to the
-   * clipboard. The history map is hydrated from a local JSON manifest on
-   * disk — no network roundtrip.
-   */
+  /** Copy the recorded Drive link from the local manifest — no network. */
   async function copyDriveLink(entry: RecordingEntry) {
     const record = gdrive.getRecordForPath(entry.path);
     if (!record?.webViewLink) {
@@ -318,8 +301,7 @@
     }
   }
 
-  // Open the stored Drive link in the user's default browser. Falls back
-  // to a plain window.open if the opener plugin isn't reachable (web build).
+  // openUrl via the opener plugin; window.open fallback for the web build.
   async function openDriveLink(entry: RecordingEntry) {
     const record = gdrive.getRecordForPath(entry.path);
     if (!record?.webViewLink) {
@@ -334,11 +316,9 @@
     }
   }
 
-  // Forget the Drive-link association for a local file. Used as the
-  // recovery path when the Drive file was deleted in Drive's UI or the
-  // local file no longer matches the uploaded copy — after forgetting,
-  // the dropdown flips back to "Upload to Drive". The Drive object itself
-  // is left untouched: anyone with the previous shared link can still see it.
+  // Recovery path when the Drive file was deleted or no longer matches: drops
+  // the local association so the dropdown flips back to "Upload to Drive". The
+  // Drive object is left untouched.
   async function forgetDriveLink(entry: RecordingEntry) {
     await gdrive.forgetUpload(entry.path);
     toast.success(`Forgot Drive link for "${entry.filename}"`);
@@ -434,7 +414,7 @@
 
 <div class="h-full overflow-y-auto scrollbar-transparent no-scrollbar">
   <div class="mx-auto flex max-w-5xl flex-col gap-8 px-6 py-10">
-    <!-- Hero (mirrors home + recasts rhythm) -->
+    <!-- Hero -->
     <header
       in:fly={{ y: 12, duration: 320, easing: cubicOut }}
       class="flex flex-col gap-3"
@@ -464,7 +444,7 @@
       </p>
     </header>
 
-    <!-- Hero search bar (matches home page) -->
+    <!-- Search bar -->
     <label
       in:fly={{ y: 12, duration: 320, delay: 60, easing: cubicOut }}
       class="group/search flex h-12 items-center gap-3 rounded-xl border border-border/60 bg-card/70 px-4 shadow-(--shadow-craft-inset) backdrop-blur transition-all duration-200 hover:border-border hover:bg-card hover:shadow-craft-sm focus-within:border-border focus-within:bg-card focus-within:shadow-craft-sm"
@@ -492,7 +472,7 @@
       {/if}
     </label>
 
-    <!-- Section header + content -->
+    <!-- Section header -->
     <div
       in:fly={{ y: 12, duration: 320, delay: 120, easing: cubicOut }}
       class="flex flex-col gap-3"
@@ -722,10 +702,7 @@
                   {getExtension(entry.filename)}
                 </Badge>
 
-                <!-- Drive upload progress chip. Sits on the thumbnail so
-                     the user can see at a glance which row is currently
-                     uploading — paired with the bottom progress bar
-                     below to make the state unambiguous. -->
+                <!-- Drive upload progress chip on the thumbnail (paired with the bottom bar). -->
                 {#if activeUpload}
                   <span
                     class="absolute left-1.5 top-1.5 flex h-4 items-center gap-1 rounded-md bg-background/85 px-1.5 text-[9px] font-semibold tracking-wide text-foreground shadow-craft-sm backdrop-blur"
@@ -808,14 +785,9 @@
                       {/if}
                       <DropdownMenu.Separator />
                       {#if gdrive.uploadHistory[entry.path]}
-                        <!-- Already uploaded — the saved webViewLink is the
-                             shareable artifact. We deliberately don't expose
-                             a "re-upload" action: it would create a NEW Drive
-                             file (different fileId) and silently abandon the
-                             URL the user already shared with others. If the
-                             Drive file was deleted in Drive's UI or the local
-                             file no longer matches the upload, "Forget Drive
-                             link" flips the row back to "Upload to Drive". -->
+                        <!-- No "re-upload" action by design: it would mint a new
+                             Drive file (new fileId) and abandon the URL the user
+                             already shared. "Forget" is the way back to upload. -->
                         <DropdownMenu.Item
                           onSelect={() => copyDriveLink(entry)}
                         >
@@ -842,10 +814,8 @@
                       {/if}
                       <DropdownMenu.Separator />
                       {#if cloudShare.uploadHistory[entry.path]}
-                        <!-- Already shared to Recast Cloud — the share link is
-                             the artifact. "Manage" opens scope / password /
-                             expiry / delete; "Forget" just drops the local
-                             association (the cloud copy is left untouched). -->
+                        <!-- "Manage" opens scope/password/expiry/delete; "Forget"
+                             drops only the local association. -->
                         <DropdownMenu.Item onSelect={() => copyCloudLink(entry)}>
                           <Link2 /> Copy share link
                         </DropdownMenu.Item>
@@ -879,9 +849,7 @@
                 </div>
               {/if}
 
-              <!-- Drive upload progress strip. Pinned to the card's bottom
-                   edge; the card has overflow-hidden so this respects the
-                   rounded corners. Width animates with the bytes-sent ratio
+              <!-- Drive upload progress strip; width tracks the bytes-sent ratio
                    the Rust side emits between resumable-upload chunks. -->
               {#if activeUpload}
                 <div
@@ -895,8 +863,7 @@
                 </div>
               {/if}
 
-              <!-- Recast Cloud share-in-flight strip. Phase-based (no byte %),
-                   so it's an indeterminate pulse rather than a fill. -->
+              <!-- Cloud share strip: phase-based (no byte %), so an indeterminate pulse. -->
               {#if cloudActive}
                 <div
                   class="pointer-events-none absolute inset-x-0 bottom-0 h-1 overflow-hidden bg-muted/30"

--- a/apps/desktop/src/routes/(app)/exports/+page.svelte
+++ b/apps/desktop/src/routes/(app)/exports/+page.svelte
@@ -11,6 +11,11 @@
     renameFile,
     type RecordingEntry,
   } from "$lib/ipc";
+  import {
+    formatSize,
+    getExtension,
+    relativeDate as relativeDateBase,
+  } from "$lib/format/files";
   import { morph } from "$lib/morph";
   import { isShareSupported, shareRecording } from "$lib/share";
   import { cloudShare } from "$lib/stores/cloudShare.svelte";
@@ -121,34 +126,9 @@
     thumbnails = next;
   }
 
-  function formatSize(bytes: number) {
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
-    return `${(bytes / 1048576).toFixed(1)} MB`;
-  }
-
-  function formatDate(unix: number) {
-    return new Date(unix * 1000).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  }
-
-  function relativeDate(unix: number) {
-    const diff = Date.now() / 1000 - unix;
-    if (diff < 60) return "just now";
-    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-    if (diff < 86400 * 7) return `${Math.floor(diff / 86400)}d ago`;
-    return formatDate(unix);
-  }
-
-  function getExtension(filename: string) {
-    const dot = filename.lastIndexOf(".");
-    return dot >= 0 ? filename.slice(dot + 1).toUpperCase() : "FILE";
-  }
+  // >1-week fallback keeps the time (date + time), matching this list's history.
+  const relativeDate = (unix: number) =>
+    relativeDateBase(unix, { withTime: true });
 
   async function copyPath(entry: RecordingEntry) {
     try {

--- a/apps/desktop/src/routes/(app)/profiles/+page.svelte
+++ b/apps/desktop/src/routes/(app)/profiles/+page.svelte
@@ -48,29 +48,22 @@
   let nameInputEl = $state<HTMLInputElement | null>(null);
   let query = $state("");
 
-  // Device lists are loaded once on mount and refreshed each time the dialog
-  // opens (devices come and go between recordings). Camera enumeration may
-  // trigger a permission probe so we deliberately keep it off the critical
-  // mount path — re-fetch when the user actually needs to pick.
+  // Refreshed each time the dialog opens since devices come and go between
+  // recordings; camera enumeration may trigger a permission probe.
   let mics = $state<AudioDeviceInfo[]>([]);
   let cameras = $state<BrowserCamera[]>([]);
   let devicesLoading = $state(false);
 
-  // Device-aware combination math: cap is #countdowns × 2 × (2+#mics) ×
-  // (2+#cams) — each attached mic / camera unlocks a new "audio + this mic +
-  // that cam" slot, and each countdown override (Default/Off/3/5/10s) is its
-  // own dimension. With zero mics + zero cams this is 5 × 8 = 40.
+  // Combination cap = #countdowns × 2 × (2+#mics) × (2+#cams); each attached
+  // mic/camera and each countdown override is its own dimension.
   const totalCombinations = $derived(
     profilesStore.maxCombinations(mics, cameras),
   );
   const remainingSlots = $derived(profilesStore.freeSlots(mics, cameras));
   const isFull = $derived(remainingSlots === 0);
 
-  // ---- Editor dialog layout. The device pickers (the rows that make the
-  // dialog tall once mic + camera are on) live in a side panel that slides out
-  // when a device capability is enabled, so the dialog grows *wider* instead of
-  // *taller* — the same move the export dialog makes for GIF settings. Below
-  // `sm` the panel can't fit beside the form, so the pickers fall back inline.
+  // Device pickers live in a side panel so the dialog grows wider, not taller,
+  // when a capability is enabled. Below `sm` they fall back inline.
   const DIALOG_MAIN_W = 408;
   const DIALOG_ASIDE_W = 300;
   let viewportWidth = $state(
@@ -148,9 +141,8 @@
       camera: combo.camera,
       cameraDeviceId: combo.cameraDeviceId,
       cameraLabel: camDevice?.label ?? null,
-      // Carry the auto-picked countdown slot so the saved profile lands on the
-      // free combo (otherwise it always serializes as "inherit" and collides
-      // once the walk starts pinning countdowns to fill the space).
+      // Carry the auto-picked countdown so the profile lands on the free combo
+      // instead of serializing as "inherit" and colliding.
       countdown: combo.countdown,
       isDefault: profilesStore.profiles.length === 0,
     };
@@ -296,10 +288,8 @@
     draft = { ...draft, cameraDeviceId: dev.deviceId, cameraLabel: dev.label };
   }
 
-  // Per-profile countdown override. `null` = inherit the global Settings →
-  // Recording countdown; `0` = no countdown for this profile. Derived from the
-  // shared `COUNTDOWN_OPTIONS` so the picker and the combination math (which
-  // treats each value as its own slot) can never drift apart.
+  // `null` = inherit the global countdown; `0` = off. Derived from the shared
+  // COUNTDOWN_OPTIONS so the picker and the combination math can't drift.
   const countdownChoices: { value: number | null; label: string }[] =
     COUNTDOWN_OPTIONS.map((value) => ({
       value,
@@ -376,7 +366,6 @@
 
 <div class="h-full overflow-y-auto scrollbar-transparent no-scrollbar">
   <div class="mx-auto flex max-w-5xl flex-col gap-8 px-6 py-10">
-    <!-- Hero (matches the home page rhythm) -->
     <header class="flex flex-col gap-3">
       <span
         in:fly={{ y: 6, duration: 280, easing: cubicOut }}
@@ -405,10 +394,8 @@
         <Tooltip.Root>
           <Tooltip.Trigger>
             {#snippet child({ props })}
-              <!--
-                Wrap a span around the disabled button so pointer events still
-                reach the trigger — disabled native buttons swallow hover.
-              -->
+              <!-- Wrap the disabled button so the tooltip trigger still gets
+                   hover — disabled native buttons swallow pointer events. -->
               <span {...props as Record<string, unknown>} class="shrink-0">
                 <Button
                   onclick={addProfile}
@@ -466,8 +453,8 @@
       </p>
     </header>
 
-    <!-- Disabled banner: profiles still configurable, but the recording
-         panel won't auto-apply them until the system is re-enabled. -->
+    <!-- Profiles stay editable here but the recording panel won't auto-apply
+         them until re-enabled. -->
     {#if !profilesStore.enabled}
       <div
         in:fly={{ y: 8, duration: 240, easing: cubicOut }}
@@ -501,7 +488,6 @@
       </div>
     {/if}
 
-    <!-- Hero search bar (matches home page) -->
     <label
       in:fly={{ y: 8, duration: 280, delay: 60, easing: cubicOut }}
       class="group/search flex h-12 items-center gap-3 rounded-xl border border-border/60 bg-card/70 px-4 shadow-(--shadow-craft-inset) backdrop-blur transition-all duration-200 hover:border-border hover:bg-card hover:shadow-craft-sm focus-within:border-border focus-within:bg-card focus-within:shadow-craft-sm"
@@ -529,7 +515,6 @@
       {/if}
     </label>
 
-    <!-- Profile grid -->
     {#if filtered.length === 0}
       <div
         in:fade={{ duration: 200 }}
@@ -573,20 +558,16 @@
                 : "border-border/50 hover:border-border",
             )}
           >
-            <!-- Default cards get a single hairline of primary along the top edge —
-                 the cue is the accent, not a full warning-tinted surface. -->
             {#if profile.isDefault}
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-x-3 top-0 h-px bg-linear-to-r from-transparent via-primary/60 to-transparent"
               ></span>
             {/if}
-            <!-- Hover sheen: a soft top-edge highlight that fades in on hover -->
             <span
               aria-hidden="true"
               class="pointer-events-none absolute inset-x-0 top-0 h-px bg-linear-to-r from-transparent via-foreground/15 to-transparent opacity-0 transition-opacity duration-200 group-hover/card:opacity-100"
             ></span>
-            <!-- Top row: name + default badge + actions -->
             <div class="flex items-start gap-2">
               <button
                 type="button"
@@ -671,7 +652,6 @@
               </DropdownMenu.Root>
             </div>
 
-            <!-- Capability chip rail (native Badge) -->
             <div class="flex flex-wrap gap-1.5">
               {#each capabilities as cap (cap.field)}
                 {@const on = profile[cap.field]}
@@ -690,7 +670,6 @@
               {/each}
             </div>
 
-            <!-- Footer: default toggle pill -->
             <div class="flex items-center justify-between pt-1">
               {#if profile.isDefault}
                 <span in:scale={{ start: 0.85, duration: 220, easing: cubicOut }}>
@@ -728,7 +707,6 @@
           </div>
         {/each}
 
-        <!-- "New profile" call-to-card always at the end of the grid -->
         {#if !isFull}
           <button
             type="button"
@@ -761,7 +739,6 @@
   </div>
 </div>
 
-<!-- Edit dialog -->
 {#snippet toggleRow(
   field: "isDefault" | "systemAudio" | "microphone" | "camera",
   Icon: typeof Star,
@@ -877,8 +854,8 @@
   </div>
 {/snippet}
 
-<!-- Device picker rows, factored so they can render either inline (compact) or
-     inside the slide-out panel (wide) without duplicating the option mapping. -->
+<!-- Factored so they render either inline (compact) or in the slide-out panel
+     (wide) without duplicating the option mapping. -->
 {#snippet micPicker()}
   {@render deviceRow(
     Mic,
@@ -946,8 +923,7 @@
         {/if}
       </header>
 
-      <!-- Name spans the full width above the columns so the form column and
-           the device panel both start at the same Y. -->
+      <!-- Full-width so the form column and device panel start at the same Y. -->
       <div class="border-b border-border/30 px-5 py-4">
         <label
           for="profile-name-input"
@@ -966,9 +942,8 @@
       </div>
 
       <div class="flex items-stretch">
-        <!-- Form column: capability toggles + countdown. Fixed width on wide
-             screens so it doesn't reflow when the device panel slides in;
-             fluid on compact where the pickers fall back inline. -->
+        <!-- Fixed width on wide screens so it doesn't reflow when the device
+             panel slides in; fluid on compact. -->
         <div
           class="flex min-w-0 flex-col divide-y divide-border/30"
           style={isCompactDialog
@@ -1006,9 +981,8 @@
             {@render camPicker()}
           {/if}
 
-          <!-- Countdown override. "Default" inherits the global Settings →
-               Recording countdown; the rest pin a per-profile value for quick
-               access when switching profiles. -->
+          <!-- "Default" inherits the global countdown; the rest pin a
+               per-profile value. -->
           <div class="flex items-center gap-3 px-5 py-3">
             <span
               class="flex size-8 shrink-0 items-center justify-center rounded-lg bg-background/70 text-muted-foreground ring-1 ring-inset ring-border/40"
@@ -1052,10 +1026,8 @@
           </div>
         </div>
 
-        <!-- Device panel: slides out on wide screens when a device capability
-             is on. Holds the mic/camera selectors so the form column stays
-             short. The dialog's width transition does the morph; the fly adds
-             the lateral reveal. -->
+        <!-- Slides out on wide screens when a device capability is on, keeping
+             the form column short. Width transition morphs; fly adds the reveal. -->
         {#if showDevicePanel}
           <aside
             in:fly={{ x: 20, duration: 260, easing: cubicOut }}

--- a/apps/desktop/src/routes/(app)/recasts/+page.svelte
+++ b/apps/desktop/src/routes/(app)/recasts/+page.svelte
@@ -164,9 +164,8 @@
   const shareSupported = isShareSupported();
 
   /**
-   * Open the OS share sheet for a recording. Raw recordings have no Drive
-   * link yet, so this just tries the file payload (Web Share Level 2) and
-   * surfaces a helpful toast when the runtime can't share files.
+   * Open the OS share sheet for a recording. Raw recordings have no Drive link,
+   * so this only tries the file payload (Web Share Level 2).
    */
   async function shareEntry(entry: RecordingEntry) {
     const result = await shareRecording({
@@ -273,7 +272,7 @@
 
 <div class="h-full overflow-y-auto scrollbar-transparent no-scrollbar">
   <div class="mx-auto flex max-w-5xl flex-col gap-8 px-6 py-10">
-    <!-- Hero (mirrors home page rhythm: eyebrow + heading + helper) -->
+    <!-- Hero -->
     <header
       in:fly={{ y: 12, duration: 320, easing: cubicOut }}
       class="flex flex-col gap-3"
@@ -302,7 +301,7 @@
       </p>
     </header>
 
-    <!-- Hero search bar (matches home: h-12 pill, inset shadow, hover lift) -->
+    <!-- Search bar -->
     <label
       in:fly={{ y: 12, duration: 320, delay: 60, easing: cubicOut }}
       class="group/search flex h-12 items-center gap-3 rounded-xl border border-border/60 bg-card/70 px-4 shadow-(--shadow-craft-inset) backdrop-blur transition-all duration-200 hover:border-border hover:bg-card hover:shadow-craft-sm focus-within:border-border focus-within:bg-card focus-within:shadow-craft-sm"
@@ -330,7 +329,7 @@
       {/if}
     </label>
 
-    <!-- Section header: matches home page sections (uppercase eyebrow + actions on the right) -->
+    <!-- Section header -->
     <div
       in:fly={{ y: 12, duration: 320, delay: 120, easing: cubicOut }}
       class="flex flex-col gap-3"

--- a/apps/desktop/src/routes/(app)/recasts/+page.svelte
+++ b/apps/desktop/src/routes/(app)/recasts/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
   import { ConfirmDialog, RenameDialog } from "$components/recast";
   import {
     deleteFile,
@@ -9,6 +8,11 @@
     renameFile,
     type RecordingEntry,
   } from "$lib/ipc";
+  import { formatSize, relativeDate as relativeDateBase } from "$lib/format/files";
+  import {
+    openInEditor as openEditorWindow,
+    openInNewWindow,
+  } from "$lib/library/editor-window";
   import { morph } from "$lib/morph";
   import { isShareSupported, shareRecording } from "$lib/share";
   import {
@@ -42,7 +46,6 @@
   import { toast } from "@recast/ui/sonner";
   import { cn } from "@recast/ui/utils";
   import { listen } from "@tauri-apps/api/event";
-  import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
   import { onMount } from "svelte";
   import { cubicOut } from "svelte/easing";
   import { SvelteSet } from "svelte/reactivity";
@@ -111,62 +114,12 @@
     thumbnails = next;
   }
 
-  function formatSize(bytes: number) {
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
-    return `${(bytes / 1048576).toFixed(1)} MB`;
-  }
+  // >1-week fallback keeps the time (date + time), matching this list's history.
+  const relativeDate = (unix: number) =>
+    relativeDateBase(unix, { withTime: true });
 
-  function formatDate(unix: number) {
-    return new Date(unix * 1000).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  }
-
-  function relativeDate(unix: number) {
-    const diff = Date.now() / 1000 - unix;
-    if (diff < 60) return "just now";
-    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-    if (diff < 86400 * 7) return `${Math.floor(diff / 86400)}d ago`;
-    return formatDate(unix);
-  }
-
-  function encodeEditorPath(path: string) {
-    return encodeURIComponent(btoa(encodeURIComponent(path)));
-  }
-
-  async function openInEditor(entry: RecordingEntry) {
-    const route = `/editor/${encodeEditorPath(entry.path)}`;
-    if (editorWindow === "new-window") {
-      await openInNewWindow(entry);
-    } else {
-      goto(route);
-    }
-  }
-
-  async function openInNewWindow(entry: RecordingEntry) {
-    const route = `/editor/${encodeEditorPath(entry.path)}`;
-    const label = `editor-${encodeEditorPath(entry.path)
-      .replace(/[^a-zA-Z0-9]/g, "")
-      .slice(0, 48)}`;
-    const existing = await WebviewWindow.getByLabel(label);
-    if (existing) {
-      await existing.setFocus();
-      return;
-    }
-    new WebviewWindow(label, {
-      url: route,
-      title: `Editor - ${entry.filename}`,
-      width: 1440,
-      height: 960,
-      center: true,
-      decorations: false,
-    });
-  }
+  const openInEditor = (entry: RecordingEntry) =>
+    openEditorWindow(entry, editorWindow);
 
   async function handleRename(entry: RecordingEntry, nextName: string) {
     const newPath = await renameFile(entry.path, nextName);

--- a/apps/desktop/src/routes/(app)/settings/+page.svelte
+++ b/apps/desktop/src/routes/(app)/settings/+page.svelte
@@ -1112,8 +1112,8 @@
                     Experimental
                   </h2>
                   <p class="mt-0.5 text-[11px] text-muted-foreground/80">
-                    Unfinished features hidden by default — opt in if you want to try
-                    them. They may move, break, or disappear.
+                    Unfinished features, off by default. Turn one on to try it;
+                    it may change or break.
                   </p>
                 </div>
                 <div

--- a/apps/desktop/src/routes/(app)/settings/+page.svelte
+++ b/apps/desktop/src/routes/(app)/settings/+page.svelte
@@ -88,25 +88,19 @@
   let editorWindow = $state<EditorBehavior>("navigate");
   let countdown = $state<CountdownSeconds>(3);
   let closeToTray = $state(true);
-  // Capture quality + frame rate (global recording preferences, read by the
-  // recording panel at start time via shared localStorage). `recordingFps`
-  // null = unset → backend default 60.
+  // Global recording prefs, read by the recording panel via shared localStorage.
   let recordingQuality = $state<RecordingQuality>("auto");
   let recordingFps = $state<number>(60);
-  // Highest refresh rate among attached displays — the capture pipeline can't
-  // produce more unique frames/sec than this, so we only offer fps options up
-  // to it. Defaults to 60 until displays are probed.
+  // Highest display refresh — capture can't produce more unique fps than this,
+  // so fps options are capped to it. 60 until displays are probed.
   let maxRefreshHz = $state(60);
-  // Land on Recording — the daily-use panel (output directory, profiles,
-  // editor behavior) — rather than the leftmost General tab, matching how
-  // people actually reach for these settings.
   let activeTab = $state<SettingsTab>("general");
 
   onMount(() => {
     fetchSettings();
     profilesStore.hydrate();
-    // `mode-watcher-mode` is owned by the mode-watcher library — we only read
-    // it here to reflect the current choice in the radio group.
+    // `mode-watcher-mode` is owned by mode-watcher; we only read it to reflect
+    // the current choice in the radio group.
     currentTheme = safeStorage.get<Theme>("mode-watcher-mode", currentTheme);
     editorWindow = safeStorage.get<EditorBehavior>(
       "recast-editor-window",
@@ -115,10 +109,8 @@
     countdown = recordingCountdown.value;
     recordingQuality = loadRecordingQuality();
     recordingFps = loadRecordingFps() ?? 60;
-    // Gate the fps options by the refresh of the display that will actually be
-    // recorded (the last-selected source), not just the global max — so the
-    // options reflect the user's real target. Re-sync whenever they change the
-    // source in the picker window.
+    // Gate fps options by the refresh of the display that'll actually be
+    // recorded (the last-selected source); re-sync when the source changes.
     void syncMaxRefresh();
     const unlistenSource = listen("source-selected", () => void syncMaxRefresh());
     return () => {
@@ -126,9 +118,8 @@
     };
   });
 
-  /** Resolve the relevant display refresh: the selected monitor's rate when a
-   *  monitor is the active source, else the highest attached display (windows
-   *  /regions don't pin a single display). Best effort — falls back to 60. */
+  /** Selected monitor's refresh when a monitor is the active source, else the
+   *  highest attached display (windows/regions don't pin one). Falls back to 60. */
   async function syncMaxRefresh() {
     try {
       const [displays, last] = await Promise.all([
@@ -157,24 +148,21 @@
 
   function updateRecordingFps(value: number) {
     recordingFps = value;
-    // Persist 60 as null (the "unset/default" sentinel) so a fresh install and
-    // an explicit 60 choice behave identically downstream.
+    // 60 persists as null (the unset/default sentinel) so a fresh install and an
+    // explicit 60 behave identically downstream.
     persistRecordingFps(value === 60 ? null : value);
   }
 
-  // Frame-rate options gated by detected display refresh. 60 is always
-  // available; 120/144/240 appear only when a monitor can actually present
-  // them (a small tolerance covers 119.88/143.86-style reported rates).
+  // 60 is always available; 120/144/240 appear only when a monitor can present
+  // them (tolerance covers 119.88/143.86-style reported rates).
   const fpsOptions = $derived(
     [60, 120, 144, 240].filter(
       (rate) => rate === 60 || maxRefreshHz >= rate - 2,
     ),
   );
 
-  // What capture will actually use on the selected display: the user's desired
-  // rate capped to the highest option this display supports. The stored
-  // preference itself is never mutated, so switching back to a high-refresh
-  // display restores the higher rate.
+  // Desired rate capped to this display's max. The stored preference is never
+  // mutated, so switching back to a high-refresh display restores it.
   const effectiveFps = $derived(
     Math.min(recordingFps, fpsOptions[fpsOptions.length - 1] ?? 60),
   );
@@ -348,16 +336,8 @@
       </p>
     </header>
 
-    <!-- Tabs, grouped by concern:
-           General      — appearance, window behavior + telemetry consent
-           Recording    — storage, editor, capture profiles (daily-use)
-           Cloud        — Recast Cloud + Google Drive (network integrations)
-           Experimental — opt-in unfinished features
-           About        — version, links, and device/encoder diagnostics
-         Telemetry lives under General (it's a small, two-toggle consent
-         block, not its own surface); Experimental gets a dedicated tab so
-         its growing flag list doesn't crowd anything else.
-         Each panel slides/fades in via tw-animate-css inside Tabs.Content. -->
+    <!-- Telemetry lives under General (small two-toggle block); Experimental
+         gets its own tab so its growing flag list doesn't crowd anything. -->
     <div
       in:fly={{ y: 12, duration: 320, delay: 80, easing: cubicOut }}
       class="flex min-w-0 flex-col gap-6"
@@ -393,10 +373,6 @@
           </Tabs.Trigger>
         </Tabs.List>
 
-        <!-- Each Tabs.Content carries its own subtle slide-in/fade-in via
-             tw-animate-css (defined in @recast/ui's tabs-content.svelte) —
-             no need for custom Svelte transitions. Panels not matching the
-             active value unmount, so we don't pay layout cost. -->
         <Tabs.Content value="recording" class="flex min-w-0 flex-col gap-8">
               <!-- Storage / Output directory -->
               <section id="settings-storage" class="flex flex-col gap-3">
@@ -444,10 +420,8 @@
                 </div>
               </section>
 
-              <!-- Countdown before recording. Read by the recording panel
-                   (panel/+page.svelte) via the shared COUNTDOWN_KEY localStorage
-                   entry. Recording profiles can override it per-profile for
-                   quick access. -->
+              <!-- Read by the recording panel via shared localStorage; profiles
+                   can override it per-profile. -->
               <section id="settings-countdown" class="flex flex-col gap-3">
                 <div class="px-1">
                   <h2
@@ -501,11 +475,8 @@
                 </div>
               </section>
 
-              <!-- Capture quality. Global recording preference read by the
-                   recording panel via shared localStorage. Higher tiers raise
-                   fidelity at the cost of real-time encode headroom; if the GPU
-                   can't keep up the result is motion judder, never desync (the
-                   pacer/encoder compensate dropped frames). -->
+              <!-- Higher tiers raise fidelity at the cost of encode headroom; if
+                   the GPU can't keep up the result is judder, never desync. -->
               <section id="settings-capture-quality" class="flex flex-col gap-3">
                 <div class="px-1">
                   <h2
@@ -560,10 +531,8 @@
                 </div>
               </section>
 
-              <!-- Capture frame rate. Options are gated by detected display
-                   refresh — capturing above the monitor's refresh only
-                   duplicates frames, so we don't offer rates no display can
-                   present. 60 is always available. -->
+              <!-- Options gated by display refresh: capturing above it only
+                   duplicates frames. 60 is always available. -->
               <section id="settings-capture-fps" class="flex flex-col gap-3">
                 <div class="px-1">
                   <h2
@@ -760,11 +729,8 @@
         </Tabs.Content>
 
         <Tabs.Content value="cloud" class="flex min-w-0 flex-col gap-8">
-              <!-- Recast Cloud sign-in. The desktop app is fully usable without
-                   it; Cloud unlocks the Loom-style sharing layer (instant
-                   share links, viewer analytics, password protection,
-                   custom branding). Free tier ships 10 active links with a
-                   watermark; paid tier removes both. See [[positioning_plan]]. -->
+              <!-- Optional. Cloud unlocks the Loom-style sharing layer. Free
+                   tier = 10 active links + watermark; paid removes both. -->
               <section id="settings-cloud" class="flex flex-col gap-3">
                 <div class="px-1">
                   <h2
@@ -786,13 +752,8 @@
                 </div>
               </section>
 
-              <!-- Self-hosting server endpoint. Gated behind the `selfHosting`
-                   experimental flag (Settings → Experimental) because Recast
-                   Cloud's server isn't shipped yet — there's nothing to point
-                   at by default, so this stays hidden for everyone except
-                   early self-hosters who opt in. When enabled, the Rust
-                   resolver validates the URL and falls back to the bundled
-                   default, so a bad value can't break sign-in. -->
+              <!-- Gated behind the `selfHosting` flag: Cloud's server isn't
+                   shipped, so there's nothing to point at by default. -->
               {#if experimentalStore.isEnabled("selfHosting")}
                 <section id="settings-cloud-endpoint" class="flex flex-col gap-3">
                   <div class="px-1">
@@ -821,11 +782,8 @@
                 </section>
               {/if}
 
-              <!-- Google Drive connection. Independent of the cloud Account
-                   section above: signing into Recast Cloud and connecting
-                   Google Drive are separate authentications. Both belong on
-                   the Cloud tab since they're both external integrations
-                   that take exports off this machine. -->
+              <!-- Separate auth from Recast Cloud above; both are external
+                   integrations that take exports off this machine. -->
               <section id="settings-google-drive" class="flex flex-col gap-3">
                 <div class="px-1">
                   <h2
@@ -1007,10 +965,8 @@
                 </div>
               </section>
 
-              <!-- Privacy & Telemetry. Two independent, locally-stored opt-ins:
-                   usage analytics (strictly opt-in, default off) and crash
-                   reports (default on). Both anonymous; crash reports are
-                   PII-scrubbed before leaving the machine. -->
+              <!-- Two locally-stored opt-ins: usage analytics (default off) and
+                   crash reports (default on, PII-scrubbed). -->
               <section id="settings-privacy" class="flex flex-col gap-3">
                 <div class="px-1">
                   <h2
@@ -1229,10 +1185,8 @@
                 </div>
               </section>
 
-              <!-- Device & diagnostics. Encoder availability is probed live
-                   against this machine's GPU (not just "compiled in"), so the
-                   matrix reflects what Recast can actually use here — handy in
-                   bug reports and for users wondering why capture is on CPU. -->
+              <!-- Encoder availability is probed live against this GPU (not just
+                   "compiled in"), so the matrix reflects what's actually usable. -->
               <section id="settings-device" class="flex flex-col gap-3">
                 <div class="px-1">
                   <h2

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -2,9 +2,7 @@
   import "@fontsource-variable/google-sans";
   import { TooltipProvider } from "@recast/ui/tooltip";
   import "../app.css";
-  // RecastPlayer theme — needs to load once globally so any route that
-  // mounts <RecastPlayer> (exports preview, future inline players) picks
-  // up the branded media-chrome styling.
+  // Loaded once globally so any route that mounts <RecastPlayer> gets its styling.
   import "@recast/player/styles.css";
 
   import { onNavigate } from "$app/navigation";
@@ -18,10 +16,9 @@
   // First-run privacy prompt — shown once in the main window only.
   let showFirstRun = $state(false);
 
-  // Analytics + global error capture. Overlay windows (panel, pickers,
-  // camera-preview) are skipped — they're transient chrome. The main window
-  // owns `app_opened` / identify / the first-run prompt; editor windows still
-  // get error capture (gated by the errors-consent flag inside the client).
+  // Analytics + global error capture. Overlay windows are skipped; the main
+  // window owns `app_opened` / identify / the first-run prompt. Editor windows
+  // still get error capture (gated by the errors-consent flag in the client).
   onMount(() => {
     if (isTransparentRoute) return;
 
@@ -34,8 +31,7 @@
       );
       if (getCurrentWebviewWindow().label !== "main") return;
 
-      // Hydrate the OS super-property, then record the launch. `app_opened`
-      // is a no-op unless the user has opted into product analytics.
+      // `app_opened` is a no-op unless the user opted into product analytics.
       try {
         const { platform } = await import("@tauri-apps/plugin-os");
         analytics.register({ os: platform() });
@@ -46,9 +42,8 @@
 
       if (!desktopConsent.hasSeenFirstRun) showFirstRun = true;
 
-      // Alias anonymous events to the cloud account on sign-in. The payload
-      // carries `userId` when the server provides it; otherwise identify is a
-      // no-op and only the anonymous install id is tracked.
+      // Alias anonymous events to the cloud account on sign-in; no-op without
+      // a `userId`, leaving only the anonymous install id tracked.
       const unlisten = await listen<{ userId?: string | null }>(
         "auth:signed-in",
         ({ payload }) => {
@@ -111,13 +106,8 @@
     TRANSPARENT_ROUTES.some((p) => page.url.pathname.startsWith(p)),
   );
 
-  // Cross-window toast bridge. The floating panel / camera-preview /
-  // picker windows are too narrow to host a 320px Sonner card themselves
-  // (they're in `TRANSPARENT_ROUTES` and don't render their own Toaster).
-  // They emit `ui:toast` events and we render them through the main
-  // window's Toaster instead. Keeps the in-window panel UI chrome-free
-  // while still giving users a polished notification language instead
-  // of the OS native alert popup.
+  // Cross-window toast bridge: transparent-route windows are too narrow to host
+  // a Sonner card, so they emit `ui:toast` and we render via the main Toaster.
   type UiToastPayload = {
     level: "error" | "warning" | "info" | "success";
     message: string;
@@ -146,24 +136,14 @@
     };
   });
 
-  // System-tray bridge. The tray icon emits high-level intent events that
-  // only make sense in the main window (the recording panel and overlay
-  // routes each have their own scoped listeners for tray actions that
-  // belong to them — e.g. panel listens for `tray:record-toggle` to stop
-  // an in-flight recording). Main-window handlers cover the cases where
-  // no recording is active: jump straight to the source picker for
-  // "Start Recording", run an updater check for "Check for Updates…".
+  // System-tray bridge. Main-window handlers cover tray actions when no
+  // recording is active; panel/overlay routes own the ones scoped to them.
   onMount(() => {
     if (isTransparentRoute) return;
     const offToggle = listen("tray:record-toggle", async () => {
-      // If a recording panel is already open, it owns the toggle — its
-      // own listener will stop the in-flight recording, and we deliberately
-      // do nothing here so we don't steal focus mid-stop. We only handle
-      // the "start from cold" path: open /panel in its own window (or
-      // focus it if it's already there). The panel restores the last
-      // source on mount, so no source-picker detour is needed.
-      //
-      // Label must stay in sync with `launchRecordingPanel()` in ipc.ts.
+      // If a panel is open it owns the toggle, so do nothing here (avoid
+      // stealing focus mid-stop). Otherwise open /panel; it restores the last
+      // source on mount. Label must stay in sync with launchRecordingPanel() in ipc.ts.
       const { getAllWebviewWindows } = await import(
         "@tauri-apps/api/webviewWindow"
       );
@@ -181,25 +161,12 @@
     };
   });
 
-  // OS file-association bridge. Two paths in:
-  //
-  //   * Cold start — the user double-clicked a .recast while the app was
-  //     not running. Rust parses argv in setup() and stashes the path in
-  //     AppState; we drain it once on mount via `take_pending_open_file`.
-  //   * Warm start — the user double-clicked while the app was already
-  //     running. tauri-plugin-single-instance forwards the ghost process's
-  //     argv to the running instance, which emits `app://open-recast`.
-  //     Close-to-tray keeps this listener alive even when main is hidden.
-  //
-  // Both paths funnel through openProjectFromExternalPath, which validates
-  // the file (metadata.json must parse), refuses while recording, and
-  // always spawns a fresh editor window — never navigates main, so the
-  // user's library view and any unsaved editor state stay put.
-  //
-  // Gated on `!isTransparentRoute` so secondary windows (panel, pickers,
-  // camera-preview) don't double-subscribe and race to spawn the window.
-  // Editor secondary windows aren't in TRANSPARENT_ROUTES but they're
-  // labelled `editor-*` rather than `main` — see the label check below.
+  // OS file-association bridge. Cold start: Rust stashes argv in AppState and we
+  // drain it via take_pending_open_file. Warm start: single-instance forwards
+  // argv and emits `app://open-recast`. Both funnel through
+  // openProjectFromExternalPath, which always spawns a fresh editor window
+  // (never navigates main). Gated to the main window so secondary windows don't
+  // race to spawn — editor windows are labelled `editor-*`, see the check below.
   onMount(() => {
     if (isTransparentRoute) return;
     let cancelled = false;
@@ -241,9 +208,8 @@
     };
   });
 
-  // Native macOS-style page transitions via the View Transitions API.
-  // Skipped for overlay/secondary windows (transparent routes) and when the
-  // user prefers reduced motion — CSS handles the reduced-motion case too.
+  // macOS-style page transitions via the View Transitions API. Skipped for
+  // overlay windows and reduced-motion (CSS handles that case too).
   onNavigate((navigation) => {
     if (typeof document === "undefined") return;
     if (!("startViewTransition" in document)) return;
@@ -265,13 +231,10 @@
     });
   });
 
-  // Kick off external-asset download (wallpapers etc.) on first paint. Safe in
-  // both browser and Tauri runtimes — no-op in the browser.
+  // Download external assets (wallpapers etc.) on first paint; no-op in browser.
   initAssets();
-  // Hydrate installed asset-pack extensions and register their contributions.
   initExtensions();
 
-  // Remove the boot splash screen after the app is mounted
   onMount(async () => {
     await tick();
     const boot = document.getElementById("boot");
@@ -282,8 +245,8 @@
 
     if (await isTauriApp()) {
       const theme = await getTauriTheme();
-      // Read-only — mode-watcher owns this key; we just defer to the OS theme
-      // when the user hasn't explicitly picked light/dark.
+      // Defer to the OS theme when the user hasn't picked light/dark. Read-only;
+      // mode-watcher owns this key.
       const stored = safeStorage.get<string>("mode-watcher-mode", "");
       if (theme && (!stored || stored === "system")) {
         setMode(theme);
@@ -291,16 +254,10 @@
     }
   });
 
-  // Diagnostic: record the TRUE fields of every modifier-involved keydown so a
-  // "phantom shortcut" report (e.g. "Ctrl alone toggles the sidebar") can be
-  // traced to the actual event. One Svelte-managed listener, gated through
-  // `log.debug` (emits only in dev or when Diagnostic logging is on), so it's
-  // silent in a normal release build. Plain typing is skipped to keep it
-  // readable. Reading guide: if a panel opens on a keydown whose logged `key`
-  // is "Control"/"Meta" (a bare modifier), the action came from a STALE
-  // listener running OLD code — a classic dev-server HMR leak — and a full
-  // `pnpm tauri dev` restart clears it. If you instead see the SAME keydown
-  // logged twice per physical press, listeners are accumulating.
+  // Logs modifier-involved keydowns to trace "phantom shortcut" reports. Gated
+  // through log.debug (dev / diagnostic only). If a bare-modifier `key`
+  // ("Control"/"Meta") triggers an action, it's a stale HMR listener — restart
+  // `pnpm tauri dev`. The same keydown logged twice means listeners are leaking.
   function logKeyDiagnostic(e: KeyboardEvent) {
     if (!e.ctrlKey && !e.metaKey && !e.altKey && e.key.length === 1) return;
     const t = e.target as HTMLElement | null;
@@ -317,16 +274,9 @@
     });
   }
 
-  // Hard stop for "phantom shortcut" triggers. A modifier key pressed ALONE
-  // (Ctrl / Cmd / Shift / Alt with no other key) is never a shortcut, yet a
-  // stale listener left on `window` by a dev-server hot-reload can still act on
-  // it (the "bare Ctrl toggles the sidebar / palette" ghost). We swallow the
-  // lone-modifier keydown in the CAPTURE phase — which runs before every
-  // bubble-phase listener, ghosts included — so nothing downstream ever sees
-  // it. Harmless in production (nothing should react to a lone modifier);
-  // decisive against HMR ghosts in dev. A real combo like Ctrl+B is untouched:
-  // its keydown carries `key === "b"`, not a bare modifier, so it propagates
-  // normally. Registered via `$effect` so HMR re-establishes it on every patch.
+  // Swallow lone-modifier keydowns in the CAPTURE phase (before any bubble
+  // listener) so stale HMR ghosts can't act on them. A real combo like Ctrl+B
+  // carries `key === "b"` and propagates normally. `$effect` re-registers on HMR.
   const BARE_MODIFIER_KEYS = new Set([
     "Control",
     "Shift",
@@ -347,9 +297,8 @@
   });
 </script>
 
-<!-- One window keydown hook (Svelte allows only one): diagnostics first, then
-     the central shortcut dispatcher. The dispatcher is skipped on the small
-     overlay windows, which own their own minimal key handling. -->
+<!-- Svelte allows one window keydown hook: diagnostics, then the dispatcher
+     (skipped on overlay windows, which own their key handling). -->
 <svelte:window
   onkeydown={(e) => {
     logKeyDiagnostic(e);
@@ -360,20 +309,12 @@
 <TooltipProvider>
   <NavProgress />
   <ModeWatcher />
-  <!-- Overlay windows (panel, camera-preview, pickers) are too small to host
-       a Sonner toast without overflow. Gate the Toaster out of those routes so
-       downstream code that calls `toast.*` is just a no-op there — the main
-       window keeps its toaster as usual. -->
+  <!-- Gate the Toaster out of overlay windows (too small to host a Sonner card);
+       toast.* becomes a no-op there. -->
   {#if !isTransparentRoute}
-    <!-- Position/styling defaults live in @recast/ui/sonner so every
-         consumer (desktop, web) gets the same bottom-right glass-card
-         notification language matching the auto-updater stack. Override
-         here only if a specific route needs a different placement. -->
     <Toaster />
-    <!-- Command palette host: owns the ⌘K shortcut + dialog so they work on
-         every route (editor included), not just the (app) sidebar layout. -->
+    <!-- Owns the ⌘K shortcut + dialog so they work on every route, not just (app). -->
     <CommandPaletteHost />
-    <!-- Global keyboard-shortcut reference (opened from the titlebar or Mod+/). -->
     <ShortcutsDialog />
   {/if}
   <div

--- a/apps/desktop/src/routes/camera-preview/+page.svelte
+++ b/apps/desktop/src/routes/camera-preview/+page.svelte
@@ -35,49 +35,32 @@
     "16:9": 16 / 9,
   };
 
-  // Shape options offered per aspect. Circle is 1:1-only — applying it to
-  // a non-square aspect produces an ellipse, which is rarely what the user
-  // wants and which the composited bubble in the editor doesn't render.
+  // Circle is 1:1-only — on a non-square aspect it'd be an ellipse, which the
+  // composited bubble in the editor doesn't render.
   function allowedShapesFor(a: AspectKey): ShapeKey[] {
     return a === "1:1"
       ? ["square", "rounded", "circle"]
       : ["square", "rounded"];
   }
 
-  // Window radius in CSS pixels for the "rounded" shape — matches the
-  // rounded-3xl token visually. "square" uses 0; "circle" uses a half-side
-  // radius and is only allowed on 1:1 aspect.
+  // CSS px radius for the "rounded" shape — matches the rounded-3xl token.
   const WINDOW_RADIUS = 20;
 
-  // Resize bounds, expressed as fractions of the primary screen's available
-  // logical dimensions. The cap exists because an oversized live preview
-  // (a) covers content the user is recording, and (b) makes the eventual
-  // composited bubble look ridiculous if the user accidentally records at
-  // that size. 25% of either axis is comfortably visible without dominating
-  // the frame.
+  // Max preview size as a fraction of the screen, so it never covers recorded
+  // content or balloons the composited bubble.
   const MAX_SCREEN_FRACTION = 0.25;
-  // Floor on the video width. Small enough to tuck into a corner, but bounded
-  // below by the control bar: the window width equals the video width, and the
-  // controls pill (aspect chip + shape + mirror + close, widest at the "16:9"
-  // label) is ~150px wide. Going narrower than that clipped the centered pill
-  // on both sides, so we floor at a width that always fits it.
+  // Min video width. Window width == video width, so this floors at the width
+  // of the controls pill (~150px, widest at the "16:9" label) to avoid clipping it.
   const CONTROL_BAR_MIN_WIDTH = 168;
   const MIN_LOGICAL_SIZE = CONTROL_BAR_MIN_WIDTH;
 
-  // Fixed-height strip reserved at the *bottom* of the window for the control
-  // bar. The bar lives outside the rounded/overflow-hidden video bubble so it
-  // never gets clipped by the circle/rounded mask and never sits over the
-  // camera feed. The window is this much taller than the video; the aspect
-  // lock (native + JS) only governs `windowHeight − CONTROL_BAR_HEIGHT`, and
-  // the preview state reports just the video rect so the recorded composite is
-  // unaffected. Keep in sync with the strip height in the markup below and the
-  // initial window height in `openCameraPreviewWindow` (ipc.ts).
+  // Bottom strip for the control bar, outside the rounded/clipped video bubble.
+  // The aspect lock governs only `windowHeight − CONTROL_BAR_HEIGHT`. Keep in
+  // sync with the strip height in markup and `openCameraPreviewWindow` (ipc.ts).
   const CONTROL_BAR_HEIGHT = 40;
 
-  // Cached max logical size for the current screen — recomputed on mount and
-  // whenever a resize crosses screens. Used by the aspect-snap helpers to
-  // clamp the box before calling setSize, since the OS-level max-size only
-  // bounds drag-resize and not our programmatic snap-to-aspect calls.
+  // Cached max logical size; aspect-snap helpers clamp against it because the
+  // OS max-size only bounds drag-resize, not our programmatic setSize calls.
   let maxLogicalW = $state(640);
   let maxLogicalH = $state(360);
 
@@ -94,8 +77,7 @@
   let isSnapping = false;
 
   const params = new URLSearchParams(window.location.search);
-  // Accept both legacy DirectShow names (passed as `deviceId` historically)
-  // and real browser MediaDevices ids — `openCameraStream` handles either.
+  // Accepts both legacy DirectShow names and browser MediaDevices ids.
   const deviceQuery = params.get("deviceId");
 
   $effect(() => {
@@ -105,9 +87,8 @@
   });
 
   onMount(() => {
-    // Make the WebView itself fully see-through so the inner rounded
-    // container is the only thing that paints — the OS window already has
-    // `transparent: true`, so corners outside the radius show the desktop.
+    // Make the WebView see-through so only the inner rounded container paints;
+    // the OS window is already transparent, so corners show the desktop.
     const html = document.documentElement;
     const body = document.body;
     html.style.background = "transparent";
@@ -135,10 +116,8 @@
     );
     const unlistenStopped = listen("camera-recording-stopped", () => {});
 
-    // Event-driven preview state push: only fire on actual window changes
-    // (move/resize) or user toggles (aspect/mirror). Replaces the old 350ms
-    // poll that did three IPC round-trips/sec into a Rust mutex even when
-    // nothing changed.
+    // Push preview state only on actual window changes, not on a poll
+    // (the old 350ms poll hit a Rust mutex thrice a second even when idle).
     const unlistenResize = getCurrentWindow().onResized(({ payload }) => {
       void snapToAspect(payload.width, payload.height);
       void reportPreviewState();
@@ -164,9 +143,7 @@
       status = "loading";
       statusMessage = "Connecting to camera…";
 
-      // Validation is best-effort and only meaningful for DirectShow names;
-      // skip silently if the query is a browser deviceId hash (validation
-      // would always fail on those).
+      // Validation only applies to DirectShow names; skip browser deviceId hashes.
       if (deviceQuery && !/^[a-f0-9]{40,}$/i.test(deviceQuery)) {
         try {
           const validation = await validateCameraSource(deviceQuery);
@@ -246,27 +223,18 @@
     getCurrentWindow().close();
   }
 
-  /**
-   * Compute and apply OS-level min/max size constraints. The cap is keyed off
-   * the screen's available *width* (`MAX_SCREEN_FRACTION` of it) — every aspect
-   * we offer is landscape-or-square (ratio ≥ 1), so height is always ≤ width
-   * and a square max box of side `0.25·screenW` bounds the window by width
-   * without ever clipping the proportional height. Called once on mount; the
-   * aspect-snap helpers clamp against `maxLogicalW/H` on top so programmatic
-   * setSize calls (cycling aspect) can't punch past the cap.
-   */
+  // Apply OS min/max size constraints. Cap is keyed off screen width; every
+  // aspect is landscape-or-square (ratio ≥ 1) so a square max box bounds the
+  // window by width without clipping the proportional height.
   async function applySizeConstraints() {
     const screenW = Math.max(window.screen.availWidth || 1920, 320);
     const maxW = Math.floor(screenW * MAX_SCREEN_FRACTION);
-    // Square bounding box for the *video*: width is the binding limit, height
-    // follows aspect. `maxLogicalW/H` are video dimensions; the window adds the
-    // control strip on top.
+    // Square video bounding box; the window adds the control strip on top.
     maxLogicalW = maxW;
     maxLogicalH = maxW;
 
-    // Loosest min height across aspects (the widest, 16:9, gives the shortest
-    // video for a given min width) so the OS floor never out-clamps the native
-    // per-aspect minimum. Window bounds add the control strip.
+    // Use the widest aspect (shortest video) for the min height so the OS floor
+    // never out-clamps the native per-aspect minimum.
     const widestRatio = Math.max(...Object.values(ASPECT_RATIO));
     const minWinH = Math.round(MIN_LOGICAL_SIZE / widestRatio) + CONTROL_BAR_HEIGHT;
 
@@ -284,14 +252,9 @@
     void applyNativeAspectLock();
   }
 
-  /**
-   * Hand the current aspect ratio to the Windows-native WM_SIZING constraint so
-   * the window resizes *proportionally while dragging* — you can't pull width
-   * or height independently, and it won't exceed MAX_SCREEN_FRACTION of the
-   * monitor width. No-op off Windows, where the `snapToAspect` handler below is
-   * the fallback. Re-invoked whenever the aspect changes so the ratio stays in
-   * sync. The drag rect is in physical pixels, so the min crosses as such.
-   */
+  // Hand the aspect ratio to the Windows-native WM_SIZING constraint so drag
+  // resizes proportionally. No-op off Windows, where `snapToAspect` is the
+  // fallback. The drag rect is in physical pixels, so the min crosses as such.
   async function applyNativeAspectLock() {
     try {
       const ratio = ASPECT_RATIO[aspect];
@@ -310,14 +273,7 @@
     }
   }
 
-  /**
-   * Fit a box of (w, h) with the given width/height ratio inside
-   * (maxLogicalW, maxLogicalH) without breaking the ratio. Returns the
-   * largest box that satisfies both bounds. Used by both `applyAspect`
-   * (cycling aspect) and `snapToAspect` (height-snap after drag-resize)
-   * since either path can derive a height that exceeds maxH on tall
-   * aspects, or a width that exceeds maxW after a height-only drag.
-   */
+  // Largest box of the given ratio that fits inside (maxLogicalW, maxLogicalH).
   function fitInsideMax(w: number, h: number, ratio: number): [number, number] {
     let outW = w;
     let outH = h;
@@ -337,8 +293,7 @@
     opts: { snap?: boolean } = {},
   ) {
     aspect = next;
-    // Keep the native WM_SIZING ratio in lockstep with the chosen aspect so the
-    // next drag is constrained to the new shape, not the previous one.
+    // Re-sync the native ratio so the next drag uses the new aspect.
     void applyNativeAspectLock();
     if (opts.snap) {
       const win = getCurrentWindow();
@@ -393,9 +348,8 @@
   function cycleAspect() {
     const nextIndex = (ASPECTS.indexOf(aspect) + 1) % ASPECTS.length;
     const next = ASPECTS[nextIndex];
-    // Coerce circle → rounded when moving off 1:1. A circular border on a
-    // non-square box renders as an ellipse, which is rarely desired and
-    // isn't supported by the composited bubble in the editor either.
+    // Circle → rounded off 1:1; a circle on a non-square box renders as an
+    // ellipse the editor's composited bubble doesn't support.
     if (next !== "1:1" && shape === "circle") {
       shape = "rounded";
     }
@@ -405,8 +359,7 @@
   function cycleShape() {
     const allowed = allowedShapesFor(aspect);
     const idx = allowed.indexOf(shape);
-    // If current shape isn't in the allowed set (shouldn't happen, but
-    // defensively), start from the first allowed option.
+    // Start from the first allowed option if the current shape isn't allowed.
     shape = allowed[(idx === -1 ? 0 : idx + 1) % allowed.length];
     void reportPreviewState();
   }
@@ -416,9 +369,7 @@
     void reportPreviewState();
   }
 
-  // CSS border-radius for the window's outer surface. `circle` uses 50%
-  // (the box is always 1:1 in that case, so it's a true circle). `rounded`
-  // matches the rounded-3xl design token; `square` is a hard cut.
+  // `circle` is 50% (box is always 1:1 then), `rounded` matches the token.
   const cssRadius = $derived.by(() => {
     switch (shape) {
       case "circle":
@@ -450,15 +401,11 @@
     const screenHeight = Math.max(window.screen.availHeight || 1, 1);
 
     const factor = window.devicePixelRatio || 1;
-    // The control strip sits at the *bottom* of the window; the recorded bubble
-    // is just the video region above it. Subtract the strip so the composite
-    // (which uses windowWidth/Height as the bubble rect) matches what's on
-    // screen and isn't stretched by the controls' height.
+    // Subtract the bottom control strip so the reported bubble rect is just the
+    // video region and the composite isn't stretched by the controls' height.
     const videoHeightPhys = Math.max(1, size.height - CONTROL_BAR_HEIGHT * factor);
     const widthLogical = size.width / factor;
-    // Relative corner radius proportional to shorter side, capped at 0.5
-    // (which paints as a full circle on a 1:1 box). Square → 0, circle →
-    // 0.5, rounded → WINDOW_RADIUS scaled to fraction-of-shorter-side.
+    // Corner radius as a fraction of the shorter side, capped at 0.5 (full circle).
     const shortLogical = Math.min(widthLogical, videoHeightPhys / factor);
     const cornerRadius =
       shape === "square"
@@ -496,10 +443,8 @@
   class="group/root relative flex h-screen w-full select-none flex-col scroll-m-0 scrollbar-none"
   data-tauri-drag-region
 >
-  <!-- Video bubble — the ONLY clipped/rounded surface. `flex-1` makes it
-       exactly the window height minus the control strip below, i.e. the video
-       region the aspect lock governs. Controls live outside it (next sibling)
-       so the rounded/circle mask never eats them. -->
+  <!-- Video bubble — the only clipped/rounded surface; `flex-1` is the window
+       height minus the control strip, the region the aspect lock governs. -->
   <div
     class="relative min-h-0 w-full flex-1 overflow-hidden bg-card transition-[border-radius] duration-150 ease-out motion-reduce:transition-none"
     data-tauri-drag-region
@@ -534,9 +479,8 @@
     {/if}
   </div>
 
-  <!-- Control strip — fixed-height row BELOW the bubble (outside its overflow),
-       so the pill is never clipped and never overlaps the camera. The window
-       reserves CONTROL_BAR_HEIGHT for it; the pill fades in on hover. -->
+  <!-- Control strip below the bubble (outside its overflow) so the pill is
+       never clipped; fades in on hover. -->
   <div
     class="flex w-full shrink-0 items-center justify-center"
     data-tauri-drag-region
@@ -602,9 +546,8 @@
 </div>
 
 <style>
-  /* Force-hide the scrollbar (and its reserved gutter) only for this page so
-     the rounded corners read through to the desktop without a Windows
-     scrollbar slot. The global stylesheet sets `scrollbar-gutter: stable`. */
+  /* Hide the scrollbar + gutter for this page only so the rounded corners read
+     through to the desktop (the global stylesheet sets scrollbar-gutter: stable). */
   :global(html) {
     background: transparent !important;
     scrollbar-width: none;

--- a/apps/desktop/src/routes/device-picker/+page.svelte
+++ b/apps/desktop/src/routes/device-picker/+page.svelte
@@ -25,7 +25,6 @@
   import { getCurrentWindow } from "@tauri-apps/api/window";
   import { onMount } from "svelte";
 
-  // Determine device type from URL query: ?type=mic or ?type=camera
   const params = new URLSearchParams(window.location.search);
   const deviceType = params.get("type") === "camera" ? "camera" : "mic";
   const selectedId = params.get("selected") ?? null;
@@ -33,9 +32,8 @@
   let devices = $state<(AudioDeviceInfo | CameraDeviceInfo)[]>([]);
   let currentSelectedId = $state<string | null>(selectedId);
   let isLoading = $state(true);
-  // Set only when camera access is a *blocker* (no MediaDevices API, or
-  // capture refused) — distinct from an empty list, which just means no
-  // camera is plugged in. Drives a dedicated, actionable empty state.
+  // Set only when camera access is a blocker (no API / refused), distinct from
+  // an empty list (no camera plugged in); drives an actionable empty state.
   let accessError = $state<{ reason: CameraAccessReason; message: string } | null>(
     null,
   );
@@ -54,10 +52,8 @@
       if (isMic) {
         devices = await getAudioDevices();
       } else {
-        // Source cameras from the WebView's MediaDevices so the deviceId we
-        // pass downstream is one getUserMedia({deviceId:{exact}}) will accept.
-        // Sorted with non-virtual hardware first; the chosen "default" below
-        // therefore prefers a real webcam over Phone Link / OBS Virtual / etc.
+        // From the WebView's MediaDevices so the deviceId is one getUserMedia
+        // accepts. Non-virtual first, so the default below prefers a real webcam.
         const cams = await enumerateCameras();
         devices = cams.map<CameraDeviceInfo>((c) => ({
           id: c.deviceId,
@@ -74,8 +70,7 @@
       }
     } catch (e) {
       if (e instanceof CameraAccessError) {
-        // Hardware-blocked / API-missing — show the actionable card, not the
-        // generic "no cameras found" (which implies nothing is plugged in).
+        // Show the actionable card, not the generic "no cameras found".
         accessError = { reason: e.reason, message: e.message };
         devices = [];
       } else {

--- a/apps/desktop/src/routes/editor/[file]/+page.svelte
+++ b/apps/desktop/src/routes/editor/[file]/+page.svelte
@@ -79,25 +79,18 @@
   const store = createEditorStore();
 
   let videoEl: HTMLVideoElement | null = $state(null);
-  // True while the WebCodecs preview engine drives the picture (its output-time
-  // clock owns `store.currentTime`). When set, `handleTimeUpdate` must NOT echo
-  // `videoEl.currentTime` back into the store: the `<video>` element free-runs
-  // through the raw (un-cut) recording, so feeding its time to the store fights
-  // the clock and snaps playback back across a cut. Bound from VideoPreview.
+  // True while the WebCodecs engine drives the picture (its clock owns
+  // `store.currentTime`). When set, handleTimeUpdate must NOT echo
+  // `videoEl.currentTime` — the element free-runs through the un-cut recording,
+  // so feeding its time to the store snaps playback back across a cut.
   let webcodecsActive = $state(false);
-  // VideoPreview binds its `captureFrame` to this slot so VideoPlayerControls
-  // can trigger a WYSIWYG screenshot (composite, not raw video frame).
+  // WYSIWYG screenshot (composite, not raw frame); bound from VideoPreview.
   let captureFrame = $state<(() => Promise<Blob | null>) | undefined>(undefined);
-  // Loop-within-trim toggle. Lives here (not inside VideoPlayerControls)
-  // because both the `ended` and `timeupdate` paths to "we hit the end"
-  // need to be handled in this file — `handleVideoEnded` already coordinates
-  // audio elements, and we want one source of truth for "what happens at
-  // the end of the clip" (pause vs. loop).
+  // Loop-within-trim. Lives here because both `ended` and `timeupdate` end-of-clip
+  // paths need handling here, with one source of truth for pause-vs-loop.
   let loopEnabled = $state(false);
 
-  // Editor layout — VS Code/Cursor-style toggles for the right properties
-  // panel and the bottom timeline. Persisted so the choice survives reloads;
-  // a missing or malformed key falls back to "everything visible".
+  // Persisted sidebar/timeline visibility; missing or malformed falls back to all visible.
   const LAYOUT_KEY = "recast-editor-layout";
   function loadLayout(): { sidebar: boolean; timeline: boolean } {
     const fallback = { sidebar: true, timeline: true };
@@ -139,10 +132,8 @@
   let videoSrc = $state("");
   let systemAudioSrc = $state("");
   let micAudioSrc = $state("");
-  // Web Audio timeline engine: sample-accurate, cut-aware audio for the
-  // WebCodecs preview (no seeking → no drift/dropout). Falls back to the
-  // <audio> elements if it can't init/decode. `$state` so creation/failure
-  // re-runs the play effect to switch paths.
+  // Sample-accurate cut-aware audio for the WebCodecs preview (no seeking → no
+  // drift). Falls back to the <audio> elements if it can't init/decode.
   let audioEngine: AudioTimelineEngine | null = $state(null);
   let audioEngineTried = false;
   let audioEngineFailed = $state(false);
@@ -188,12 +179,8 @@
     }
   });
 
-  /** Seek the video (+ audio tracks) back to `trimStart` and resume playback.
-   *  Used by both loop paths — `timeupdate` (catches trimEnd < duration)
-   *  and `ended` (catches the natural end where timeupdate may have
-   *  missed its ~40 ms window thanks to Chromium's ~250 ms timeupdate
-   *  cadence). Returns true if it actually wrapped, so the timeupdate
-   *  handler can short-circuit further work on the same tick. */
+  // Seek video + audio back to trimStart and resume. Used by both loop paths
+  // (timeupdate and ended); returns true so the timeupdate handler can bail.
   function loopBackToStart(): boolean {
     if (!videoEl) return false;
     const start = store.trimStart || 0;
@@ -201,9 +188,7 @@
     for (const el of [systemAudioEl, micAudioEl]) {
       if (el) el.currentTime = start;
     }
-    // play() can reject if the browser thinks user-gesture is required —
-    // unlikely here since we're chaining off an existing play, but log
-    // it instead of silently stalling.
+    // play() can reject (user-gesture) — log instead of stalling silently.
     void videoEl.play().catch((err) => {
       console.warn("loop replay failed:", err);
     });
@@ -214,19 +199,12 @@
   function handleTimeUpdate() {
     if (!videoEl) return;
     if (store.isPlaying) {
-      // In the WebCodecs path the picture clock is the master and owns
-      // `store.currentTime`, and audio is slaved to it by `syncAudioToClock`
-      // (rAF) — NOT to this `<video>` element. The element free-runs through the
-      // raw recording (it doesn't skip cuts), so echoing its time into the store,
-      // running the trim-loop off it, or snapping audio to it all fight the clock
-      // and yank playback/audio back across a cut. Everything below is therefore
-      // legacy-`<video>`-path only; the clock path handles time, end/loop, and
-      // audio elsewhere.
+      // Legacy <video> path only: in the WebCodecs path the clock owns time and
+      // audio, so echoing this element's time would fight it across cuts.
       if (webcodecsActive) return;
       store.currentTime = videoEl.currentTime;
-      // Loop within trim region. Only relevant when trimEnd is set BELOW
-      // the natural duration — at the natural end we rely on the `ended`
-      // event below, which is more precise than timeupdate's ~250 ms tick.
+      // Loop only matters when trimEnd is below the natural duration; the
+      // natural end uses the `ended` event (more precise than the ~250ms tick).
       if (loopEnabled && store.metadata) {
         const trimEnd = store.trimEnd > 0 ? store.trimEnd : store.metadata.duration;
         if (trimEnd > 0 && trimEnd < store.metadata.duration - 0.05) {
@@ -247,12 +225,8 @@
   }
 
   function handleVideoEnded() {
-    // Loop wins over the default "stop at end" — restart from trimStart
-    // and keep audio tracks rolling. Without this short-circuit the
-    // pause + audio.pause() calls below would race with loopBackToStart
-    // and the audio $effect (watching `isPlaying`) might batch the
-    // false→true transition out of existence, leaving audio paused
-    // while video plays.
+    // Loop wins over stop-at-end. The short-circuit avoids the pause calls below
+    // racing loopBackToStart and the audio effect batching out the false→true flip.
     if (loopEnabled && videoEl) {
       loopBackToStart();
       return;
@@ -262,23 +236,13 @@
     micAudioEl?.pause();
   }
 
-  // Slave the audio tracks to the picture clock (WebCodecs path). The audio WAVs
-  // are the FULL recording, so to play the edited timeline they must skip the
-  // same cuts the picture does: `store.currentTime` is the cut-aware playhead the
-  // draw loop publishes, so we snap each element onto it whenever it drifts past
-  // a threshold. Normal playback runs both at 1× so they stay locked with no
-  // correction; the only correction is one snap at each cut boundary (where
-  // `store.currentTime` jumps the cut's length) and on a seek — exactly the
-  // events the old `<video>`-slaving handled late/twice, which is what made audio
-  // lag and repeat. Tighter than the visual threshold since audio desync is more
-  // audible, but not so tight that per-frame jitter causes constant re-seeks.
-  // Steady-state drift past this hard-seeks audio back onto the playhead. Loose
-  // enough that the ~25Hz publish quantum doesn't cause constant re-seeks.
+  // Slave the audio (full-recording WAVs) to the cut-aware picture clock so they
+  // skip the same cuts. Normal playback stays locked at 1×; the only corrections
+  // are one snap per cut boundary and per seek. Steady-state drift past this
+  // threshold hard-seeks audio back; loose enough the ~25Hz publish doesn't thrash.
   const AUDIO_SYNC_THRESHOLD = 0.12;
-  // A cut crossing or a scrub makes the cut-aware playhead jump by far more than
-  // one publish quantum of realtime playback. We detect that and snap audio
-  // EXACTLY on it — which is what keeps audio aligned across cuts of ANY length,
-  // including short ones the drift threshold alone would let slip and accumulate.
+  // A cut crossing or scrub jumps the playhead far past one publish quantum;
+  // detecting it snaps audio exactly on cuts of any length, including short ones.
   const AUDIO_JUMP = 0.12;
   let audioSyncRaf: number | null = null;
   let lastAudioTarget = -1;
@@ -315,17 +279,16 @@
   onDestroy(stopAudioClockSync);
   onDestroy(() => audioEngine?.dispose());
 
-  // Kept original-time audio regions (trim minus cuts) and the current OUTPUT
-  // time — what the Web Audio engine schedules against.
+  // Kept audio regions (trim minus cuts) and current OUTPUT time — what the
+  // Web Audio engine schedules against.
   function audioRegions() {
     return keptRegions(store.inPoint, store.outPoint, store.effectiveCuts);
   }
   function outputNow() {
     return originalToOutput(store.effectiveCuts, store.currentTime);
   }
-  // Lazily build the Web Audio engine on first WebCodecs playback. Tried once;
-  // on failure (no Web Audio / nothing decodes) we mark it failed and the
-  // <audio> elements take over.
+  // Lazily build the engine on first WebCodecs playback. Tried once; on failure
+  // it's marked failed and the <audio> elements take over.
   async function ensureAudioEngine() {
     if (audioEngine || audioEngineTried) return;
     audioEngineTried = true;
@@ -347,11 +310,8 @@
     }
   }
 
-  // Play/pause audio in lockstep with the store's `isPlaying`. On the WebCodecs
-  // path we drive the sample-accurate Web Audio engine (which schedules around
-  // cuts — no seeking); the <audio> elements are the fallback / legacy-<video>
-  // path. Reads `audioEngine`/`audioEngineFailed` reactively so creation/failure
-  // re-runs this and switches paths.
+  // Play/pause audio in lockstep with `isPlaying`. WebCodecs path drives the
+  // Web Audio engine; the <audio> elements are the fallback / legacy path.
   $effect(() => {
     const playing = store.isPlaying;
     const wc = webcodecsActive;
@@ -397,10 +357,8 @@
     else stopAudioClockSync();
   });
 
-  // Keep the engine locked to the playhead on a SEEK or a cut EDIT while
-  // playing. Cuts don't move OUTPUT time (it's gapless), so normal playback —
-  // including crossing a cut — never reschedules; only a real scrub/loop (output
-  // jump) or a change to the kept regions does. Runs at the publish rate; cheap.
+  // Reschedule the engine only on a seek/loop (output jump) or a kept-regions
+  // edit. Crossing a cut doesn't move gapless OUTPUT time, so it doesn't trigger.
   const ENGINE_RESEEK_JUMP = 0.15;
   let engineSyncOut = -1;
   let lastRegionsKey = "";
@@ -437,12 +395,8 @@
     audioEngine?.setVolume(settings.volume, settings.muted);
   });
 
-  // Snap audio to the video's time whenever the user scrubs. WebCodecs path:
-  // audio follows the clock (`syncAudioToClock`), and the `<video>` element gets
-  // seeked by its own transport-correction (to a cut-aware time, but mid-stream),
-  // so snapping audio to those events would fight the clock and reintroduce the
-  // lag/repeat. Skip it there — paused-scrub audio realigns on the next play via
-  // the play/pause effect.
+  // Snap audio to the video time on scrub. Skipped on the WebCodecs path, where
+  // audio follows the clock and snapping to seeks would fight it.
   function handleVideoSeeked() {
     if (!videoEl || webcodecsActive) return;
     const t = videoEl.currentTime;
@@ -451,9 +405,8 @@
     }
   }
 
-  // Frame-step on the OUTPUT (post-cut) axis so stepping across a cut boundary
-  // lands on the next kept frame, never inside a removed range. Mirrors the
-  // player controls' stepFrame; `store.currentTime` stays original time.
+  // Frame-step on the OUTPUT axis so stepping across a cut lands on the next
+  // kept frame, never inside a removed range. `store.currentTime` stays original.
   function frameStepSeek(direction: 1 | -1) {
     if (!store.metadata) return;
     const cuts = store.effectiveCuts;
@@ -483,9 +436,8 @@
   }
 
   async function loadThumbnailStrip(path: string) {
-    // Skip when we don't have a usable duration yet — bumping the token
-    // would cancel any genuinely in-flight strip, and generateThumbnails
-    // against a 0-duration source just yields black frames.
+    // Skip without a usable duration: bumping the token would cancel an in-flight
+    // strip, and a 0-duration source just yields black frames.
     const duration = store.metadata?.duration ?? 0;
     if (duration <= 0) return;
 
@@ -504,12 +456,9 @@
     }
   }
 
-  // Decode the audio peak envelope for the timeline waveform. Best-effort
-  // and fully async — the editor is usable before it resolves.
+  // Decode the audio peak envelope for the timeline waveform. Best-effort async.
   async function loadWaveform() {
-    // Sub-5s clips don't benefit from a waveform strip — the timeline is
-    // too narrow to show anything readable, and the FFmpeg pass to decode
-    // peaks costs more than the result is worth at that scale.
+    // Skip sub-5s clips: too narrow to read, and the FFmpeg pass isn't worth it.
     const duration = store.metadata?.duration ?? 0;
     if (duration > 0 && duration < 5) {
       store.waveform = [];
@@ -561,8 +510,7 @@
     videoEl?.pause();
     systemAudioEl?.pause();
     micAudioEl?.pause();
-    // Tear down the Web Audio engine for the previous file; it rebuilds for the
-    // new one on first play.
+    // Tear down the previous file's engine; it rebuilds on first play.
     audioEngine?.dispose();
     audioEngine = null;
     audioEngineTried = false;
@@ -594,9 +542,8 @@
       store.audioPath = document.audioPath ?? null;
       store.microphonePath = document.microphonePath ?? null;
       store.waveform = [];
-      // Waveform decode is only consumed by the cut lane (experimental).
-      // Skip the ffmpeg roundtrip when the feature is off; the $effect below
-      // back-fills it if the user flips the flag on later.
+      // Only the experimental cut lane uses the waveform; skip the ffmpeg pass
+      // when off (the $effect below back-fills if the flag flips on).
       if (experimentalStore.silenceDetection) void loadWaveform();
       systemAudioSrc = document.audioPath
         ? convertFileSrc(document.audioPath)
@@ -606,8 +553,8 @@
         : "";
       cameraPath = document.cameraPath ?? null;
       cameraSrc = cameraPath ? convertFileSrc(cameraPath) : "";
-      // Mount the editor body so the <video> element exists before we call load().
-      // The video element lives inside VideoPreview, which only renders when !isLoading.
+      // Mount the editor body (VideoPreview renders only when !isLoading) so the
+      // <video> exists before load().
       isLoading = false;
       await tick();
       videoEl?.load();
@@ -622,24 +569,20 @@
     }
   }
 
-  // Smart Auto-Zoom: on the first load of a recording, place a focus region
-  // at every detected click + settle-after-motion. Persisted via the
-  // `autoZoomApplied` flag on the project document so subsequent reopens
-  // don't repopulate (the user may have intentionally cleared regions).
+  // On first load, place a focus region at each detected click + settle. The
+  // `autoZoomApplied` document flag stops reopens from repopulating cleared regions.
   let autoZoomRunning = false;
 
   async function maybeRunAutoZoom() {
     if (autoZoomRunning) return;
     if (!store.autoZoomEnabled || store.autoZoomApplied) return;
     if (!cursorPath) {
-      // Screen-only recording with no cursor track to analyse — latch the
-      // flag so we don't retry every reopen.
+      // No cursor track to analyse — latch the flag so we don't retry on reopen.
       store.autoZoomApplied = true;
       return;
     }
     if (store.zoomRegions.length > 0) {
-      // Project already has regions (autosave restored them, or the user
-      // added some manually before the auto-apply ran). Skip silently.
+      // Regions already exist (autosave-restored or manual) — skip silently.
       store.autoZoomApplied = true;
       return;
     }
@@ -651,8 +594,7 @@
     if (!cursorPath) return;
     autoZoomRunning = true;
     try {
-      // generateAutoZoom latches store.autoZoomApplied itself (it's persisted
-      // document state) on all non-error paths, before its own autosave.
+      // generateAutoZoom latches store.autoZoomApplied itself on non-error paths.
       const outcome = await generateAutoZoom(store, cursorPath, {
         documentPath,
       });
@@ -681,9 +623,8 @@
     }
   }
 
-  // Re-run is exposed to FocusPanel via a typed CustomEvent on `window` so
-  // the deeply-nested panel doesn't need to thread a prop through every
-  // intermediate component.
+  // Re-run is exposed to FocusPanel via a window CustomEvent so the nested panel
+  // doesn't thread a prop through every component.
   $effect(() => {
     function onRerun() {
       store.clearAutoZooms();
@@ -694,8 +635,8 @@
     return () => window.removeEventListener("recast:rerun-auto-zoom", onRerun);
   });
 
-  // Export lifecycle UI state — lives in the route, not the store, because the
-  // overlay handles success/cancel/error reveals that don't belong in global state.
+  // Export lifecycle UI state — in the route, not the store, since the overlay
+  // owns success/cancel/error reveals that don't belong in global state.
   let exportStartedAt = $state<number>(0);
   let exportNow = $state<number>(Date.now());
   let exportCancelling = $state(false);
@@ -704,8 +645,7 @@
   let activeExportId = $state<string | null>(null);
 
 
-  // Rotating, encode-themed status messages shown below the progress ring —
-  // gives the wait some personality (à la an AI assistant's "thinking" line).
+  // Rotating status messages shown below the progress ring during encode.
   const ENCODE_MESSAGES = [
     "Crunching frames",
     "Encoding pixels",
@@ -716,8 +656,7 @@
   ];
   let encodeMessageIndex = $state(0);
 
-  // Preparing-stage substages — surfaced in the dialog so users see the
-  // hybrid-raster work happening rather than a generic spinner.
+  // Preparing-stage substages, surfaced in the dialog instead of a generic spinner.
   let prepText = $state<"pending" | "running" | "done">("pending");
   let prepCursor = $state<"pending" | "running" | "done">("pending");
   let prepSending = $state<"pending" | "running" | "done">("pending");
@@ -727,10 +666,8 @@
     prepSending = "pending";
   }
 
-  // Eased display percentage. Raw FFmpeg progress is jumpy (5–10% jumps,
-  // sticky around 99%), so we lerp the rendered ring toward it with a
-  // cubic-bezier-like response. Rerun on every animation tick while
-  // exporting so the ring never sits stale.
+  // Eased display percentage: raw FFmpeg progress is jumpy, so lerp the ring
+  // toward it each animation tick while exporting.
   let displayPct = $state(0);
   let easeRafHandle: number | null = null;
   $effect(() => {
@@ -749,14 +686,11 @@
         : Math.min(99.5, Math.max(0, store.exportProgress ?? 0));
       const dt = lastTs === null ? 16 : Math.max(1, Math.min(64, now - lastTs));
       lastTs = now;
-      // Critically-damped follower with a ~250 ms time constant. The
-      // exponential form is shape-equivalent to a cubic-bezier-ease-out
-      // toward `target` and avoids overshoot at the high end.
+      // Critically-damped follower (~250ms tau): ease-out toward target, no overshoot.
       const tau = 250;
       const k = 1 - Math.exp(-dt / tau);
       const next = displayPct + (target - displayPct) * k;
-      // Don't animate backwards on micro-jitter; the underlying export is
-      // monotonic so the ring should feel monotonic too.
+      // Never animate backwards; the export is monotonic so the ring should be too.
       displayPct = Math.max(displayPct, next);
       easeRafHandle = requestAnimationFrame(tick);
     }
@@ -773,8 +707,7 @@
     return store.annotations.some((a) => a.kind.kind === "text");
   }
 
-  // ETA — only meaningful once we have ≥10% real progress. Computed from
-  // wall-clock-elapsed × (1 − pct) / pct, smoothed by the same ring follower.
+  // ETA from elapsed × (1 − pct) / pct; only meaningful past ≥10% progress.
   function exportEtaMs(): number | null {
     if (!exportHasProgress || exportFinalizing) return null;
     const pct = store.exportProgress ?? 0;
@@ -813,10 +746,8 @@
 
     if (next.kind === "success") {
       toast.success("Export complete");
-      // Refresh the tray's Recent Exports submenu so this export is
-      // selectable from there immediately. Pass `isRecording: null` to
-      // signal "list changed, don't touch the recording flag" — the
-      // panel window is the authoritative source for that.
+      // Refresh the tray's Recent Exports. `null` = "list changed, leave the
+      // recording flag alone" (the panel window owns that).
       void refreshTray(null).catch(() => {});
     } else if (next.kind === "cancelled") {
       toast.info("Export cancelled");
@@ -833,22 +764,14 @@
         const next = Math.min(Math.max(event.progress, 0), 100);
         const current = store.exportProgress ?? 0;
 
-        // FFmpeg progress gets noisy near the end on some Windows builds.
-        // Keep the UI monotonic and ignore sub-tenth-percent jitter so the
-        // progress bar does not flicker around 99%.
+        // FFmpeg progress is noisy near the end on some Windows builds; keep the
+        // bar monotonic and ignore sub-0.1% jitter so it doesn't flicker at 99%.
         if (!exportHasProgress || next >= 100 || next > current + 0.1) {
           store.exportProgress = Math.max(current, next);
         }
         exportHasProgress = true;
-        // Previously this block speculatively flipped the UI to "finalizing"
-        // at ≥99.5% raw progress, on the assumption that stderr pipe batching
-        // was hiding the real `progress=end`. With `-progress pipe:2
-        // -stats_period 0.1` the Rust side now emits a real `finalizing`
-        // event within ~100ms of ffmpeg's actual finish, so the speculative
-        // flip was just mislabelling the last second of active encoding as
-        // "Writing video file…". Only a very-near-end safety net remains
-        // below as a last-resort for the rare case where the `finalizing`
-        // event is dropped entirely.
+        // Safety net only: Rust emits a real `finalizing` event now, so this just
+        // catches the rare case where that event is dropped.
         if (!exportFinalizing && next >= 99.95) {
           exportFinalizing = true;
         }
@@ -884,9 +807,8 @@
     resetPrep();
 
     try {
-      // Build the exact payload Rust renders: hybrid-raster passes (text →
-      // PNG, cursor → sprite sheet) plus per-lane enable toggles. The prep
-      // sub-stages drive the "Preparing…" UI via these hooks.
+      // Build the payload Rust renders (text→PNG, cursor→sprite sheet); the
+      // hooks drive the "Preparing…" sub-stages.
       const { renderState: finalRenderState, metadata: meta } =
         await buildExportRenderState(store, {
           hooks: {
@@ -896,8 +818,7 @@
           },
         });
 
-      // Capture the exact settings this export ran with — the single most
-      // useful line when a user reports "my export looked wrong".
+      // The settings this export ran with — key when a user reports a bad export.
       log.info("export", "export_started", {
         exportId,
         format: store.exportFormat,
@@ -919,13 +840,11 @@
         gifSettings:
           store.exportFormat === "gif" ? store.gifSettings : undefined,
         speed: store.exportSpeed,
-        // GIF carries its own fps in gifSettings; MP4/WebM use the picker
-        // (null = keep source rate).
+        // GIF carries fps in gifSettings; MP4/WebM use the picker (null = source).
         fps: store.exportFormat === "gif" ? undefined : store.exportFps,
         onState: handleExportState,
       });
-      // Safety net: if the export-state success event was missed, fall back to
-      // the Promise result. Don't overwrite if the listener already set it.
+      // Fall back to the Promise result if the success event was missed.
       if (!exportResult) {
         setExportResult({ kind: "success", path });
       }
@@ -977,10 +896,8 @@
     exportResult = null;
   }
 
-  // Options phase is purely UI — true while the user is in the format/quality
-  // picker, before they hit Export. Progress/result phases are derived from
-  // the export pipeline state above, so the flow dialog stays a single
-  // controlled surface that morphs as the pipeline advances.
+  // Options phase is UI-only (the picker before Export); progress/result phases
+  // derive from the pipeline state, so the dialog is one surface that morphs.
   let exportOptionsOpen = $state(false);
   const exportPhase: ExportFlowPhase | null = $derived(
     store.isExporting
@@ -997,10 +914,8 @@
   );
   const isExportFlowOpen = $derived(exportPhase !== null);
 
-  // Silence-detection cuts only. Manual ripple deletes (`source: "manual"`) are
-  // a shipped feature — always honoured in preview and export regardless of the
-  // experimental flag — so they must NOT trip the "enable Silence detection"
-  // banner. Only auto-detected silence cuts depend on that flag's lane/UI.
+  // Silence cuts only. Manual ripple deletes are always honoured, so they must
+  // not trip the "enable Silence detection" banner — only auto cuts depend on it.
   const silenceCutCount = $derived(
     store.cuts.filter((c) => c.source === "silence").length,
   );
@@ -1019,9 +934,8 @@
     void handleExport();
   }
 
-  // Esc routes per phase: cancel a running export, dismiss a finished one,
-  // close the options picker. Backdrop click follows the same logic except
-  // it never cancels a running export (too easy to misclick mid-encode).
+  // Esc per phase: cancel a running export, dismiss a finished one, close the
+  // picker. Backdrop click is the same but never cancels a running export.
   function handleExportEscape() {
     if (store.isExporting) {
       void handleCancelExport();
@@ -1054,11 +968,8 @@
     }
   }
 
-  /**
-   * Push the most recent export to Google Drive. If Drive isn't connected
-   * yet we send the user to Settings instead — connecting opens a browser
-   * tab and can't sensibly happen from this modal-style success card.
-   */
+  // Push the latest export to Drive, or route to Settings to connect first
+  // (connecting opens a browser tab, which can't happen from this card).
   async function uploadExportToDrive() {
     if (exportResult?.kind !== "success") return;
     await gdrive.init();
@@ -1069,20 +980,15 @@
     }
     try {
       await gdrive.upload(exportResult.path);
-      // Progress + completion surface inline via successUpload (below) AND
-      // through the corner-notifications store, so the user can still track
-      // the upload if they dismiss the success card.
+      // Progress surfaces inline via successUpload and the corner-notifications
+      // store, so the upload stays trackable after dismissing the card.
     } catch (e) {
       toast.error(`Drive upload failed: ${e}`);
     }
   }
 
-  /**
-   * Share the just-exported file to Recast Cloud and copy the public link.
-   * Progress surfaces through the corner-notifications stack (the cloud
-   * upload is phase-based, not byte-based, so it isn't mirrored inline like
-   * the Drive card). Routes to Settings if not signed in.
-   */
+  // Share the export to Recast Cloud and copy the link; routes to Settings if
+  // not signed in. Progress surfaces through corner-notifications (phase-based).
   async function shareCurrentExportToCloud() {
     if (exportResult?.kind !== "success") return;
     await cloudShare.init();
@@ -1106,14 +1012,13 @@
     }
   }
 
-  // Mirror the export-success card's path so the upload state below can key
-  // off it reactively. Null whenever the dialog isn't in the success state.
+  // The success card's path, so the upload state can key off it. Null unless the
+  // dialog is in the success state.
   const successPath = $derived(
     exportResult?.kind === "success" ? exportResult.path : null,
   );
-  // Most-recent upload (any status) targeting the freshly-exported file —
-  // drives the inline progress/result rendering inside the success card.
-  // Survives status transitions so we can show the completed state too.
+  // Most-recent upload for the exported file; drives the inline progress in the
+  // success card and survives status transitions.
   const successUpload = $derived.by(() => {
     if (!successPath) return undefined;
     const list = gdrive.activeUploads.filter(
@@ -1142,8 +1047,8 @@
     }
   }
 
-  // `navigator.share` exposure is static — sample once at module load so the
-  // Share button can be conditionally rendered without a reactive read.
+  // `navigator.share` exposure is static; sample once so the button renders
+  // without a reactive read.
   const shareSupported = isShareSupported();
 
   async function shareExportedFile() {
@@ -1229,10 +1134,8 @@
     }
   }
 
-  // Wire the editor's mod-combo shortcuts to the central registry. They stay
-  // bound for exactly as long as this route is mounted, and are inert on every
-  // other route (no handler registered there). Each bails while the export flow
-  // dialog owns the screen.
+  // Bind the editor's mod-combo shortcuts to the central registry for the life
+  // of this route. Each bails while the export flow dialog owns the screen.
   onMount(() =>
     registerShortcutHandlers({
       "editor.undo": () => {
@@ -1254,17 +1157,13 @@
   );
 
   function handleKeydown(e: KeyboardEvent) {
-    // `repeat` fires this on auto-repeat while a key is held — a held
-    // Ctrl+B would otherwise flip the panel on every tick. Bail so each
-    // physical press counts once.
+    // Bail on auto-repeat so a held key counts once.
     if (e.defaultPrevented || e.repeat) return;
 
-    // The flow dialog now owns Esc routing per phase; just bail if it's
-    // active so the global shortcuts below don't fire under it.
+    // The flow dialog owns Esc routing; bail so global shortcuts don't fire under it.
     if (isExportFlowOpen) return;
 
-    // Never hijack typing. Inputs, textareas, and contenteditable surfaces
-    // (text annotations) all own their own keystrokes.
+    // Never hijack typing in inputs / textareas / contenteditable.
     const target = e.target;
     if (
       target instanceof HTMLInputElement ||
@@ -1274,14 +1173,11 @@
       return;
     }
 
-    // Mod-combo editor shortcuts (undo/redo/save, toggle panels, presets) are
-    // owned by the central shortcut registry — see `registerShortcutHandlers`
-    // below and `$lib/shortcuts`. Dispatched once from the root layout, so they
-    // can't double-fire. Bail here on any held Ctrl/⌘ so a modifier combo never
-    // trips a plain-key action below.
+    // Mod-combo shortcuts are owned by the central registry; bail on Ctrl/⌘ so a
+    // combo never trips a plain-key action below.
     if (e.ctrlKey || e.metaKey) return;
 
-    // Plain keys (no Ctrl/⌘): play/pause, frame step, fullscreen.
+    // Plain keys: play/pause, frame step, fullscreen.
     switch (e.key) {
       case " ":
         e.preventDefault();
@@ -1323,9 +1219,7 @@
     videoEl.muted = true;
   });
 
-  // Back-fill the waveform if the experimental flag flips on after the
-  // document loaded with it off. The decode is one-shot per recording, so
-  // only fire when we actually have audio paths and no peaks yet.
+  // Back-fill the waveform if the experimental flag flips on after load.
   $effect(() => {
     if (!experimentalStore.silenceDetection) return;
     if (store.waveform.length > 0) return;
@@ -1336,10 +1230,7 @@
   $effect(() => {
     if (!store.isExporting) return;
     exportNow = Date.now();
-    // Elapsed-time timer for the export status strip. The Rust side is now
-    // the source of truth for when the UI flips to "finalizing" — it emits
-    // an explicit event on ffmpeg's `progress=end`, typically within ~100ms.
-    // No more client-side speculative flips on progress stalls.
+    // Elapsed-time timer for the status strip.
     const timer = setInterval(() => {
       exportNow = Date.now();
     }, 500);
@@ -1396,7 +1287,6 @@
 <div
   class="fixed inset-0 flex min-h-screen w-full flex-col overflow-hidden bg-background text-foreground"
 >
-  <!-- Dense custom titlebar that embeds the whole editor toolbar in a single row -->
   <CustomTitlebar wrapperClass="h-9">
     <EditorToolbar
       {store}
@@ -1411,10 +1301,8 @@
     />
   </CustomTitlebar>
 
-  <!-- Cuts-detected banner: project has accepted silence/manual cuts but the
-       experimental flag is off, so the cut lane is hidden and the cuts will
-       be silently ignored on export. Surface that loudly with an inline
-       opt-in so users sharing projects across machines don't lose work. -->
+  <!-- Project has silence cuts but the flag is off, so they're hidden and
+       skipped on export — surface an inline opt-in so work isn't lost. -->
   {#if !isLoading && !error && silenceCutCount > 0 && !experimentalStore.silenceDetection}
     <div
       class="flex items-center gap-2.5 border-b border-warning/30 bg-warning/10 px-3 py-1.5 text-[11px] text-warning"
@@ -1466,7 +1354,7 @@
     </div>
   {:else}
     <div class="flex min-h-0 flex-1 overflow-hidden">
-      <!-- Left column: preview + playback + timeline -->
+      <!-- Preview + playback + timeline -->
       <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
         <div
           bind:this={previewContainerEl}
@@ -1500,9 +1388,8 @@
           />
         </div>
 
-        <!-- Timeline collapses vertically. `slide` (axis:y) animates the
-             wrapper height to 0 while the inner keeps its natural height,
-             so the preview smoothly reclaims the space instead of snapping. -->
+        <!-- `slide` (axis:y) animates the wrapper height to 0 while the inner
+             keeps its height, so the preview reclaims space smoothly. -->
         {#if showTimeline}
           <div
             class="shrink-0 overflow-hidden"
@@ -1513,9 +1400,8 @@
         {/if}
       </div>
 
-      <!-- Right column: properties panel. Collapses horizontally — the inner
-           div holds the fixed width so `slide` (axis:x) clips it cleanly to
-           0 rather than reflowing the panel's container queries mid-animation. -->
+      <!-- Inner div holds the fixed width so `slide` (axis:x) clips cleanly
+           instead of reflowing the panel's container queries. -->
       {#if showSidebar}
         <aside
           class="min-h-0 shrink-0 overflow-hidden border-l border-border/60"
@@ -1529,9 +1415,8 @@
     </div>
   {/if}
 
-  <!-- Separate audio tracks — .recast projects store system audio and mic audio
-       as separate WAVs (the recording.mp4 video stream has no audio). These
-       elements are kept in lockstep with the video via $effects above. -->
+  <!-- .recast stores system + mic audio as separate WAVs (the mp4 has no audio);
+       kept in lockstep with the video via the $effects above. -->
   {#if systemAudioSrc}
     <!-- svelte-ignore a11y_media_has_caption -->
     <audio
@@ -1596,10 +1481,8 @@
     : store.exportFps
       ? `${store.exportFps} fps`
       : `${srcFps} fps`}
-  <!-- Spec recap — carries the committed export settings forward from the
-       options step so every later phase (encoding, done, cancelled, failed)
-       stays anchored to "what you're exporting". Mirrors the options stat
-       strip styling for visual continuity. -->
+  <!-- Carries the committed export settings forward so every later phase stays
+       anchored to "what you're exporting". -->
   <section
     class="flex items-stretch divide-x divide-border/40 border-b border-border/40 bg-muted/15 px-5 py-2.5"
   >
@@ -1654,9 +1537,6 @@
   {@const RING_R = 52}
 
   <div class="flex flex-col" style="width: 540px;">
-    <!-- Header: phase title + reassuring status line. The encode spec moves to
-         the shared spec strip below so it reads as a continuation of the
-         options step. -->
     <header
       class="flex items-start gap-3 border-b border-border/40 px-5 py-4"
     >
@@ -1696,8 +1576,6 @@
 
     {@render exportSpecStrip()}
 
-    <!-- Circular progress ring + stages, centred so the wider spec strip and
-         footer frame it consistently with the other phases. -->
     <div
       class="mx-auto flex w-full max-w-xs flex-col items-center gap-3 px-5 pt-5 pb-3"
     >
@@ -1716,10 +1594,8 @@
             class="fill-none text-muted"
           />
           {#if isPreparing}
-                  <!-- Indeterminate spinner: a 25-unit arc revolving on a
-                       100-unit path. `pathLength="100"` decouples the
-                       dash math from `2πr` so floating-point precision
-                       can't make the ring sit one pixel short of full. -->
+                  <!-- Indeterminate spinner. `pathLength="100"` decouples the
+                       dash math from 2πr so precision can't leave it short of full. -->
                   <circle
                     cx="60"
                     cy="60"
@@ -1732,10 +1608,8 @@
                     style="stroke-dasharray: 25 100; animation-duration: 1.2s;"
                   />
                 {:else}
-                  <!-- Determinate progress with cubic-bezier-eased fill.
-                       Dash values live in inline style so they participate
-                       in the CSS transition; mixing attribute + style for
-                       the same property breaks animation in some engines. -->
+                  <!-- Dash values in inline style so they participate in the CSS
+                       transition; mixing attribute + style breaks it in some engines. -->
                   <circle
                     cx="60"
                     cy="60"
@@ -1758,8 +1632,7 @@
                   {/if}
                 {/if}
               </svg>
-              <!-- Centre readout: percentage during encoding, dashes
-                   while preparing or finalising. -->
+              <!-- Percentage during encode; dashes while preparing/finalising. -->
               <div
                 class="absolute inset-0 flex flex-col items-center justify-center"
               >
@@ -1801,9 +1674,7 @@
               </div>
             </div>
 
-            <!-- Rotating, encode-themed status line — shimmer sweep + fade
-                 between messages so the wait feels alive. Shown only while
-                 frames are actually encoding. -->
+            <!-- Rotating status line, shown only while frames are encoding. -->
             {#if !isPreparing && !exportFinalizing && !exportCancelling}
               <div class="relative h-4 self-stretch" aria-live="polite">
                 {#key encodeMessageIndex}
@@ -1818,9 +1689,7 @@
               </div>
             {/if}
 
-            <!-- Stage list — checkmarks for completed substages, a dot
-                 with a subtle pulse for the running one. Collapses to a
-                 single "Encoding…" line once Rust takes over. -->
+            <!-- Substage list; collapses to a single "Encoding…" line once Rust takes over. -->
             <ul class="flex flex-col gap-1 self-stretch text-[11px]">
               {#each stages as s}
                 {#if !s.skip}
@@ -1832,8 +1701,8 @@
                         >{s.label}</span
                       >
                     {:else if s.state === "running" && s.key === "ship"}
-                      <!-- Beam animation: dots travel through a pipe to suggest
-                           the render state being piped to the encoder. -->
+                      <!-- Dots travel through a pipe, suggesting the render state
+                           being piped to the encoder. -->
                       <span
                         class="ship-beam relative flex h-2.5 w-3.5 shrink-0 items-center overflow-hidden rounded-full bg-primary/15"
                       >
@@ -1865,7 +1734,6 @@
             </ul>
           </div>
 
-    <!-- Footer: Cancel with shortcut Kbd per DESIGN -->
     <footer
       class="flex items-center justify-end gap-2 border-t border-border/40 bg-muted/30 px-3 py-2.5"
     >
@@ -1885,9 +1753,6 @@
 
 {#snippet success()}
   <div class="flex flex-col" style="width: 540px;">
-    <!-- Header: success badge + title + file path as the secondary line. The
-         encode spec is recapped in the shared strip below; the path is the
-         thing the user actually needs here, so it stays in the subtitle. -->
     <header class="flex items-start gap-3 border-b border-border/40 px-5 py-4">
       <div
         class="flex size-10 shrink-0 items-center justify-center rounded-xl border border-success/30 bg-success/10 text-success shadow-(--shadow-craft-inset)"
@@ -1915,11 +1780,8 @@
     {@render exportSpecStrip()}
 
     {#if successUpload}
-      <!-- Drive row: single horizontal row with leading status icon, label,
-           inline progress (when uploading), and trailing inline action
-           ("Copy link" when complete, "Cancel" when uploading, "Retry"
-           after error/cancel). Sits on a faintly tinted strip so it reads
-           as the export's outbound destination, not a generic status card. -->
+      <!-- Drive status row with inline progress and a trailing action that
+           tracks the upload state (cancel / copy-link / retry). -->
       <div
         class="flex items-center gap-3 border-t border-border/40 bg-muted/15 px-5 py-3"
         aria-live="polite"
@@ -1974,10 +1836,7 @@
           {/if}
         </div>
 
-        <!-- Inline trailing actions. The Drive row owns its whole
-             lifecycle: cancel while uploading, copy-link + open once
-             complete, retry on failure — so the footer never has to
-             carry a Drive-specific action. -->
+        <!-- The Drive row owns its lifecycle so the footer carries no Drive action. -->
         {#if successUpload.status === "uploading"}
           <Button
             variant="ghost"
@@ -2023,12 +1882,9 @@
       </div>
     {/if}
 
-    <!-- Destinations strip: the three "send it somewhere" actions, grouped
-         out of the footer into share-sheet tiles so they read as a single
-         choice ("where does this go?") rather than competing with the
-         dialog's Dismiss / Show-in-folder lifecycle actions. The Drive tile
-         drops out once an upload exists — the Drive row above owns it from
-         then on. Tiles use the list-row glass + hover-lift language. -->
+    <!-- Share/upload tiles, grouped out of the footer so they read as one
+         "where does this go?" choice. The Drive tile drops out once an upload
+         exists — the Drive row above owns it then. -->
     <div class="border-t border-border/40 bg-muted/15 px-5 py-3.5">
       <p
         class="mb-2.5 text-[10px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
@@ -2088,8 +1944,6 @@
       </div>
     </div>
 
-    <!-- Footer: just the two lifecycle actions, per the dialog rhythm —
-         dismiss on the left, the primary "Show in folder" on the right. -->
     <footer
       class="flex items-center justify-between gap-2 border-t border-border/40 bg-muted/30 px-3 py-2.5"
     >
@@ -2187,8 +2041,8 @@
 
     {@render exportSpecStrip()}
 
-    <!-- Failure detail — the raw FFmpeg/pipeline message, scrollable so a long
-         stack never blows out the dialog height. -->
+    <!-- Raw FFmpeg/pipeline message, scrollable so a long stack doesn't blow out
+         the dialog height. -->
     <div
       class="max-h-40 overflow-y-auto border-b border-border/40 px-5 py-3"
     >
@@ -2222,9 +2076,7 @@
 {/snippet}
 
 <style>
-  /* Hand-off-to-encoder beam: three dots travel left → right with offset
-     so it reads as data being piped through. Wrapping container clips,
-     dots fade in/out at the track edges. */
+  /* Three dots travel left → right with offset, reading as data being piped. */
   .ship-beam {
     box-shadow: inset 0 0 0 1px hsl(var(--border) / 0.3);
   }
@@ -2247,9 +2099,7 @@
   .ship-dot-3 {
     animation-delay: 0.72s;
   }
-  /* Rotating encode status line: a primary-tinted highlight sweeps across
-     muted text for a subtle shimmer. The text itself crossfades via Svelte
-     transitions when the message changes. */
+  /* Primary-tinted highlight sweeps across muted text for a subtle shimmer. */
   .export-shimmer {
     background: linear-gradient(
       100deg,

--- a/apps/desktop/src/routes/panel/+page.svelte
+++ b/apps/desktop/src/routes/panel/+page.svelte
@@ -987,10 +987,8 @@
   }
 </script>
 
-<!-- Outer wrapper: fills the (oversized) Tauri window. Padding gives the
-     inner panel's drop-shadow room to render without being clipped at the
-     window edge. The window itself is transparent so this padding shows
-     the desktop through. -->
+<!-- Padding gives the panel's drop-shadow room; the window is transparent so
+     it shows the desktop through. -->
 <div
   class="flex h-dvh w-dvw items-center justify-center px-4 py-3"
   data-tauri-drag-region
@@ -1000,26 +998,22 @@
   style="width: {barWidth.current}px"
   data-tauri-drag-region
 >
-  <!-- Content declares its own natural width (`w-fit`); the bar's width is a
-       Tween that follows it via ResizeObserver, so collapse/expand is one
-       smooth motion. The bar centers this content, so it morphs symmetrically. -->
+  <!-- Content is `w-fit`; the bar tweens to follow it, centered, so collapse
+       and expand are one symmetric motion. -->
   <div
     bind:this={barContentEl}
     class="relative flex w-fit shrink-0 items-center justify-center gap-1 p-2"
     data-tauri-drag-region
   >
   {#if phase === "countdown"}
-    <!-- Countdown phase: a depleting progress ring with the ticking second
-         inside (click to start now), a two-line status, and Cancel. Crossfades
-         with the other phases; the bar Tween follows its natural width. -->
+    <!-- Depleting ring with the ticking second (click to start now), status, Cancel. -->
     <div
       class="flex w-fit items-center gap-2.5 pl-1"
       data-tauri-drag-region
       in:fade={{ duration: 200, delay: 80, easing: cubicOut }}
       out:phaseOut
     >
-      <!-- Ring + number. The whole disc is a "start now" affordance: clicking
-           skips the remaining pre-roll and begins capture immediately. -->
+      <!-- The whole disc is a "start now" affordance. -->
       <button
         type="button"
         onclick={startNow}
@@ -1055,8 +1049,7 @@
             stroke-dashoffset={RING_C * (1 - countdownProgress)}
           />
         </svg>
-        <!-- The second pops on each tick; on hover it yields to a play glyph so
-             the skip affordance is discoverable. -->
+        <!-- On hover the second yields to a play glyph to reveal the skip affordance. -->
         {#key countdownValue}
           <span
             in:scale={{
@@ -1102,8 +1095,7 @@
       </Button>
     </div>
   {:else if phase === "recording"}
-    <!-- Recording phase: compact transport — soft-red Stop+timer, Pause,
-         Close — crossfaded in and centered by the bar. -->
+    <!-- Compact transport: Stop+timer, Pause, Close. -->
     <div
       class="flex w-fit items-center gap-1"
       in:fade={{ duration: 200, delay: 80, easing: cubicOut }}
@@ -1158,14 +1150,13 @@
       </Button>
     </div>
   {:else}
-    <!-- Idle phase: full control set. Crossfades with the others. -->
+    <!-- Idle phase: full control set. -->
     <div
       class="flex w-fit items-center gap-1"
       in:fade={{ duration: 200, delay: 80, easing: cubicOut }}
       out:phaseOut
     >
-      <!-- Drag handle: explicit affordance for moving the panel. The whole
-           bar is a Tauri drag region, but the grip makes that discoverable. -->
+      <!-- The whole bar is a drag region; the grip makes that discoverable. -->
       <div
         data-tauri-drag-region
         class="flex h-7 w-4 shrink-0 cursor-grab items-center justify-center rounded text-muted-foreground/40 transition-colors hover:bg-muted/40 hover:text-muted-foreground active:cursor-grabbing"
@@ -1174,8 +1165,7 @@
       >
         <GripVertical size={12} strokeWidth={2} class="pointer-events-none" />
       </div>
-      <!-- Record. The big primary action; clicking it begins the countdown
-           (or starts capture immediately when countdown is off). -->
+      <!-- Begins the countdown, or captures immediately when countdown is off. -->
       <Button
         onclick={toggleRecording}
         onmousedown={(e: MouseEvent) => e.stopPropagation()}
@@ -1186,10 +1176,8 @@
         <Circle size={14} strokeWidth={0} fill="currentColor" />
       </Button>
 
-  <!-- Source. Hidden once recording starts — the source is locked in, so the
-       selector just takes space; dropping it is part of the collapse. The
-       fade lives on a wrapping div because Svelte transitions can't bind to a
-       component directly. -->
+  <!-- Hidden once recording starts (source is locked in). Fade is on a wrapping
+       div since Svelte transitions can't bind to a component. -->
   {#if !isRecording}
   <div class="inline-flex" out:fade={{ duration: 120 }}>
   <Button
@@ -1235,20 +1223,15 @@
   </div>
   {/if}
 
-  <!-- Right cluster. While recording, the profile switcher and device toggles
-       are hidden and `ml-auto` is dropped so the remaining Close button packs
-       in tight next to the transport — the panel collapses to just the
-       essentials. -->
+  <!-- While recording, drop `ml-auto` so Close packs tight next to the transport. -->
   <div
     class="shrink-0 px-1 inline-flex items-center gap-1"
     class:ml-auto={!isRecording}
   >
     {#if !isRecording}
     <div class="inline-flex items-center gap-1" out:fade={{ duration: 120 }}>
-    <!-- Profile switcher button. Opens a separate Tauri window (like the
-         device-pickers) instead of a popover — the panel window is too
-         short to host an in-place dropdown without changing its height,
-         and resizing the panel mid-flow looks wrong. -->
+    <!-- Opens a separate window, not a popover — the panel is too short to host
+         an in-place dropdown without resizing. -->
     {#if profilesStore.enabled && profilesStore.profiles.length > 0}
       <Button
         size="icon-sm"
@@ -1283,9 +1266,7 @@
         {/if}
       </Button>
 
-      <!-- Mic. `micWarning` is set by `applyProfile` when a saved mic was
-           missing or got swapped — surfaced in the tooltip rather than a
-           toast so the panel stays minimal. -->
+      <!-- micWarning (from applyProfile) surfaces in the tooltip, not a toast. -->
       <Button
         variant={micOn
           ? micWarning
@@ -1311,9 +1292,8 @@
         {/if}
       </Button>
 
-      <!-- Camera. `cameraWarning` (from profile apply) and `cameraValidation`
-           (from device probe) both surface in the tooltip; whichever is
-           present wins the destructive_soft tint. -->
+      <!-- cameraWarning (profile apply) and cameraValidation (device probe) both
+           surface in the tooltip; either wins the destructive_soft tint. -->
       <Button
         disabled={isRecording}
         onclick={toggleCamera}

--- a/apps/desktop/src/routes/panel/+page.svelte
+++ b/apps/desktop/src/routes/panel/+page.svelte
@@ -64,13 +64,8 @@
   import { cubicOut } from "svelte/easing";
   import { fade, scale } from "svelte/transition";
 
-  // The panel window is too small to host its own Sonner Toaster; the
-  // main window's layout listens for `ui:toast` events and renders
-  // them through its always-mounted Toaster. Native `window.alert` is
-  // a last-resort fallback for the rare case where `emit` itself
-  // throws (no Tauri runtime, IPC unavailable). Sonner is the primary
-  // notification surface across the app — see
-  // `+layout.svelte` for the listener side of the bridge.
+  // The panel is too small for its own Toaster, so emit `ui:toast` for the main
+  // window to render (see +layout.svelte). alert() is the fallback if emit throws.
   type ToastLevel = "error" | "warning" | "info" | "success";
   function notify(level: ToastLevel, message: string, duration?: number) {
     emit("ui:toast", { level, message, duration }).catch((err) => {
@@ -96,50 +91,27 @@
 
   let selectedSource: TargetSource | null = $state(null);
   let isRecording = $state(false);
-  // True for the brief window between the countdown ending (or being skipped)
-  // and the `startRecording` IPC resolving. Without it, `countdownValue` goes
-  // null while we await the IPC, so `phase` falls back to "idle" and the bar
-  // flashes the full control set — expanding then collapsing — between the
-  // countdown and recording phases. Treating "starting" as "recording" keeps
-  // the morph a single countdown→recording crossfade.
+  // True between the countdown ending and startRecording resolving. Treating it
+  // as "recording" stops `phase` dipping to "idle" and flashing the full bar.
   let isStarting = $state(false);
-  // Stop IPC in-flight. On macOS, `stop_recording` joins the capture/encoder
-  // threads and finalizes the muxer, which can take a beat — without this
-  // guard a second click fired another `stopRecording()` (the first await
-  // hadn't resolved, so `isRecording` was still true), racing the backend's
-  // `guard.take()` and surfacing a bogus "recording is not running" error.
+  // Guards against a second stop click while stop_recording is in flight (it can
+  // take a beat on macOS), which would race the backend and error spuriously.
   let isStopping = $state(false);
   let recordingStartTime: number | null = $state(null);
   let now = $state(Date.now());
 
-  // Countdown-before-recording. The effective duration (`countdownSeconds`) is
-  // derived from the *active profile's* override, falling back to the global
-  // `recordingCountdown` store — both reactive and both kept in sync across
-  // windows, so editing either on another page is reflected live here. That
-  // derived lives next to `activeProfile` below. `countdownValue` is the live
-  // integer tick (null unless counting down); `countdownProgress` (1 → 0) drives
-  // the depleting ring (already normalised against the chosen duration).
+  // `countdownValue` is the live integer tick (null unless counting down);
+  // `countdownProgress` (1 → 0) drives the depleting ring.
   let countdownValue = $state<number | null>(null);
   let countdownProgress = $state(1);
   let countdownRaf: number | null = null;
-  // Circumference of the progress ring (r=16 in the 36×36 viewBox). The visible
-  // arc length is `C × progress`, so the dash offset is `C × (1 − progress)`.
+  // Ring circumference (r=16 in the 36×36 viewBox); dash offset = C × (1 − progress).
   const RING_C = 2 * Math.PI * 16;
 
-  // Panel sizing. The bar's width is driven by a Svelte `Tween` that follows
-  // the *measured* natural width of its content (the same morph technique as
-  // ExportFlowDialog) — buttery, rAF-driven, and consistent with the rest of
-  // the app's motion. The content declares its own size via `w-fit`; the bar
-  // just follows.
-  //
-  // Crucially, the Tauri window is left at its fixed launch size (520×72, sized
-  // in ipc.ts to hug the full idle bar with room for the drop shadow) and is
-  // NOT resized per phase. A centered, always-on-top window can't be resized
-  // and repositioned in a single atomic frame, so snapping it mid-morph made
-  // the bar visibly drift sideways. Instead the bar just morphs *centered
-  // inside the fixed window* — the transparent margins on either side double as
-  // a drag region. This mirrors ExportFlowDialog, which morphs a DOM element
-  // within a fixed viewport and never touches the window.
+  // The bar width tweens to follow its content's measured natural width. The
+  // Tauri window stays at its fixed launch size and is NOT resized per phase: a
+  // centered always-on-top window can't resize+reposition in one atomic frame,
+  // so the bar morphs centered inside it (transparent margins are a drag region).
   const BAR_W_IDLE = 488;
 
   let barContentEl = $state<HTMLElement | null>(null);
@@ -151,9 +123,8 @@
     typeof window !== "undefined" &&
     window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
 
-  // Watch the content's natural width and tween the bar to match. Uses the
-  // border box (includes the content's own padding) so the bar wraps it
-  // exactly, and rounds to whole px so sub-pixel jitter can't retrigger.
+  // Tween the bar to the content's natural width. Border box so the bar wraps
+  // exactly; rounded to whole px so sub-pixel jitter can't retrigger.
   $effect(() => {
     if (!barContentEl) return;
     const ro = new ResizeObserver((entries) => {
@@ -184,9 +155,7 @@
     else barWidth.target = measuredBarW;
   });
 
-  // Three visual phases. `idle` = full controls; `countdown` = big number +
-  // cancel; `recording` = collapsed transport. Derived so the markup can
-  // switch on a single value.
+  // `idle` = full controls; `countdown` = number + cancel; `recording` = transport.
   const phase = $derived<"idle" | "countdown" | "recording">(
     isRecording || isStarting
       ? "recording"
@@ -195,16 +164,14 @@
         : "idle",
   );
 
-  // Mirror the recording flag to the system tray so its "Start/Stop
-  // Recording" label and any tray-driven UX stays accurate. Best-effort:
-  // tray init may have failed (no icon registered) — the command is a
-  // no-op in that case.
+  // Mirror the recording flag to the tray label. Best-effort; no-op if tray
+  // init failed.
   $effect(() => {
     void refreshTray(isRecording);
   });
 
-  // Pause state. `pausedAccumMs` banks completed pauses; `pausedSince` marks
-  // an in-progress pause — the elapsed timer subtracts both so it freezes.
+  // `pausedAccumMs` banks completed pauses; `pausedSince` marks one in progress
+  // — the elapsed timer subtracts both so it freezes.
   let isPaused = $state(false);
   let pausedAccumMs = $state(0);
   let pausedSince: number | null = $state(null);
@@ -227,11 +194,8 @@
   let selectedCameraName = $state("Default");
   let cameraValidation = $state<CameraValidationResult | null>(null);
 
-  // Inline notice surface. The panel window is too narrow for a Sonner toast,
-  // so resolution outcomes (fallback / missing device / fresh profile applied)
-  // are surfaced via button tooltips and a transient profile-button highlight.
-  // micWarning / cameraWarning persist in tooltips until the next apply or
-  // manual toggle so the user can hover later to see what got swapped.
+  // Resolution outcomes (fallback / missing) surface in button tooltips since
+  // the panel can't host a toast; persist until the next apply or manual toggle.
   let micWarning = $state<string | null>(null);
   let cameraWarning = $state<string | null>(null);
 
@@ -252,12 +216,9 @@
     activeProfileId ? profilesStore.findById(activeProfileId) : null,
   );
 
-  // Effective countdown duration: the active profile's per-profile override
-  // (`0` = off, a number = pinned, `null`/absent = inherit) wins over the global
-  // setting. Derived straight off `activeProfile` rather than snapshotted at
-  // apply-time, so a live edit to the active profile (synced cross-window via
-  // `profilesStore`) updates the countdown immediately — this is what makes the
-  // per-profile value actually get respected, not just the global one.
+  // Active profile's override (0 = off, number = pinned, null = inherit) wins
+  // over the global setting. Derived off `activeProfile`, not snapshotted, so a
+  // live cross-window edit updates the countdown immediately.
   const countdownSeconds = $derived(
     activeProfile?.countdown ?? recordingCountdown.value,
   );
@@ -268,10 +229,8 @@
       return;
     }
 
-    // Browser MediaDevices ids are 64-char hex hashes; the Rust validator
-    // looks them up against DirectShow names and will always miss those.
-    // Skip validation in that case — `openCameraStream` itself is the source
-    // of truth for whether a browser-id camera will actually open.
+    // Skip browser MediaDevices ids (hex hashes) — the Rust validator only
+    // knows DirectShow names; openCameraStream is the source of truth there.
     if (/^[a-f0-9]{40,}$/i.test(deviceId)) {
       cameraValidation = {
         id: deviceId,
@@ -362,9 +321,7 @@
       }
     });
 
-    // Profile picker (separate Tauri window, like device-picker) emits this
-    // when the user confirms a selection. We resolve the id against the store
-    // and apply through the same path as ⌘1-⌘8 shortcuts.
+    // Profile-picker window applies through the same path as ⌘1-⌘8 shortcuts.
     const unlistenProfile = listen<{ id: string }>("profile-selected", (event) => {
       const target = profilesStore.findById(event.payload.id);
       if (target) handleProfileSwitch(target);
@@ -396,9 +353,8 @@
                   }
                 : undefined,
           };
-          // Restored a monitor — look up its current refresh rate (best
-          // effort, off the start path) so record-time fps clamping knows the
-          // display's ceiling without an extra probe at capture time.
+          // Look up the restored monitor's refresh rate so fps clamping knows
+          // the display ceiling without a capture-time probe.
           if (selectedSource?.type === "monitor") {
             const restoredId = selectedSource.id;
             getDisplays()
@@ -429,24 +385,19 @@
     profilesStore.hydrate();
 
     void initDevicesAndProfile();
-    // Warm the capability probe so the first mic/camera/system-audio toggle
-    // resolves instantly instead of waiting on a cold `capture_capabilities`.
+    // Warm the capability probe so the first device toggle resolves instantly.
     void loadCapabilities();
 
     window.addEventListener("keydown", handleGlobalShortcut);
 
-    // Intercept the window close while a recording is live so it gets
-    // finalized & saved instead of lost.
+    // Intercept close during a live recording so it's finalized, not lost.
     const closeReq = getCurrentWindow().onCloseRequested((event) => {
-      // Already finalizing (or nothing to finalize) — let the close proceed.
       if (isClosing || !isRecording) return;
       event.preventDefault();
       void finalizeAndClose();
     });
 
-    // Tray "Start/Stop Recording" routes here when the panel is open. The
-    // toggleRecording() function already does the right thing for either
-    // direction (start with current selection, or stop the in-flight one).
+    // Tray "Start/Stop Recording" routes here when the panel is open.
     const unlistenTrayToggle = listen("tray:record-toggle", () => {
       void toggleRecording();
     });
@@ -464,12 +415,8 @@
     };
   });
 
-  /**
-   * Load audio + video devices, then apply the user's default profile if the
-   * profile system is enabled. When profiles are off, fall back to the legacy
-   * behavior (default mic, first non-virtual camera, all toggles off except
-   * system audio).
-   */
+  // Load devices, then apply the default profile if enabled; otherwise seed
+  // defaults (default mic, first non-virtual camera, only system audio on).
   async function initDevicesAndProfile() {
     const [audioDevices, videoDevices] = await Promise.all([
       getAudioDevices().catch(() => [] as AudioDeviceInfo[]),
@@ -478,9 +425,8 @@
     mics = audioDevices;
     cameras = videoDevices;
 
-    // Always seed the "current" mic/camera selection with system defaults,
-    // even when applying a profile — that way if the user manually toggles
-    // mic/camera on later (without the profile), we have something to use.
+    // Seed defaults even when applying a profile, so a later manual toggle has
+    // something to use.
     const defaultMic = audioDevices.find((d) => d.isDefault) ?? audioDevices[0];
     if (defaultMic) {
       selectedMicId = defaultMic.id;

--- a/apps/desktop/src/routes/select-area/+page.svelte
+++ b/apps/desktop/src/routes/select-area/+page.svelte
@@ -5,9 +5,8 @@
   import { getCurrentWindow } from "@tauri-apps/api/window";
   import { onMount } from "svelte";
 
-  // The overlay window is created at virtual desktop origin, sized to span all
-  // monitors. Pointer coords from the window therefore equal virtual-desktop
-  // pixel coords, which is what the Rust resolver expects.
+  // Overlay spans all monitors from the virtual-desktop origin, so pointer
+  // coords are virtual-desktop pixels — what the Rust resolver expects.
   let originX = $state(0);
   let originY = $state(0);
 
@@ -23,7 +22,7 @@
   );
 
   onMount(() => {
-    // Read window position so we can convert local pointer to global coords.
+    // Window position, to convert local pointer coords to global.
     const win = getCurrentWindow();
     win
       .outerPosition()
@@ -132,7 +131,6 @@
 
 <svelte:window onkeydown={onKey} />
 
-<!-- Fullscreen transparent overlay; pointer events drive the selection. -->
 <div
   role="presentation"
   class="absolute inset-0 cursor-crosshair select-none"
@@ -142,9 +140,8 @@
   onpointerup={onPointerUp}
 >
   {#if liveRect && liveRect.w > 0 && liveRect.h > 0}
-    <!-- Cut-out via box-shadow trick: rect itself is transparent, the dim
-         layer is painted by an outer box-shadow on this element.
-         pointer-events: none so clicks inside the rect don't restart a drag. -->
+    <!-- Cut-out via box-shadow: rect is transparent, the dim layer is the outer
+         box-shadow. pointer-events: none so clicks inside don't restart a drag. -->
     <div
       class="pointer-events-none absolute border border-primary/90 ring-1 ring-primary/40"
       style="left: {liveRect.x}px; top: {liveRect.y}px; width: {liveRect.w}px; height: {liveRect.h}px; background: transparent; box-shadow: 0 0 0 9999px rgba(0,0,0,0.45);"
@@ -174,9 +171,8 @@
   {/if}
 
   {#if rect && !dragging}
-    <!-- Confirm toolbar — stop pointer events on the wrapper itself so clicks
-         on its padding don't bubble to the overlay (which would clear the
-         rect mid-click). Position is clamped into the viewport. -->
+    <!-- Stop pointer events so clicks on the toolbar's padding don't bubble to
+         the overlay and clear the rect. -->
     <div
       role="toolbar"
       aria-label="Confirm selected area"

--- a/apps/desktop/src/routes/select/+page.svelte
+++ b/apps/desktop/src/routes/select/+page.svelte
@@ -105,8 +105,7 @@
       await existing.setFocus();
       return;
     }
-    // Cover the entire virtual desktop. Tauri will clamp to displays; using
-    // a large width/height ensures multi-monitor setups are fully covered.
+    // Oversize to cover the whole virtual desktop across multiple monitors.
     new WebviewWindow("region-picker", {
       url: "/select-area",
       title: "Select Area",

--- a/apps/web/src/lib/share/engagement.ts
+++ b/apps/web/src/lib/share/engagement.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure engagement helpers for the share page. Most of the share page's
+ * engagement code is irreducibly coupled to the player API, the DOM, and shared
+ * page-reactive state, so it stays in the component; this is the one piece with
+ * real, bug-prone logic worth isolating — the optimistic reaction toggle.
+ */
+
+import type { ReactionCount } from "./client";
+
+export interface ReactionState {
+	/** Emojis the current viewer has reacted with. */
+	myReactions: Set<string>;
+	/** Aggregate counts per emoji. */
+	reactions: ReactionCount[];
+}
+
+/**
+ * Optimistic local update for toggling the viewer's reaction to `emoji`:
+ * add/remove from `myReactions` and bump/drop the aggregate count (removing the
+ * entry entirely when it hits zero, adding a new one at count 1). Returns fresh
+ * objects; does not mutate the input.
+ */
+export function toggleReactionState(
+	current: ReactionState,
+	emoji: string,
+): ReactionState {
+	const had = current.myReactions.has(emoji);
+	const nextSet = new Set(current.myReactions);
+	const next = current.reactions.map((r) => ({ ...r }));
+	const idx = next.findIndex((r) => r.emoji === emoji);
+	if (had) {
+		nextSet.delete(emoji);
+		if (idx >= 0) {
+			next[idx].count -= 1;
+			if (next[idx].count <= 0) next.splice(idx, 1);
+		}
+	} else {
+		nextSet.add(emoji);
+		if (idx >= 0) next[idx].count += 1;
+		else next.push({ emoji, count: 1 });
+	}
+	return { myReactions: nextSet, reactions: next };
+}

--- a/apps/web/src/lib/share/format.ts
+++ b/apps/web/src/lib/share/format.ts
@@ -1,0 +1,100 @@
+/**
+ * Pure time/text formatting for the public share page. Extracted from
+ * `routes/share/[id]/+page.svelte` so the parsing/formatting is isolated from
+ * the player wiring. (apps/web has no unit-test runner yet, so these are not
+ * unit-tested — they're plain pure functions verified by svelte-check.)
+ */
+
+/** A parsed segment of comment text — plain text, a clickable timestamp, or a mention. */
+export type CommentSegment =
+	| { kind: "text"; text: string }
+	| { kind: "timestamp"; seconds: number; raw: string }
+	| { kind: "mention"; name: string };
+
+/**
+ * Parse a `?t=` deep-link value into seconds. Accepts a bare seconds count
+ * (`90`) or a unit string (`1h2m3s`); missing units default to 0.
+ */
+export function parseTimeParam(raw: string | null): number {
+	if (!raw) return 0;
+	const t = raw.trim().toLowerCase();
+	if (/^\d+$/.test(t)) return Number(t);
+	let total = 0;
+	const h = t.match(/(\d+)h/);
+	const m = t.match(/(\d+)m/);
+	const s = t.match(/(\d+)s/);
+	if (h) total += Number(h[1]) * 3600;
+	if (m) total += Number(m[1]) * 60;
+	if (s) total += Number(s[1]);
+	return total;
+}
+
+/** Parse an `mm:ss` or `hh:mm:ss` token into seconds (0 on malformed input). */
+export function parseTimeToken(s: string): number {
+	const parts = s.split(":").map((p) => Number(p));
+	if (parts.some(Number.isNaN)) return 0;
+	if (parts.length === 2) return parts[0]! * 60 + parts[1]!;
+	if (parts.length === 3) return parts[0]! * 3600 + parts[1]! * 60 + parts[2]!;
+	return 0;
+}
+
+/**
+ * Split comment text into segments, linkifying `[mm:ss]`/`mm:ss` timestamps and
+ * `@mentions`.
+ */
+export function parseCommentText(text: string): CommentSegment[] {
+	const re =
+		/\[(\d{1,2}(?::\d{2}){1,2})\]|\b(\d{1,2}:\d{2}(?::\d{2})?)\b|@([A-Za-z][\w]{0,31})/g;
+	const out: CommentSegment[] = [];
+	let lastIdx = 0;
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(text)) !== null) {
+		if (m.index > lastIdx) out.push({ kind: "text", text: text.slice(lastIdx, m.index) });
+		if (m[1] !== undefined) out.push({ kind: "timestamp", seconds: parseTimeToken(m[1]), raw: m[1] });
+		else if (m[2] !== undefined) out.push({ kind: "timestamp", seconds: parseTimeToken(m[2]), raw: m[2] });
+		else if (m[3] !== undefined) out.push({ kind: "mention", name: m[3] });
+		lastIdx = m.index + m[0].length;
+	}
+	if (lastIdx < text.length) out.push({ kind: "text", text: text.slice(lastIdx) });
+	return out;
+}
+
+/** `m:ss` clock for the player readout. */
+export function formatTime(sec: number): string {
+	const m = Math.floor(sec / 60);
+	const s = Math.floor(sec % 60);
+	return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+/** Compact unit string for `?t=` (`1h2m3s`); empty at 0. */
+export function compactTime(sec: number): string {
+	const s = Math.max(0, Math.floor(sec));
+	if (s === 0) return "";
+	const h = Math.floor(s / 3600);
+	const m = Math.floor((s % 3600) / 60);
+	const r = s % 60;
+	let out = "";
+	if (h) out += `${h}h`;
+	if (m) out += `${m}m`;
+	if (r || !out) out += `${r}s`;
+	return out;
+}
+
+/** Avatar fallback initials from a name or email. */
+export function initials(
+	name: string | null | undefined,
+	email: string | null | undefined,
+): string {
+	const src = (name ?? email ?? "?").trim();
+	if (!src) return "?";
+	const parts = src.split(/\s+/).filter(Boolean);
+	if (parts.length >= 2) return (parts[0]![0]! + parts[1]![0]!).toUpperCase();
+	return src.slice(0, 2).toUpperCase();
+}
+
+/** Deterministic hue (0..359) from a seed string, for per-commenter colour. */
+export function commentHue(seed: string): number {
+	let h = 0;
+	for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0;
+	return h % 360;
+}

--- a/apps/web/src/routes/(public)/extensions/+page.svelte
+++ b/apps/web/src/routes/(public)/extensions/+page.svelte
@@ -148,7 +148,7 @@
 			<SectionHeader
 				eyebrow="Safe by design"
 				title="Installable, without the install-anything risk."
-				description="Plugins usually mean running someone else's code on your machine. Recast packs don't. They only carry assets, so the whole class of plugin supply-chain attacks simply doesn't apply."
+				description="Plugins usually mean running someone else's code. Recast packs don't run code at all. They only carry assets, so plugin supply-chain attacks don't apply."
 				align="center"
 			/>
 			<div class="mt-16 grid grid-cols-1 gap-px overflow-hidden rounded-2xl border border-border-low/40 bg-border-low/30 sm:grid-cols-2 lg:grid-cols-4">

--- a/apps/web/src/routes/(public)/features/+page.svelte
+++ b/apps/web/src/routes/(public)/features/+page.svelte
@@ -98,12 +98,6 @@
 			cap: "Limited",
 		},
 		{
-			feature: "Pause and resume mid-take",
-			recast: "Built in",
-			loom: "Paid",
-			cap: "Built in",
-		},
-		{
 			feature: "Hardware-accelerated export",
 			recast: "Built in",
 			loom: "Cloud render only",
@@ -117,9 +111,9 @@
 		},
 		{
 			feature: "Share to your own storage (Drive today)",
-			recast: "Built in",
+			recast: "Built in, free",
 			loom: "Not supported",
-			cap: "Not supported",
+			cap: "Pro only",
 		},
 		{
 			feature: "No account required to record",
@@ -136,8 +130,8 @@
 		{
 			feature: "Per-seat pricing",
 			recast: "None",
-			loom: "Per editor",
-			cap: "Per editor",
+			loom: "Per seat",
+			cap: "Per seat",
 		},
 	];
 

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1071,7 +1071,7 @@
 					<SectionHeader
 						eyebrow="Coming next · Recast Cloud"
 						title="When a Drive link isn't enough."
-						description="For the moments a shared file can't express: knowing which prospect actually watched, gating an investor demo by viewer, branding the player as your product. Loom-style hosted demos, with more of the dials handed to you."
+						description="For the moments a shared file can't express: knowing which prospect actually watched, gating an investor demo by viewer, branding the player as your product. Loom-style hosted demos, with more of the controls in your hands."
 					/>
 
 					<ul class="mt-10 grid grid-cols-1 gap-x-4 gap-y-3 sm:grid-cols-2">

--- a/apps/web/src/routes/share/[id]/+page.svelte
+++ b/apps/web/src/routes/share/[id]/+page.svelte
@@ -11,6 +11,7 @@
 		parseTimeParam,
 		type CommentSegment,
 	} from "$lib/share/format";
+	import { toggleReactionState } from "$lib/share/engagement";
 	import Logo from "$lib/logo.svelte";
 	import {
 	  ArrowRight,
@@ -451,23 +452,9 @@
 	const totalReactions = $derived(reactions.reduce((sum, r) => sum + r.count, 0));
 
 	async function react(emoji: string) {
-		const had = myReactions.has(emoji);
-		const nextSet = new Set(myReactions);
-		const next = reactions.map((r) => ({ ...r }));
-		const idx = next.findIndex((r) => r.emoji === emoji);
-		if (had) {
-			nextSet.delete(emoji);
-			if (idx >= 0) {
-				next[idx].count -= 1;
-				if (next[idx].count <= 0) next.splice(idx, 1);
-			}
-		} else {
-			nextSet.add(emoji);
-			if (idx >= 0) next[idx].count += 1;
-			else next.push({ emoji, count: 1 });
-		}
-		myReactions = nextSet;
-		reactions = next;
+		const nextState = toggleReactionState({ myReactions, reactions }, emoji);
+		myReactions = nextState.myReactions;
+		reactions = nextState.reactions;
 		if (isDemo) return;
 		try {
 			await toggleReaction(slug, { sessionId, emoji, atSeconds: Math.floor(currentTime) });

--- a/apps/web/src/routes/share/[id]/+page.svelte
+++ b/apps/web/src/routes/share/[id]/+page.svelte
@@ -2,6 +2,15 @@
 	import { browser } from "$app/environment";
 	import { page } from "$app/state";
 	import { SeoMeta } from "$lib/components";
+	import {
+		commentHue,
+		compactTime,
+		formatTime,
+		initials,
+		parseCommentText,
+		parseTimeParam,
+		type CommentSegment,
+	} from "$lib/share/format";
 	import Logo from "$lib/logo.svelte";
 	import {
 	  ArrowRight,
@@ -240,19 +249,6 @@
 	}
 
 	// ── Player wiring ────────────────────────────────────────────────
-	function parseTimeParam(raw: string | null): number {
-		if (!raw) return 0;
-		const t = raw.trim().toLowerCase();
-		if (/^\d+$/.test(t)) return Number(t);
-		let total = 0;
-		const h = t.match(/(\d+)h/);
-		const m = t.match(/(\d+)m/);
-		const s = t.match(/(\d+)s/);
-		if (h) total += Number(h[1]) * 3600;
-		if (m) total += Number(m[1]) * 60;
-		if (s) total += Number(s[1]);
-		return total;
-	}
 
 	const initialSeekSeconds = untrack(() => parseTimeParam(page.url.searchParams.get("t")));
 
@@ -605,36 +601,6 @@
 		}
 	}
 
-	// ── Comment rich text (timestamps + mentions) ────────────────────
-	type CommentSegment =
-		| { kind: "text"; text: string }
-		| { kind: "timestamp"; seconds: number; raw: string }
-		| { kind: "mention"; name: string };
-
-	function parseTimeToken(s: string): number {
-		const parts = s.split(":").map((p) => Number(p));
-		if (parts.some(Number.isNaN)) return 0;
-		if (parts.length === 2) return parts[0]! * 60 + parts[1]!;
-		if (parts.length === 3) return parts[0]! * 3600 + parts[1]! * 60 + parts[2]!;
-		return 0;
-	}
-
-	function parseCommentText(text: string): CommentSegment[] {
-		const re =
-			/\[(\d{1,2}(?::\d{2}){1,2})\]|\b(\d{1,2}:\d{2}(?::\d{2})?)\b|@([A-Za-z][\w]{0,31})/g;
-		const out: CommentSegment[] = [];
-		let lastIdx = 0;
-		let m: RegExpExecArray | null;
-		while ((m = re.exec(text)) !== null) {
-			if (m.index > lastIdx) out.push({ kind: "text", text: text.slice(lastIdx, m.index) });
-			if (m[1] !== undefined) out.push({ kind: "timestamp", seconds: parseTimeToken(m[1]), raw: m[1] });
-			else if (m[2] !== undefined) out.push({ kind: "timestamp", seconds: parseTimeToken(m[2]), raw: m[2] });
-			else if (m[3] !== undefined) out.push({ kind: "mention", name: m[3] });
-			lastIdx = m.index + m[0].length;
-		}
-		if (lastIdx < text.length) out.push({ kind: "text", text: text.slice(lastIdx) });
-		return out;
-	}
 
 	function jumpTo(seconds: number) {
 		api?.seek(seconds);
@@ -648,24 +614,6 @@
 		window.history.replaceState({}, "", url.toString());
 	}
 
-	function formatTime(sec: number): string {
-		const m = Math.floor(sec / 60);
-		const s = Math.floor(sec % 60);
-		return `${m}:${String(s).padStart(2, "0")}`;
-	}
-
-	function compactTime(sec: number): string {
-		const s = Math.max(0, Math.floor(sec));
-		if (s === 0) return "";
-		const h = Math.floor(s / 3600);
-		const m = Math.floor((s % 3600) / 60);
-		const r = s % 60;
-		let out = "";
-		if (h) out += `${h}h`;
-		if (m) out += `${m}m`;
-		if (r || !out) out += `${r}s`;
-		return out;
-	}
 
 	async function writeClipboard(text: string, okMsg: string) {
 		try {
@@ -709,19 +657,6 @@
 	const session = authClient.useSession();
 	const viewer = $derived(($session as unknown as SessionShape).data?.user ?? null);
 
-	function initials(name: string | null | undefined, email: string | null | undefined): string {
-		const src = (name ?? email ?? "?").trim();
-		if (!src) return "?";
-		const parts = src.split(/\s+/).filter(Boolean);
-		if (parts.length >= 2) return (parts[0]![0]! + parts[1]![0]!).toUpperCase();
-		return src.slice(0, 2).toUpperCase();
-	}
-
-	function commentHue(seed: string): number {
-		let h = 0;
-		for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0;
-		return h % 360;
-	}
 
 	async function signOut() {
 		await authClient.signOut();

--- a/apps/web/static/robots.txt
+++ b/apps/web/static/robots.txt
@@ -1,3 +1,0 @@
-# allow crawling everything by default
-User-agent: *
-Disallow:

--- a/packages/player/src/RecastPlayer.svelte
+++ b/packages/player/src/RecastPlayer.svelte
@@ -110,11 +110,9 @@
 	let activeTooltipId = $state<string | null>(null);
 
 	const isHls = $derived(/\.m3u8(\?|#|$)/i.test(src));
-	// A negative `autohide` means "never hide the controls". media-chrome's
-	// `autohide` attribute only suppresses the inactivity *timer* — the
-	// controller still starts in `user-inactive` on connect, so an autoplaying
-	// clip hides its bar until the first pointer move. Pinning the control bar
-	// with `noautohide` is what actually keeps it visible from frame one.
+	// media-chrome's `autohide` only suppresses the inactivity timer; the bar
+	// still starts hidden on an autoplaying clip. `noautohide` on the control bar
+	// is what keeps it visible from frame one (negative autohide = never hide).
 	const pinControls = $derived(typeof autohide === "number" && autohide < 0);
 	const mergedControls = $derived({ ...DEFAULT_CONTROLS, ...controls });
 	const mergedFeatures = $derived({ ...DEFAULT_FEATURES, ...features });
@@ -161,12 +159,8 @@
 	});
 	const playerStyle = $derived.by(() => {
 		const vars = [
-			// Before metadata loads we don't know the true ratio, but `auto`
-			// collapses a slotted <video> to its 300×150 default — so the hero
-			// renders short, then jumps to the real ratio once dimensions
-			// arrive (a visible layout shift). Reserve 16/9 (the overwhelmingly
-			// common screen-recording ratio) as the placeholder: zero shift for
-			// 16:9, and a single small adjust for the rare portrait clip.
+			// Reserve 16/9 before metadata loads; `auto` would collapse the
+			// slotted <video> to 300×150 and cause a layout shift on the common case.
 			resolvedAspectRatio
 				? `--recast-player-aspect-ratio: ${resolvedAspectRatio};`
 				: "--recast-player-aspect-ratio: 16 / 9;",

--- a/packages/player/src/RecastPlayer.svelte
+++ b/packages/player/src/RecastPlayer.svelte
@@ -443,6 +443,18 @@
 		emitState();
 	}
 
+	// PiP events aren't in Svelte's typed video attributes; bind them directly.
+	$effect(() => {
+		const el = videoEl;
+		if (!el) return;
+		el.addEventListener("enterpictureinpicture", handleEnterPictureInPicture);
+		el.addEventListener("leavepictureinpicture", handleLeavePictureInPicture);
+		return () => {
+			el.removeEventListener("enterpictureinpicture", handleEnterPictureInPicture);
+			el.removeEventListener("leavepictureinpicture", handleLeavePictureInPicture);
+		};
+	});
+
 	function handleKeyDown(event: KeyboardEvent) {
 		if (!videoEl) return;
 		const target = event.target as HTMLElement | null;
@@ -571,8 +583,6 @@
 			onratechange={handleRateChange}
 			onseeked={handleSeeked}
 			onended={handleEnded}
-			onenterpictureinpicture={handleEnterPictureInPicture}
-			onleavepictureinpicture={handleLeavePictureInPicture}
 		>
 			{#if thumbnails}
 				<track kind="metadata" src={thumbnails} label="thumbnails" default />
@@ -609,8 +619,6 @@
 			onratechange={handleRateChange}
 			onseeked={handleSeeked}
 			onended={handleEnded}
-			onenterpictureinpicture={handleEnterPictureInPicture}
-			onleavepictureinpicture={handleLeavePictureInPicture}
 		>
 			{#if thumbnails}
 				<track kind="metadata" src={thumbnails} label="thumbnails" default />


### PR DESCRIPTION

Split fat editor/settings components into thin markup + pure, unit-tested logic
modules (vitest), and hoist duplicated formatting into shared helpers.

Logic extraction (.logic.ts + .logic.test.ts)
- editor: focus-overlay, preset-picker, audio-panel, background-picker,
  focus-panel, info-panel
- settings: cloud-signin
  Components (FocusOverlay, PresetPicker, AudioPanel, BackgroundPicker,
  FocusPanel, InfoPanel, CloudSignIn, …) now hold markup only.

Shared formatters / helpers (with tests)
- $lib/format/{bytes,files,time}.ts and $lib/library/editor-window.ts, consumed
  by the library pages (home/recasts/exports) and the editor panels — removing
  the inline duplicates.

Release notes
- Consume the late-states changeset into CHANGELOG.md and regenerate the desktop
  in-app changelog (constants/changelog.ts).

Misc
- Minor web copy/link tweaks (features/landing/extensions); drop unused
  apps/web/static/robots.txt.