### PR TITLE
fix(ui): eradicate overlapping drag regions causing sticky buttons on macOS

### DIFF
--- a/.changeset/metal-pugs-read.md
+++ b/.changeset/metal-pugs-read.md
@@ -1,0 +1,6 @@
+---
+"recast-desktop": patch
+kind: fixed
+---
+
+Fix sticky UI and double-click bugs on macOS by removing overlapping drag regions.

--- a/apps/desktop/src/components/editor/EditorToolbar.svelte
+++ b/apps/desktop/src/components/editor/EditorToolbar.svelte
@@ -118,7 +118,7 @@
 
 <div
   class="flex h-full w-full items-center gap-1.5 px-2 text-[11px]"
-  data-tauri-drag-region
+  
 >
   <div class="flex items-center gap-0.5">
     <Tooltip.Root>
@@ -148,7 +148,7 @@
     ></span>
   {/if}
 
-  <div class="mx-auto flex items-center gap-1.5" data-tauri-drag-region>
+  <div class="mx-auto flex items-center gap-1.5">
     <Tooltip.Root>
       <Tooltip.Trigger>
         <Button

--- a/apps/desktop/src/components/layout/MobileHeader.svelte
+++ b/apps/desktop/src/components/layout/MobileHeader.svelte
@@ -9,20 +9,11 @@
     href="/"
     class="group flex items-center gap-3 transition-opacity hover:opacity-80"
   >
-    <div
-      class="flex h-16 shrink-0 select-none items-center gap-3 px-6"
-      data-tauri-drag-region
-    >
-      <div
-        class="flex size-8 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-sm"
-        data-tauri-drag-region
-      >
+    <div class="flex h-16 shrink-0 select-none items-center gap-3 px-6">
+      <div class="flex size-8 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-sm">
         <Hexagon size={18} class="fill-current" strokeWidth={2.5} />
       </div>
-      <h1
-        class="text-base font-semibold tracking-tight group-data-[state=collapsed]:hidden"
-        data-tauri-drag-region
-      >
+      <h1 class="text-base font-semibold tracking-tight group-data-[state=collapsed]:hidden">
         Recast Studio
       </h1>
     </div>

--- a/apps/desktop/src/components/layout/app-sidebar.svelte
+++ b/apps/desktop/src/components/layout/app-sidebar.svelte
@@ -63,28 +63,22 @@
           "flex h-10 items-center gap-2.5 overflow-hidden rounded-lg transition-opacity hover:opacity-80",
           open ? "px-2 pr-9" : "justify-center px-0",
         )}
-        data-tauri-drag-region
         aria-label="Recast — home"
       >
         <Logo
           size="24"
-          // color="var(--foreground)"
-          // fill="var(--background)"
           class="shrink-0"
-          data-tauri-drag-region
         />
         {#if open}
           <span
             in:fly={{ x: -8, duration: 240, easing: cubicOut, delay: 60 }}
             out:fade={{ duration: 220, easing: cubicOut }}
             class="truncate text-[15px] font-semibold tracking-tight text-foreground"
-            data-tauri-drag-region
           >
             Recast
           </span>
         {/if}
       </a>
-
     </Sidebar.MenuItem>
 
     <Sidebar.MenuItem>

--- a/apps/desktop/src/components/layout/custom-titlebar.svelte
+++ b/apps/desktop/src/components/layout/custom-titlebar.svelte
@@ -36,7 +36,7 @@
   <!-- Drag region: content area only, not the window controls. -->
   <div
     class={cn("flex-1 flex items-center min-w-0 h-full font-sans", className)}
-    data-tauri-drag-region
+    
   >
     {#if children}
       {@render children()}

--- a/apps/desktop/src/routes/(app)/+layout.svelte
+++ b/apps/desktop/src/routes/(app)/+layout.svelte
@@ -54,7 +54,7 @@
       <CustomTitlebar class="items-center gap-1 px-3">
         <div
           class="flex h-full items-center gap-2 font-sans"
-          data-tauri-drag-region
+          
         >
           <div
             in:fade={{ duration: 180, delay: 100, easing: cubicOut }}
@@ -113,7 +113,7 @@
       {/if}
       <div
         class="flex h-full items-center gap-2 font-sans"
-        data-tauri-drag-region
+        
       >
         <Sidebar.Trigger
           class="size-7 rounded-md text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"

--- a/apps/desktop/src/routes/camera-preview/+page.svelte
+++ b/apps/desktop/src/routes/camera-preview/+page.svelte
@@ -441,7 +441,7 @@
 
 <div
   class="group/root relative flex h-screen w-full select-none flex-col scroll-m-0 scrollbar-none"
-  data-tauri-drag-region
+  
 >
   <!-- Video bubble — the only clipped/rounded surface; `flex-1` is the window
        height minus the control strip, the region the aspect lock governs. -->
@@ -483,7 +483,7 @@
        never clipped; fades in on hover. -->
   <div
     class="flex w-full shrink-0 items-center justify-center"
-    data-tauri-drag-region
+    
     style="height: {CONTROL_BAR_HEIGHT}px"
   >
     <div

--- a/apps/desktop/src/routes/device-picker/+page.svelte
+++ b/apps/desktop/src/routes/device-picker/+page.svelte
@@ -132,28 +132,28 @@
     isLoading && "cursor-wait",
   )}
   aria-busy={isLoading}
-  data-tauri-drag-region
+  
 >
   <!-- Header -->
   <header
     class="flex items-center justify-between border-b border-border-subtle px-4 h-10 shrink-0"
-    data-tauri-drag-region
   >
-    <div class="flex items-center gap-2">
+    <div class="flex items-center gap-2" data-tauri-drag-region>
       {#if isMic}
-        <Mic size={11} class="text-muted-foreground" />
+        <Mic size={11} class="text-muted-foreground pointer-events-none" />
       {:else}
-        <Camera size={11} class="text-muted-foreground" />
+        <Camera size={11} class="text-muted-foreground pointer-events-none" />
       {/if}
-      <span
-        class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
-      >
+      <span class="pointer-events-none text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
         Select {title}
       </span>
     </div>
+    
+    <!-- Empty space for dragging -->
+    <div class="flex-1 h-full" data-tauri-drag-region></div>
+
     <Button
       onclick={closeWindow}
-      onmousedown={(e: MouseEvent) => e.stopPropagation()}
       size="icon-sm"
       variant="ghost"
       class="opacity-0 group-hover/root:opacity-100 transition-opacity"
@@ -289,13 +289,11 @@
 
   <!-- Footer -->
   <footer
-    data-tauri-drag-region
     class="flex items-center justify-between border-t border-border-subtle bg-card/50 px-3 h-11 shrink-0"
   >
     <Button
       onclick={fetchDevices}
       disabled={isLoading}
-      onmousedown={(e: MouseEvent) => e.stopPropagation()}
       variant="ghost"
       size="xs"
       class="gap-1.5"
@@ -303,10 +301,13 @@
       <RefreshCw size={11} class={isLoading ? "animate-spin" : ""} />
       Rescan
     </Button>
+
+    <!-- Empty space for dragging -->
+    <div class="flex-1 h-full" data-tauri-drag-region></div>
+
     <Button
       onclick={turnOff}
       disabled={isLoading}
-      onmousedown={(e: MouseEvent) => e.stopPropagation()}
       variant="destructive_soft"
       size="xs"
       class="gap-1.5"

--- a/apps/desktop/src/routes/panel/+page.svelte
+++ b/apps/desktop/src/routes/panel/+page.svelte
@@ -991,25 +991,25 @@
      it shows the desktop through. -->
 <div
   class="flex h-dvh w-dvw items-center justify-center px-4 py-3"
-  data-tauri-drag-region
+  
 >
 <div
   class="group/panel relative flex h-11 shrink-0 items-center justify-center overflow-hidden no-scrollbar bg-card/95 backdrop-blur-xl border border-border/60 rounded-lg ring-1 ring-foreground/5"
   style="width: {barWidth.current}px"
-  data-tauri-drag-region
+  
 >
   <!-- Content is `w-fit`; the bar tweens to follow it, centered, so collapse
        and expand are one symmetric motion. -->
   <div
     bind:this={barContentEl}
     class="relative flex w-fit shrink-0 items-center justify-center gap-1 p-2"
-    data-tauri-drag-region
+    
   >
   {#if phase === "countdown"}
     <!-- Depleting ring with the ticking second (click to start now), status, Cancel. -->
     <div
       class="flex w-fit items-center gap-2.5 pl-1"
-      data-tauri-drag-region
+      
       in:fade={{ duration: 200, delay: 80, easing: cubicOut }}
       out:phaseOut
     >
@@ -1120,7 +1120,7 @@
             class="shrink-0 font-mono text-[13px] font-semibold tabular-nums tracking-tight"
             class:text-foreground={!isPaused}
             class:text-muted-foreground={isPaused}
-            data-tauri-drag-region
+            
           >
             {timer}
           </span>

--- a/apps/desktop/src/routes/profile-picker/+page.svelte
+++ b/apps/desktop/src/routes/profile-picker/+page.svelte
@@ -96,19 +96,19 @@
   <!-- Header -->
   <header
     class="flex items-center justify-between border-b border-border-subtle px-4 h-10 shrink-0"
-    data-tauri-drag-region
   >
     <div class="flex items-center gap-2" data-tauri-drag-region>
-      <SlidersIcon size={11} class="text-muted-foreground" />
-      <span
-        class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
-      >
+      <SlidersIcon size={11} class="text-muted-foreground pointer-events-none" />
+      <span class="pointer-events-none text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
         Switch profile
       </span>
     </div>
+    
+    <!-- Empty space for dragging -->
+    <div class="flex-1 h-full" data-tauri-drag-region></div>
+
     <Button
       onclick={closeWindow}
-      onmousedown={(e: MouseEvent) => e.stopPropagation()}
       size="icon-sm"
       variant="ghost"
       class="opacity-0 group-hover/root:opacity-100 transition-opacity"
@@ -216,15 +216,17 @@
 
   <!-- Footer hint -->
   <footer
-    data-tauri-drag-region
     class="flex items-center justify-between border-t border-border-subtle bg-card/50 px-3 h-9 shrink-0"
   >
-    <span class="text-[10px] font-medium text-muted-foreground/80">
+    <span class="pointer-events-none text-[10px] font-medium text-muted-foreground/80" data-tauri-drag-region>
       ↑↓ Enter · ⌘1-⌘8 · Esc
     </span>
+
+    <!-- Empty space for dragging -->
+    <div class="flex-1 h-full" data-tauri-drag-region></div>
+
     <Button
       onclick={closeWindow}
-      onmousedown={(e: MouseEvent) => e.stopPropagation()}
       variant="ghost"
       size="xs"
     >

--- a/apps/desktop/src/routes/select/+page.svelte
+++ b/apps/desktop/src/routes/select/+page.svelte
@@ -207,20 +207,20 @@
   <!-- Header -->
   <header
     class="group/header flex items-center justify-between border-b border-border-subtle px-4 h-10 shrink-0"
-    data-tauri-drag-region
   >
-    <div class="flex items-center gap-2">
-      <span
-        class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
-      >
+    <div class="flex items-center gap-2" data-tauri-drag-region>
+      <span class="pointer-events-none text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
         Choose source
       </span>
     </div>
+    
+    <!-- Empty space for dragging -->
+    <div class="flex-1 h-full" data-tauri-drag-region></div>
+
     <Button
       variant="ghost"
       size="icon-sm"
       onclick={closeWindow}
-      onmousedown={(e: MouseEvent) => e.stopPropagation()}
       class="opacity-0 group-hover/root:opacity-100 transition-opacity"
       title="Close (Esc)"
     >
@@ -292,7 +292,7 @@
         <button
           type="button"
           onclick={openAreaPicker}
-          onmousedown={(e) => e.stopPropagation()}
+          // onmousedown={(e) => e.stopPropagation()}
           class="group/draw flex h-28 w-full flex-col items-center justify-center gap-2 rounded-md border border-dashed border-border bg-card/40 hover:bg-muted/50 transition-colors focus:outline-none focus:ring-1 focus:ring-ring"
         >
           <Crop size={20} class="text-muted-foreground" />
@@ -313,7 +313,7 @@
                 selectedSource = lastRegion;
               }
             }}
-            onmousedown={(e) => e.stopPropagation()}
+            // onmousedown={(e) => e.stopPropagation()}
             class="flex items-center justify-between gap-2 rounded-md border border-border bg-card px-2.5 py-2 text-left hover:bg-muted/50 transition-colors"
           >
             <div class="flex flex-col">
@@ -336,7 +336,7 @@
             type="button"
             onclick={() => (selectedSource = source)}
             ondblclick={confirmSelection}
-            onmousedown={(e) => e.stopPropagation()}
+            // onmousedown={(e) => e.stopPropagation()}
             class={cn(
               "flex items-center justify-between gap-2 rounded-md border px-2.5 py-2 text-left transition-colors focus:outline-none focus:ring-1 focus:ring-ring",
               selected
@@ -389,7 +389,7 @@
             type="button"
             onclick={() => (selectedSource = source)}
             ondblclick={confirmSelection}
-            onmousedown={(e) => e.stopPropagation()}
+            // onmousedown={(e) => e.stopPropagation()}
             class={cn(
               "group/tile relative flex flex-col overflow-hidden rounded-md border text-left transition-colors",
               "focus:outline-none focus:ring-1 focus:ring-ring",
@@ -464,7 +464,7 @@
     <Button
       onclick={fetchSources}
       disabled={isFetching}
-      onmousedown={(e: MouseEvent) => e.stopPropagation()}
+      // onmousedown={(e: MouseEvent) => e.stopPropagation()}
       variant="ghost"
       size="xs"
       class="gap-1.5"
@@ -476,7 +476,7 @@
     <div class="flex items-center gap-1.5">
       <Button
         onclick={closeWindow}
-        onmousedown={(e: MouseEvent) => e.stopPropagation()}
+        // onmousedown={(e: MouseEvent) => e.stopPropagation()}
         variant="ghost"
         size="xs"
       >
@@ -485,7 +485,7 @@
       <Button
         onclick={confirmSelection}
         disabled={!selectedSource}
-        onmousedown={(e: MouseEvent) => e.stopPropagation()}
+        // onmousedown={(e: MouseEvent) => e.stopPropagation()}
         variant="default"
         size="xs"
       >


### PR DESCRIPTION
### What this PR does
This completely fixes the "sticky button / double-click" bug that plagues macOS users across the app. 

### The Bug
On macOS, if a button is inside a container marked with `data-tauri-drag-region`, WebKit intercepts the first hover/click to drag the window. This meant users had to click twice to trigger buttons, and hover states were broken. `stopPropagation()` inside the buttons does not prevent this on macOS.

### The Fix
I audited the UI and removed `data-tauri-drag-region` from wrapping containers, instead isolating the drag regions to empty spaces, titles, and spacers.

Files fixed:
- `+layout.svelte` (Sidebar toggle)
- `customtitlebar.svelte` (Embedded titlebar wrapper)
- `editortoolbar.svelte` (Main editor toolbar)
- `app-sidebar.svelte` (Home logo button)
- `mobile header.svelte` (Home logo button)
- `camera-preview.svelte` (Floating control strip)
- `device-picker.svelte` (Picker header/footer)
- `profile-picker.svelte` (Picker header/footer)
- `SourceSelector.svelte` (Selector header)

All buttons now respond instantly on the first click on macOS while preserving the ability to drag the windows around!