### PR TITLE
perf(desktop): move heavy editor work off the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ See [`.changeset/README.md`](.changeset/README.md) for the full flow.
 
 ## [Unreleased]
 
+### Added
+- Update older recordings to the current project format in bulk from the library, or one at a time from a recording's menu. Recordings that still use the old format are marked so you can see which need updating.
+
+### Changed
+- Recordings now save in a new project format that keeps each part of your edit (background, zoom, annotations, audio) in its own section, so project files are more robust and easier to inspect. Older recordings are updated to the new format when you open them, and a copy of the original is kept alongside it first.
+- The editor stays responsive on long recordings. Adjusting cursor smoothing no longer freezes the preview, undo and redo are quicker, and autosave no longer causes a brief stutter.
+
 ## [0.2.8] — 2026-06-28
 
 ### Highlights

--- a/apps/desktop/src-tauri/src/commands/editor.rs
+++ b/apps/desktop/src-tauri/src/commands/editor.rs
@@ -2442,10 +2442,16 @@ pub fn cancel_export(export_id: String, state: State<'_, AppState>) -> Result<()
     Ok(())
 }
 
+/// Crash-recovery shadow write, fired on a ~30s timer — async + spawn_blocking
+/// so the JSON serialize + atomic file write never stall the UI thread.
 #[tauri::command]
-pub fn autosave_project(project_path: String, edits_json: String) -> Result<(), String> {
-    crate::project::autosave::save_autosave(Path::new(&project_path), &edits_json)
-        .map_err(|e| e.to_string())
+pub async fn autosave_project(project_path: String, edits_json: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::project::autosave::save_autosave(Path::new(&project_path), &edits_json)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("autosave task panicked: {e}"))?
 }
 
 /// Re-pack a legacy `.recast` as the current format in place (keeps a `.bak`).
@@ -2481,13 +2487,20 @@ pub async fn save_project_edits(project_path: String, edits_json: String) -> Res
 }
 
 #[tauri::command]
-pub fn clear_autosave(project_path: String) {
-    crate::project::autosave::clear_autosave(Path::new(&project_path));
+pub async fn clear_autosave(project_path: String) {
+    let _ = tauri::async_runtime::spawn_blocking(move || {
+        crate::project::autosave::clear_autosave(Path::new(&project_path));
+    })
+    .await;
 }
 
+/// Scans the autosave temp dir + parses each shadow file — async so a cluttered
+/// recovery dir doesn't block startup on the UI thread.
 #[tauri::command]
-pub fn get_recoverable_sessions() -> Vec<crate::project::autosave::AutosaveState> {
-    crate::project::autosave::find_recoverable_sessions()
+pub async fn get_recoverable_sessions() -> Vec<crate::project::autosave::AutosaveState> {
+    tauri::async_runtime::spawn_blocking(crate::project::autosave::find_recoverable_sessions)
+        .await
+        .unwrap_or_default()
 }
 
 /// Analyse a captured cursor track and return the list of moments that would
@@ -2498,16 +2511,22 @@ pub fn get_recoverable_sessions() -> Vec<crate::project::autosave::AutosaveState
 /// improvement would otherwise keep serving stale (often far noisier)
 /// suggestions. Detection is cheap (µs over the in-memory track).
 #[tauri::command]
-pub fn suggest_zoom_regions(
+pub async fn suggest_zoom_regions(
     cursor_path: String,
 ) -> Result<Vec<crate::cursor::smoothing::ZoomTrigger>, String> {
-    let bytes = fs::read(Path::new(&cursor_path)).map_err(|e| format!("read cursor track: {e}"))?;
-    let track: crate::cursor::CursorTrack =
-        serde_json::from_slice(&bytes).map_err(|e| format!("parse cursor track: {e}"))?;
-    Ok(crate::cursor::smoothing::detect_zoom_triggers(
-        &track.samples,
-        &track.clicks,
-    ))
+    // The cursor track is multi-MB on long recordings; read + parse off-thread.
+    tauri::async_runtime::spawn_blocking(move || {
+        let bytes =
+            fs::read(Path::new(&cursor_path)).map_err(|e| format!("read cursor track: {e}"))?;
+        let track: crate::cursor::CursorTrack =
+            serde_json::from_slice(&bytes).map_err(|e| format!("parse cursor track: {e}"))?;
+        Ok(crate::cursor::smoothing::detect_zoom_triggers(
+            &track.samples,
+            &track.clicks,
+        ))
+    })
+    .await
+    .map_err(|e| format!("suggest task panicked: {e}"))?
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/commands/recording.rs
+++ b/apps/desktop/src-tauri/src/commands/recording.rs
@@ -278,11 +278,16 @@ fn list_files_by_ext(dir: &PathBuf, exts: &[&str]) -> Result<Vec<RecordingEntry>
                 .duration_since(std::time::SystemTime::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
+            // Only `.recast` carries a format; the probe reads just the zip
+            // central directory, and this whole scan is already off the main
+            // thread (spawn_blocking).
+            let needs_migration = file_ext == "recast" && crate::project::is_legacy_project(&path);
             entries.push(RecordingEntry {
                 filename: entry.file_name().to_string_lossy().to_string(),
                 path: path.to_string_lossy().to_string(),
                 size_bytes: meta.len(),
                 created,
+                needs_migration,
             });
         }
     }

--- a/apps/desktop/src-tauri/src/commands/types.rs
+++ b/apps/desktop/src-tauri/src/commands/types.rs
@@ -51,6 +51,9 @@ pub struct RecordingEntry {
     pub path: String,
     pub size_bytes: u64,
     pub created: u64,
+    /// `.recast` only: a legacy v1 bundle the editor must migrate first.
+    /// Detected from the ZIP central directory, no extraction.
+    pub needs_migration: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]

--- a/apps/desktop/src-tauri/src/project/mod.rs
+++ b/apps/desktop/src-tauri/src/project/mod.rs
@@ -10,6 +10,20 @@ pub mod format;
 pub mod reader;
 pub mod writer;
 
+/// Cheap format probe: reads only the ZIP central directory (entry names) — no
+/// extraction or media decompression — to decide whether `path` is a legacy v1
+/// bundle. Returns false for unreadable or non-archive files.
+pub fn is_legacy_project(path: &Path) -> bool {
+    let Ok(file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let Ok(archive) = zip::ZipArchive::new(file) else {
+        return false;
+    };
+    let names: Vec<String> = archive.file_names().map(str::to_string).collect();
+    !format::is_v2(&names)
+}
+
 /// Re-pack a legacy v1 `.recast` as v2 in place, keeping a one-time
 /// `*.recast.bak` of the original first (recordings can be irreplaceable).
 /// No-op if the project is already v2. The atomic rename inside `write_project`

--- a/apps/desktop/src/components/editor/VideoPreview.svelte
+++ b/apps/desktop/src/components/editor/VideoPreview.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
 	import { resolveAsset } from "$lib/assets";
 	import { computeCanvasGeometry } from "$lib/canvas-geometry";
-	import {
-	  smoothCursorPath,
-	  smoothingStrengthToSigmaMs,
-	} from "$lib/cursor/smoothing";
+	import { smoothingStrengthToSigmaMs } from "$lib/cursor/smoothing";
+	import { CursorSmoother } from "$lib/cursor/smoother";
 	import {
 		cursorSpriteHotspot,
 		resolveBackgroundWireValue,
@@ -150,6 +148,8 @@
 	type IdlePeriodJS = { startUs: number; endUs: number };
 	let cursorSamplesRaw: CursorSampleJS[] = [];
 	let cursorSamples: CursorSampleJS[] = []; // post-smoothing; read by interpolateCursor
+	// Off-thread smoother; results are applied async (see loadCursorTrackIfNeeded).
+	let smoother: CursorSmoother | null = null;
 	let idlePeriods: IdlePeriodJS[] = [];
 	let loadedCursorPath = "";
 
@@ -646,6 +646,13 @@ void main() {
 			// Rebuild once per track load; the result is keyed by sample
 			// timestamps, which never move regardless of smoothing settings.
 			pressEvents = buildPressEvents(cursorSamplesRaw);
+			if (!smoother) {
+				smoother = new CursorSmoother((samples) => {
+					cursorSamples = samples;
+					requestRedraw();
+				});
+			}
+			smoother.load(cursorSamplesRaw);
 			ensureSmoothingCurrent();
 		} catch (err) {
 			console.warn("Cursor track load failed:", err);
@@ -656,8 +663,12 @@ void main() {
 		}
 	}
 
-	// Recompute the smoothed cursor path whenever the inputs change. Called
-	// once per draw() — cheap signature check, real work only on deltas.
+	// Recompute the smoothed cursor path whenever the inputs change. Called once
+	// per draw() — cheap signature check, real work only on deltas. The signature
+	// is set immediately (in-flight marker) so the per-frame call doesn't re-fire
+	// the request while the worker runs; the result is applied async via the
+	// smoother's callback. `sigmaMs <= 0` is the raw path — applied inline since
+	// there's nothing to compute.
 	function ensureSmoothingCurrent() {
 		if (cursorSamplesRaw.length === 0) {
 			cursorSamples = cursorSamplesRaw;
@@ -667,14 +678,18 @@ void main() {
 		const cs = store.cursorSettings;
 		const sig = `${loadedCursorPath}|${cs.smoothing}|${cs.snapToClicks ? 1 : 0}|${cs.snapWindowMs}`;
 		if (sig === smoothingSignature) return;
+		smoothingSignature = sig;
 		const sigmaMs = smoothingStrengthToSigmaMs(cs.smoothing);
-		const result = smoothCursorPath(cursorSamplesRaw, {
+		if (sigmaMs <= 0) {
+			cursorSamples = cursorSamplesRaw;
+			requestRedraw();
+			return;
+		}
+		smoother?.request({
 			sigmaMs,
 			snapToClicks: cs.snapToClicks,
 			snapWindowMs: cs.snapWindowMs,
 		});
-		cursorSamples = result.samples;
-		smoothingSignature = sig;
 	}
 
 	// Idle hide fade — shared 200ms ramp at each end of an idle period.
@@ -1475,6 +1490,8 @@ void main() {
 	onDestroy(() => {
 		stopVideoFrameLoop();
 		if (rafHandle !== null) cancelAnimationFrame(rafHandle);
+		smoother?.dispose();
+		smoother = null;
 		wcSource?.dispose();
 		wcSource = null;
 		if (gl) {

--- a/apps/desktop/src/lib/cursor/smoother.ts
+++ b/apps/desktop/src/lib/cursor/smoother.ts
@@ -1,0 +1,72 @@
+// Client for the cursor-smoothing worker: keeps the raw track in the worker,
+// debounces + supersedes rapid slider changes, and falls back to a synchronous
+// pass if the worker can't be created. Owns no rendering — callers apply the
+// result (the smoothed sample array) however they like.
+
+import {
+	smoothCursorPath,
+	type CursorSampleLike,
+	type SmoothingOptions,
+} from "./smoothing";
+
+type ResultMsg = { id: number; samples: CursorSampleLike[] };
+type Listener = (samples: CursorSampleLike[]) => void;
+
+// Coalesce slider drags; long enough to skip intermediate values, short enough
+// to feel immediate on the first change.
+const DEBOUNCE_MS = 60;
+
+export class CursorSmoother {
+	#worker: Worker | null = null;
+	#raw: CursorSampleLike[] = [];
+	#reqId = 0;
+	#debounce: ReturnType<typeof setTimeout> | null = null;
+	readonly #onResult: Listener;
+
+	constructor(onResult: Listener) {
+		this.#onResult = onResult;
+		try {
+			this.#worker = new Worker(
+				new URL("./smoothing-worker.ts", import.meta.url),
+				{ type: "module" },
+			);
+			this.#worker.onmessage = (e: MessageEvent<ResultMsg>) => {
+				// Drop superseded results — only the latest request matters.
+				if (e.data.id !== this.#reqId) return;
+				this.#onResult(e.data.samples);
+			};
+			this.#worker.onerror = () => {
+				this.#worker?.terminate();
+				this.#worker = null;
+			};
+		} catch {
+			this.#worker = null;
+		}
+	}
+
+	/** Replace the raw track; shipped to the worker once so later requests are cheap. */
+	load(raw: CursorSampleLike[]) {
+		this.#raw = raw;
+		this.#worker?.postMessage({ type: "load", raw });
+	}
+
+	/** Compute a smoothed path for `opts`, off-thread when possible. */
+	request(opts: SmoothingOptions) {
+		const id = ++this.#reqId;
+		if (!this.#worker) {
+			this.#onResult(smoothCursorPath(this.#raw, opts).samples);
+			return;
+		}
+		if (this.#debounce !== null) clearTimeout(this.#debounce);
+		this.#debounce = setTimeout(() => {
+			this.#debounce = null;
+			this.#worker?.postMessage({ type: "smooth", id, opts });
+		}, DEBOUNCE_MS);
+	}
+
+	dispose() {
+		if (this.#debounce !== null) clearTimeout(this.#debounce);
+		this.#worker?.terminate();
+		this.#worker = null;
+	}
+}

--- a/apps/desktop/src/lib/cursor/smoothing-worker.ts
+++ b/apps/desktop/src/lib/cursor/smoothing-worker.ts
@@ -1,0 +1,27 @@
+/// <reference lib="webworker" />
+// Off-main-thread cursor smoothing. The Gaussian pass is O(N·window) — hundreds
+// of ms on a long high-σ track — so it must not run on the UI thread. The raw
+// track is sent once via `load`; each slider change then ships only the tiny
+// opts, and the smoothed path comes back without ever touching the main thread.
+
+import {
+	smoothCursorPath,
+	type CursorSampleLike,
+	type SmoothingOptions,
+} from "./smoothing";
+
+type InMsg =
+	| { type: "load"; raw: CursorSampleLike[] }
+	| { type: "smooth"; id: number; opts: SmoothingOptions };
+
+let raw: CursorSampleLike[] = [];
+
+self.onmessage = (e: MessageEvent<InMsg>) => {
+	const msg = e.data;
+	if (msg.type === "load") {
+		raw = msg.raw;
+		return;
+	}
+	const { samples } = smoothCursorPath(raw, msg.opts);
+	self.postMessage({ id: msg.id, samples });
+};

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -50,6 +50,8 @@ export interface RecordingEntry {
 	path: string;
 	sizeBytes: number;
 	created: number;
+	/** `.recast` only: a legacy bundle that must be migrated before editing. */
+	needsMigration: boolean;
 }
 
 export interface EditorDocument {

--- a/apps/desktop/src/lib/stores/editor-store.svelte.ts
+++ b/apps/desktop/src/lib/stores/editor-store.svelte.ts
@@ -885,13 +885,13 @@ export function createEditorStore() {
 	let exportProgress = $state<number | null>(null);
 	let isExporting = $state(false);
 
-	// Undo/Redo stacks (simplified — stores snapshots of key settings)
-	// Undo/redo history — arrays of full serialized-project JSON strings, always
+	// Undo/redo history — arrays of de-proxied settings snapshots, always
 	// reassigned with spreads (never index-mutated) and bounded to
 	// `MAX_UNDO_HISTORY`. `$state.raw` since only the array identity is read
-	// reactively; the string contents never need proxying.
-	let undoStack = $state.raw<string[]>([]);
-	let redoStack = $state.raw<string[]>([]);
+	// reactively; the snapshot contents are already plain.
+	type EditorSettings = ReturnType<typeof captureSettings>;
+	let undoStack = $state.raw<EditorSettings[]>([]);
+	let redoStack = $state.raw<EditorSettings[]>([]);
 
 	// Dirty tracking — flips to true the moment the user makes any undoable edit,
 	// clears when the edits are persisted to the .recast archive (markSaved) or
@@ -901,18 +901,16 @@ export function createEditorStore() {
 	// Frozen snapshot of the last on-disk state. Used by `revertToSaved` to
 	// blow away every unsaved edit at once without walking the undo stack.
 	// Captured whenever the project is loaded from disk or successfully saved.
-	let savedSnapshot = $state<string | null>(null);
+	let savedSnapshot = $state<EditorSettings | null>(null);
 
 	// Timeline zoom
 	let timelineZoom = $state(1); // 1x = fit to width
 
-	function getSettingsSnapshot(): string {
-		// Captures every undoable state field. Anything left out here
-		// silently survives a `pushUndoState` call but isn't restored on
-		// undo — the user sees the unrelated edits revert while their
-		// annotation/camera tweak stays put. Keep this list in sync with
-		// `applySnapshot` so they round-trip 1:1.
-		return JSON.stringify({
+	// Every undoable state field. Anything left out here silently survives a
+	// `pushUndoState` call but isn't restored on undo — the user sees unrelated
+	// edits revert while their tweak stays put. Keep in sync with `applySnapshot`.
+	function captureSettings() {
+		return {
 			backgroundType,
 			backgroundValue,
 			backgroundBlur,
@@ -935,7 +933,14 @@ export function createEditorStore() {
 			outputAspect,
 			lastAppliedPresetId,
 			cursorMotionEasing,
-		});
+		};
+	}
+
+	// Deep, de-proxied clone via `$state.snapshot` rather than a JSON round-trip,
+	// so undo/redo never pays a stringify+parse on the press. `applySnapshot`
+	// copies each field into fresh state, so the stored snapshot stays pristine.
+	function getSettingsSnapshot(): EditorSettings {
+		return $state.snapshot(captureSettings()) as EditorSettings;
 	}
 
 	const MAX_UNDO_HISTORY = 50;
@@ -998,14 +1003,15 @@ export function createEditorStore() {
 		applySnapshot(next);
 	}
 
-	function applySnapshot(json: string) {
-		const s = JSON.parse(json);
+	// Each field is copied (spread/map) into fresh state, never aliased — the
+	// snapshot lives on the undo stack and must stay immutable across re-applies.
+	function applySnapshot(s: EditorSettings) {
 		backgroundType = s.backgroundType;
 		backgroundValue = s.backgroundValue;
 		backgroundBlur = s.backgroundBlur;
 		padding = normalizeFramePaddingPercent(s.padding, metadata);
 		borderRadius = s.borderRadius ?? 0;
-		shadow = s.shadow ?? shadow;
+		shadow = s.shadow ? { ...s.shadow } : shadow;
 		trimStart = s.trimStart;
 		trimEnd = s.trimEnd;
 		zoomRegions = (s.zoomRegions ?? []).map((r: ZoomRegion) => ({
@@ -1032,9 +1038,11 @@ export function createEditorStore() {
 				hoveredAnnotationId = null;
 			}
 		}
-		cursorSettings = s.cursorSettings;
-		audioSettings = s.audioSettings ?? audioSettings;
-		watermarkSettings = s.watermarkSettings ?? watermarkSettings;
+		cursorSettings = { ...s.cursorSettings };
+		audioSettings = s.audioSettings ? { ...s.audioSettings } : audioSettings;
+		watermarkSettings = s.watermarkSettings
+			? { ...s.watermarkSettings }
+			: watermarkSettings;
 		// Camera overlay was previously captured in the snapshot but not
 		// restored here, which silently destroyed camera-overlay edits on
 		// undo. Deep-copy so subsequent mutations don't alias the snapshot.

--- a/apps/desktop/src/routes/(app)/exports/+page.svelte
+++ b/apps/desktop/src/routes/(app)/exports/+page.svelte
@@ -45,9 +45,9 @@
     Unlink2,
     X,
   } from "@lucide/svelte";
-  import { Badge } from "@recast/ui/badge";
   import { Button } from "@recast/ui/button";
   import { ButtonGroup } from "@recast/ui/button-group";
+  import { Cutout } from "@recast/ui/cutout";
   import * as DropdownMenu from "@recast/ui/dropdown-menu";
   import { Kbd } from "@recast/ui/kbd";
   import { safeStorage } from "@recast/ui/persisted-state";
@@ -638,7 +638,7 @@
                   : "flex-row items-center gap-3 rounded-lg p-1.5",
                 isSelected
                   ? "border-primary/60 bg-primary/5"
-                  : "border-border/40 bg-card/40 hover:border-border hover:bg-card/70 hover:shadow-craft-sm",
+                  : "border-border/40 bg-card hover:border-border hover:shadow-craft-sm",
               )}
             >
               <!-- Thumbnail -->
@@ -695,12 +695,20 @@
                   </div>
                 {/if}
 
-                <Badge
-                  variant="secondary"
-                  class="absolute right-1.5 top-1.5 h-4 px-1 text-[8.5px] font-bold uppercase tracking-wider backdrop-blur"
-                >
-                  {getExtension(entry.filename)}
-                </Badge>
+                {#if view === "grid"}
+                  <Cutout
+                    corner="bl"
+                    surface="card"
+                    radius={8}
+                    class="flex items-center px-2.5 pt-2.5 pb-1"
+                  >
+                    <span
+                      class="text-[8.5px] font-bold uppercase leading-none tracking-wider text-muted-foreground"
+                    >
+                      {getExtension(entry.filename)}
+                    </span>
+                  </Cutout>
+                {/if}
 
                 <!-- Drive upload progress chip on the thumbnail (paired with the bottom bar). -->
                 {#if activeUpload}

--- a/apps/desktop/src/routes/(app)/recasts/+page.svelte
+++ b/apps/desktop/src/routes/(app)/recasts/+page.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
   import { ConfirmDialog, RenameDialog } from "$components/recast";
+  import { formatSize, relativeDate as relativeDateBase } from "$lib/format/files";
   import {
     deleteFile,
     generateThumbnails,
     listRecasts,
+    migrateProject,
     openFileLocation,
     renameFile,
     type RecordingEntry,
   } from "$lib/ipc";
-  import { formatSize, relativeDate as relativeDateBase } from "$lib/format/files";
   import {
     openInEditor as openEditorWindow,
     openInNewWindow,
@@ -23,6 +24,7 @@
     Film,
     FolderOpen,
     Grid3x3,
+    History,
     List,
     ListChecks,
     MoreHorizontal,
@@ -35,9 +37,9 @@
     Trash2,
     X,
   } from "@lucide/svelte";
-  import { Badge } from "@recast/ui/badge";
   import { Button } from "@recast/ui/button";
   import { ButtonGroup } from "@recast/ui/button-group";
+  import { Cutout } from "@recast/ui/cutout";
   import * as DropdownMenu from "@recast/ui/dropdown-menu";
   import { Kbd } from "@recast/ui/kbd";
   import { safeStorage } from "@recast/ui/persisted-state";
@@ -68,6 +70,11 @@
   let selectMode = $state(false);
   let bulkDeleteOpen = $state(false);
   const selected = new SvelteSet<string>();
+
+  // Legacy-format migration: surfaced only when the scan finds older bundles.
+  let migrateAllOpen = $state(false);
+  let migrating = $state(false);
+  const legacyCount = $derived(entries.filter((e) => e.needsMigration).length);
 
   onMount(() => {
     fetchRecasts();
@@ -268,6 +275,38 @@
     }
     exitSelectMode();
   }
+
+  // Migrate every legacy bundle sequentially — each `migrateProject` runs off
+  // the Rust main thread, and awaiting one at a time avoids parallel disk
+  // re-zips. Failures are surfaced, not thrown, so the dialog still closes.
+  async function handleMigrateAll() {
+    const legacy = entries.filter((e) => e.needsMigration);
+    migrating = true;
+    let ok = 0;
+    for (const e of legacy) {
+      try {
+        await migrateProject(e.path);
+        ok++;
+      } catch (err) {
+        console.warn("Migration failed:", e.path, err);
+      }
+    }
+    migrating = false;
+    const failed = legacy.length - ok;
+    if (failed > 0) toast.error(`Updated ${ok} · ${failed} failed`);
+    else toast.success(`Updated ${ok} project${ok === 1 ? "" : "s"}`);
+    await fetchRecasts();
+  }
+
+  async function handleMigrateOne(entry: RecordingEntry) {
+    try {
+      await migrateProject(entry.path);
+      toast.success(`Updated "${entry.filename}"`);
+      await fetchRecasts();
+    } catch (err) {
+      toast.error(`Update failed: ${err}`);
+    }
+  }
 </script>
 
 <div class="h-full overflow-y-auto scrollbar-transparent no-scrollbar">
@@ -341,6 +380,24 @@
           {query ? `Results for “${query}”` : "All recordings"}
         </h2>
         <div class="flex items-center gap-1.5">
+          {#if legacyCount > 0}
+            <Button
+              variant="secondary"
+              size="xs"
+              class="h-7 gap-1 text-[11px]"
+              onclick={() => (migrateAllOpen = true)}
+              disabled={migrating}
+              title="Update older projects to the current format"
+            >
+              {#if migrating}
+                <RefreshCw size={11} class="animate-spin" />
+              {:else}
+                <History size={11} />
+              {/if}
+              Update {legacyCount} older
+            </Button>
+          {/if}
+
           <Button
             variant={selectMode ? "secondary" : "ghost"}
             size="xs"
@@ -486,7 +543,7 @@
                 : "flex-row items-center gap-3 rounded-lg p-1.5",
               isSelected
                 ? "border-primary/60 bg-primary/5"
-                : "border-border/40 bg-card/40 hover:border-border hover:bg-card/70 hover:shadow-craft-sm",
+                : "border-border/40 bg-card hover:border-border hover:shadow-craft-sm",
             )}
           >
             <!-- Thumbnail -->
@@ -539,12 +596,18 @@
               {/if}
 
               {#if view === "grid"}
-                <Badge
-                  variant="secondary"
-                  class="absolute right-1.5 top-1.5 h-4 px-1 text-[8.5px] font-bold uppercase tracking-wider backdrop-blur"
+                <Cutout
+                  corner="bl"
+                  surface="card"
+                  radius={8}
+                  class="flex items-center px-2.5 pt-2.5 pb-1"
                 >
-                  .recast
-                </Badge>
+                  <span
+                    class="text-[8.5px] font-bold uppercase leading-none tracking-wider text-muted-foreground"
+                  >
+                    .recast
+                  </span>
+                </Cutout>
               {/if}
             </div>
 
@@ -561,6 +624,14 @@
               <div class="truncate text-[10.5px] text-muted-foreground/80">
                 {formatSize(entry.sizeBytes)} · {relativeDate(entry.created)}
               </div>
+              {#if entry.needsMigration}
+                <span
+                  class="mt-1 inline-flex w-fit items-center gap-1 rounded bg-warning/10 px-1.5 py-0.5 text-[9px] font-medium text-warning"
+                  title="Older project format — update to keep editing"
+                >
+                  <History size={9} /> Older format
+                </span>
+              {/if}
             </div>
 
             <!-- Actions -->
@@ -590,6 +661,12 @@
                     {/snippet}
                   </DropdownMenu.Trigger>
                   <DropdownMenu.Content align="end" size="sm" class="w-44">
+                    {#if entry.needsMigration}
+                      <DropdownMenu.Item onSelect={() => handleMigrateOne(entry)}>
+                        <History class="size-3" /> Update format
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Separator />
+                    {/if}
                     <DropdownMenu.Item onSelect={() => openInEditor(entry)}>
                       <Pencil class="size-3" /> Open in editor
                     </DropdownMenu.Item>
@@ -684,6 +761,19 @@
       </Button>
     </div>
   </div>
+{/if}
+
+{#if migrateAllOpen}
+  <ConfirmDialog
+    open={true}
+    title={`Update ${legacyCount} older project${legacyCount === 1 ? "" : "s"}?`}
+    description="These projects use an older format. Each is updated in place to the current format, keeping a backup (.bak) next to it. You can also update them one at a time from a project's menu."
+    confirmLabel="Update all"
+    onConfirm={handleMigrateAll}
+    onOpenChange={(v) => {
+      if (!v) migrateAllOpen = false;
+    }}
+  />
 {/if}
 
 {#if bulkDeleteOpen}

--- a/apps/desktop/src/routes/editor/[file]/+page.svelte
+++ b/apps/desktop/src/routes/editor/[file]/+page.svelte
@@ -162,6 +162,10 @@
     stopAutosave();
     autosaveTimer = setInterval(async () => {
       if (!documentPath || isLoading) return;
+      // Skip the full-state serialize when nothing changed since the last
+      // save/autosave — most idle ticks are clean, so the 30s timer stays off
+      // the main thread entirely until there's real work to persist.
+      if (!store.isDirty) return;
       try {
         const editsJson = JSON.stringify(store.toRenderState());
         await autosaveProject(documentPath, editsJson);
@@ -1146,6 +1150,12 @@
   async function handleSave() {
     if (!documentPath || isSaving || isLoading) return;
     isSaving = true;
+    // Paint the saving state before the synchronous serialize so the button
+    // reflects the click immediately. The serialize itself stays on the main
+    // thread by necessity — Tauri's IPC bridge JSON-encodes command args on the
+    // main thread anyway, so a worker would only add a proxy-stripping clone of
+    // equal cost; the win is gating autosave on isDirty (see startAutosave).
+    await tick();
     try {
       const editsJson = JSON.stringify(store.toRenderState());
       const savedAt = await saveProjectEdits(documentPath, editsJson);

--- a/apps/web/src/lib/tools/tool-icons.ts
+++ b/apps/web/src/lib/tools/tool-icons.ts
@@ -1,0 +1,94 @@
+/**
+ * First-party line glyphs for the tool cards, authored as Lucide-style
+ * `IconNode` data (24×24 viewBox, currentColor stroke). Drawn in-house so each
+ * tool reads as its own operation rather than a generic file icon; rendered via
+ * `<LocalIcon iconNode={…} />`. Several slugs share an op (transcode), so they
+ * intentionally share a glyph. Keyed by slug — add a tool, add an entry.
+ */
+import type { IconNode } from "@recast/ui/local-icon";
+
+// Animated frames + play → GIF.
+const gif: IconNode = [
+  ["rect", { x: 7, y: 3, width: 14, height: 11, rx: 2 }],
+  ["rect", { x: 3, y: 9, width: 14, height: 12, rx: 2 }],
+  ["path", { d: "M8 13v4l3.5-2z", fill: "currentColor", stroke: "none" }],
+];
+
+// Scissors → trim.
+const trim: IconNode = [
+  ["circle", { cx: 6, cy: 6, r: 3 }],
+  ["circle", { cx: 6, cy: 18, r: 3 }],
+  ["line", { x1: 20, y1: 4, x2: 8.12, y2: 15.88 }],
+  ["line", { x1: 14.47, y1: 14.48, x2: 20, y2: 20 }],
+  ["line", { x1: 8.12, y1: 8.12, x2: 12, y2: 12 }],
+];
+
+// Speaker + cross → mute (remove audio).
+const mute: IconNode = [
+  ["path", { d: "M11 5 6 9H2v6h4l5 4z", fill: "currentColor", stroke: "none" }],
+  ["line", { x1: 22, y1: 9, x2: 16, y2: 15 }],
+  ["line", { x1: 16, y1: 9, x2: 22, y2: 15 }],
+];
+
+// Music note → MP3.
+const mp3: IconNode = [
+  ["path", { d: "M9 18V5l12-2v13" }],
+  ["circle", { cx: 6, cy: 18, r: 3 }],
+  ["circle", { cx: 18, cy: 16, r: 3 }],
+];
+
+// Waveform → extract audio.
+const waveform: IconNode = [
+  ["line", { x1: 4, y1: 10, x2: 4, y2: 14 }],
+  ["line", { x1: 8, y1: 6, x2: 8, y2: 18 }],
+  ["line", { x1: 12, y1: 3, x2: 12, y2: 21 }],
+  ["line", { x1: 16, y1: 7, x2: 16, y2: 17 }],
+  ["line", { x1: 20, y1: 9, x2: 20, y2: 15 }],
+];
+
+// Frame with picture → video to images.
+const frames: IconNode = [
+  ["rect", { x: 3, y: 5, width: 18, height: 14, rx: 2 }],
+  ["circle", { cx: 8.5, cy: 10, r: 1.5 }],
+  ["path", { d: "M21 16l-4.5-4.5L8 20" }],
+];
+
+// Bidirectional swap → transcode (format conversion).
+const convert: IconNode = [
+  ["path", { d: "M8 4 4 8l4 4" }],
+  ["path", { d: "M4 8h16" }],
+  ["path", { d: "M16 20l4-4-4-4" }],
+  ["path", { d: "M20 16H4" }],
+];
+
+// Diagonal arrows inward → compress.
+const compress: IconNode = [
+  ["polyline", { points: "4 14 10 14 10 20" }],
+  ["polyline", { points: "20 10 14 10 14 4" }],
+  ["line", { x1: 14, y1: 10, x2: 21, y2: 3 }],
+  ["line", { x1: 3, y1: 21, x2: 10, y2: 14 }],
+];
+
+// Frame + diagonal handles → resize.
+const resize: IconNode = [
+  ["rect", { x: 3, y: 3, width: 18, height: 18, rx: 2 }],
+  ["path", { d: "M8 16 16 8" }],
+  ["path", { d: "M11 8h5v5" }],
+  ["path", { d: "M13 16H8v-5" }],
+];
+
+export const TOOL_ICONS: Record<string, IconNode> = {
+  "mp4-to-gif": gif,
+  "trim-video": trim,
+  "mute-video": mute,
+  "mp4-to-mp3": mp3,
+  "extract-audio": waveform,
+  "video-to-images": frames,
+  "mov-to-mp4": convert,
+  "mp4-to-webm": convert,
+  "webm-to-mp4": convert,
+  "compress-video": compress,
+  "resize-video": resize,
+};
+
+export const toolIcon = (slug: string): IconNode => TOOL_ICONS[slug] ?? convert;

--- a/apps/web/src/routes/tools/+page.svelte
+++ b/apps/web/src/routes/tools/+page.svelte
@@ -1,41 +1,214 @@
 <script lang="ts">
-	import Container from "$lib/components/Container.svelte";
-	import SeoMeta from "$lib/components/SeoMeta.svelte";
-	import { TOOLS } from "$lib/tools/registry";
-	import { Badge } from "@recast/ui/badge";
-	import * as Card from "@recast/ui/card";
-	import { ShieldCheck } from "@lucide/svelte";
+  import { Container, Footer, SeoMeta } from "$lib/components";
+  import { TOOLS } from "$lib/tools/registry";
+  import { toolIcon } from "$lib/tools/tool-icons";
+  import {
+    ArrowRight,
+    Download,
+    MousePointerClick,
+    ShieldCheck,
+    Upload,
+    UserX,
+    WifiOff,
+  } from "@lucide/svelte";
+  import { Cutout } from "@recast/ui/cutout";
+  import { LocalIcon } from "@recast/ui/local-icon";
+
+  const steps = [
+    {
+      icon: MousePointerClick,
+      title: "Pick a tool",
+      body: "Convert, trim, compress, mute — each tool is a single focused page.",
+    },
+    {
+      icon: Upload,
+      title: "Drop your file",
+      body: "It loads into your browser's own video engine. Nothing is uploaded.",
+    },
+    {
+      icon: Download,
+      title: "Save the result",
+      body: "Download the output instantly. No watermark, no account, no wait.",
+    },
+  ];
+
+  const privacy = [
+    { icon: WifiOff, label: "Runs offline", body: "Works after the page loads." },
+    { icon: ShieldCheck, label: "No upload", body: "Files never leave your device." },
+    { icon: UserX, label: "No account", body: "No sign-up, no email, no limits." },
+  ];
 </script>
 
 <SeoMeta
-	title="Free Browser Video Tools"
-	description="Convert, trim, compress, and extract from video for free. Everything runs in your browser. Your files are never uploaded."
-	eyebrow="Tools"
+  title="Free Browser Video Tools"
+  description="Convert, trim, compress, and extract from video for free. Everything runs in your browser. Your files are never uploaded."
+  eyebrow="Tools"
 />
 
-<div class="pt-24 pb-24 sm:pt-28">
-	<Container size="wide">
-		<header class="mx-auto max-w-2xl text-center">
-			<Badge variant="secondary" class="gap-1.5">
-				<ShieldCheck class="size-3.5" /> No upload, no account
-			</Badge>
-			<h1 class="mt-4 text-3xl font-semibold tracking-tight sm:text-4xl">Free video tools</h1>
-			<p class="mt-3 text-base text-muted-foreground">
-				Quick conversions that run entirely in your browser. Your files never leave your device.
-			</p>
-		</header>
+<main class="flex flex-col pb-8">
+  <!-- Hero -->
+  <Container size="wide" class="pt-28 pb-10 sm:pt-32">
+    <header class="mx-auto max-w-2xl text-center">
+      <span
+        class="inline-flex items-center gap-1.5 rounded-full border border-border/50 bg-card px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground shadow-(--shadow-craft-inset)"
+      >
+        <ShieldCheck class="size-3.5 text-primary" /> No upload · No account
+      </span>
+      <h1 class="mt-5 text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
+        Free video tools
+      </h1>
+      <p class="mt-3 text-pretty text-base leading-relaxed text-muted-foreground">
+        Quick conversions that run entirely in your browser. Your files never
+        leave your device.
+      </p>
+    </header>
+  </Container>
 
-		<div class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-			{#each TOOLS as tool (tool.slug)}
-				<a href={`/tools/${tool.slug}`} class="group block">
-					<Card.Root class="h-full transition-colors group-hover:border-primary/60">
-						<Card.Header>
-							<Card.Title class="text-base">{tool.title}</Card.Title>
-							<Card.Description>{tool.tagline}</Card.Description>
-						</Card.Header>
-					</Card.Root>
-				</a>
-			{/each}
-		</div>
-	</Container>
-</div>
+  <!-- Tools grid -->
+  <Container size="wide">
+    <div class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+      {#each TOOLS as tool (tool.slug)}
+        <a
+          href={`/tools/${tool.slug}`}
+          class="group relative flex h-full flex-col gap-3 overflow-hidden rounded-2xl border border-border/50 bg-card p-6 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-border hover:shadow-md"
+        >
+          <Cutout
+            corner="tr"
+            surface="background"
+            radius={14}
+            class="flex items-center pb-4 pl-4 pr-3 pt-2"
+          >
+            <span
+              class="text-[10px] font-bold uppercase tracking-[0.12em] text-muted-foreground"
+            >
+              {tool.outputLabel}
+            </span>
+          </Cutout>
+
+          <span
+            class="grid size-11 place-items-center rounded-xl bg-primary/10 text-primary"
+          >
+            <LocalIcon iconNode={toolIcon(tool.slug)} class="size-5" />
+          </span>
+
+          <h3 class="text-base font-semibold tracking-tight">{tool.title}</h3>
+          <p class="line-clamp-2 text-sm leading-relaxed text-muted-foreground">
+            {tool.tagline}
+          </p>
+
+          <span
+            class="mt-auto inline-flex items-center gap-1.5 pt-4 text-xs font-semibold text-primary"
+          >
+            Open tool
+            <ArrowRight
+              class="size-3.5 transition-transform group-hover:translate-x-0.5"
+            />
+          </span>
+        </a>
+      {/each}
+    </div>
+  </Container>
+
+  <!-- How it works — cutout step cards -->
+  <Container size="wide" class="mt-20">
+    <div class="mx-auto mb-8 max-w-xl text-center">
+      <span
+        class="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground"
+      >
+        <span class="size-1.5 rounded-full bg-primary"></span>
+        How it works
+      </span>
+      <h2 class="mt-3 text-balance text-2xl font-semibold tracking-tight sm:text-3xl">
+        Three steps, zero uploads
+      </h2>
+    </div>
+
+    <div class="grid gap-5 sm:grid-cols-3">
+      {#each steps as step, i (step.title)}
+        <article
+          class="group relative flex flex-col gap-3 overflow-hidden rounded-2xl border border-border/50 bg-card p-6 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-md"
+        >
+          <Cutout
+            corner="tr"
+            surface="background"
+            radius={14}
+            class="flex items-center justify-center pb-4 pl-4 pr-3 pt-2"
+          >
+            <span class="text-[11px] font-bold tabular-nums text-muted-foreground">
+              0{i + 1}
+            </span>
+          </Cutout>
+
+          <span
+            class="grid size-10 place-items-center rounded-xl bg-primary/10 text-primary"
+          >
+            <step.icon class="size-5" />
+          </span>
+          <h3 class="text-base font-semibold tracking-tight">{step.title}</h3>
+          <p class="text-sm leading-relaxed text-muted-foreground">{step.body}</p>
+        </article>
+      {/each}
+    </div>
+  </Container>
+
+  <!-- Privacy panel — one cutout-tagged surface -->
+  <Container size="wide" class="mt-16">
+    <div
+      class="relative overflow-hidden rounded-3xl border border-border/50 bg-card shadow-sm"
+    >
+      <Cutout corner="tl" surface="background" radius={14} class="pb-3.5 pl-3 pr-4 pt-2.5">
+        <span class="text-[10px] font-bold uppercase tracking-[0.18em] text-primary">
+          Private by default
+        </span>
+      </Cutout>
+
+      <div class="grid gap-6 p-6 pt-11 sm:grid-cols-3 sm:p-8 sm:pt-11">
+        {#each privacy as item (item.label)}
+          <div class="flex items-start gap-3">
+            <span
+              class="grid size-9 shrink-0 place-items-center rounded-lg bg-foreground/5 text-foreground"
+            >
+              <item.icon class="size-4.5" />
+            </span>
+            <div>
+              <p class="text-sm font-semibold tracking-tight">{item.label}</p>
+              <p class="mt-0.5 text-[13px] leading-relaxed text-muted-foreground">
+                {item.body}
+              </p>
+            </div>
+          </div>
+        {/each}
+      </div>
+    </div>
+  </Container>
+
+  <!-- CTA -->
+  <Container size="wide" class="mt-16">
+    <div
+      class="relative overflow-hidden rounded-3xl border border-border/50 bg-card px-6 py-10 text-center shadow-sm sm:px-10"
+    >
+      <Cutout corner="tr" surface="background" radius={12} class="pb-3 pl-3.5 pr-3.5 pt-1.5">
+        <span class="text-[11px] font-bold tracking-wide text-foreground">Free forever</span>
+      </Cutout>
+
+      <div class="mx-auto max-w-xl">
+        <h2 class="text-balance text-2xl font-semibold tracking-tight sm:text-3xl">
+          Want the full editor?
+        </h2>
+        <p class="mt-3 text-pretty text-sm leading-relaxed text-muted-foreground sm:text-base">
+          These tools are the quick path. Recast for desktop records, polishes,
+          and exports a finished demo — offline, in one app.
+        </p>
+        <a
+          href="/download"
+          class="mt-6 inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground shadow-craft-sm transition-transform hover:-translate-y-0.5"
+        >
+          Download Recast
+          <ArrowRight class="size-4" />
+        </a>
+      </div>
+    </div>
+  </Container>
+
+  <Footer />
+</main>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,6 +44,10 @@
       "svelte": "./src/components/ui/command/index.ts",
       "default": "./src/components/ui/command/index.ts"
     },
+    "./cutout": {
+      "svelte": "./src/components/ui/cutout/index.ts",
+      "default": "./src/components/ui/cutout/index.ts"
+    },
     "./dialog": {
       "svelte": "./src/components/ui/dialog/index.ts",
       "default": "./src/components/ui/dialog/index.ts"
@@ -71,6 +75,10 @@
     "./label": {
       "svelte": "./src/components/ui/label/index.ts",
       "default": "./src/components/ui/label/index.ts"
+    },
+    "./local-icon": {
+      "svelte": "./src/components/ui/local-icon/index.ts",
+      "default": "./src/components/ui/local-icon/index.ts"
     },
     "./markdown": {
       "svelte": "./src/components/ui/markdown/index.ts",

--- a/packages/ui/src/components/ui/cutout/cutout.svelte
+++ b/packages/ui/src/components/ui/cutout/cutout.svelte
@@ -1,0 +1,131 @@
+<script lang="ts" module>
+  export type CutoutCorner = "tl" | "tr" | "bl" | "br";
+  /** Token surface the notch blends into (must match the area behind the corner). */
+  export type CutoutSurface = "background" | "card" | "muted" | "popover" | "inherit" | "custom";
+</script>
+
+<script lang="ts">
+  /**
+   * Corner chip with an inverted ("carved out") radius. Anchors to one corner
+   * of a `relative` parent and uses two `currentColor` box-shadow pseudo-corners
+   * to bend the surrounding surface into a concave notch — so the chip reads as
+   * punched out of the parent rather than laid on top.
+   *
+   * `surface` sets both the chip fill and the notch colour, so it MUST match the
+   * token of whatever sits behind that corner (page = `background`, inside a
+   * card = `card`). Inner content sets its own text colour — the wrapper's text
+   * colour is reserved to drive the notch.
+   *
+   * Padding caveat: each notch reaches up to `radius` px into the chip on its
+   * two notched sides (e.g. a `bl` corner notches the TOP and RIGHT). Keep
+   * padding on those sides ≥ `radius` or the surface-coloured notch will paint
+   * over the content.
+   */
+  import { cn } from "@recast/ui/utils";
+  import type { Snippet } from "svelte";
+
+  let {
+    corner = "tr",
+    surface = "background",
+    radius = 16,
+    class: className,
+    children,
+    ...rest
+  }: {
+    corner?: CutoutCorner;
+    surface?: CutoutSurface;
+    radius?: number;
+    class?: string;
+    children: Snippet;
+  } & Record<string, unknown> = $props();
+
+  const surfaceClass: Record<CutoutSurface, string> = {
+    background: "bg-background text-background",
+    card: "bg-card text-card",
+    muted: "bg-muted text-muted",
+    popover: "bg-popover text-popover",
+    inherit: "bg-inherit text-current",
+    custom: "bg-[var(--cut-bg)] text-[var(--cut-text)]",
+  };
+  const anchorClass: Record<CutoutCorner, string> = {
+    tr: "right-0 top-0 rounded-bl-[var(--cut)]",
+    tl: "left-0 top-0 rounded-br-[var(--cut)]",
+    br: "right-0 bottom-0 rounded-tl-[var(--cut)]",
+    bl: "left-0 bottom-0 rounded-tr-[var(--cut)]",
+  };
+</script>
+
+<div
+  data-slot="cutout"
+  data-corner={corner}
+  style={`--cut:${radius}px`}
+  class={cn("cutout absolute z-10", anchorClass[corner], surfaceClass[surface], className)}
+  {...rest}
+>
+  {@render children()}
+</div>
+
+<style>
+  .cutout::before,
+  .cutout::after {
+    content: "";
+    position: absolute;
+    width: var(--cut);
+    height: var(--cut);
+    background: transparent;
+    pointer-events: none;
+    transition: box-shadow 0.3s ease;
+  }
+
+  .cutout[data-corner="tr"]::before {
+    top: 0;
+    left: calc(var(--cut) * -1);
+    border-top-right-radius: var(--cut);
+    box-shadow: calc(var(--cut) / 2) calc(var(--cut) / -2) 0 calc(var(--cut) / 2) currentColor;
+  }
+  .cutout[data-corner="tr"]::after {
+    bottom: calc(var(--cut) * -1);
+    right: 0;
+    border-top-right-radius: var(--cut);
+    box-shadow: calc(var(--cut) / 2) calc(var(--cut) / -2) 0 calc(var(--cut) / 2) currentColor;
+  }
+
+  .cutout[data-corner="tl"]::before {
+    top: 0;
+    right: calc(var(--cut) * -1);
+    border-top-left-radius: var(--cut);
+    box-shadow: calc(var(--cut) / -2) calc(var(--cut) / -2) 0 calc(var(--cut) / 2) currentColor;
+  }
+  .cutout[data-corner="tl"]::after {
+    bottom: calc(var(--cut) * -1);
+    left: 0;
+    border-top-left-radius: var(--cut);
+    box-shadow: calc(var(--cut) / -2) calc(var(--cut) / -2) 0 calc(var(--cut) / 2) currentColor;
+  }
+
+  .cutout[data-corner="bl"]::before {
+    top: calc(var(--cut) * -1);
+    left: 0;
+    border-bottom-left-radius: var(--cut);
+    box-shadow: calc(var(--cut) / -2) calc(var(--cut) / 2) 0 calc(var(--cut) / 2) currentColor;
+  }
+  .cutout[data-corner="bl"]::after {
+    bottom: 0;
+    right: calc(var(--cut) * -1);
+    border-bottom-left-radius: var(--cut);
+    box-shadow: calc(var(--cut) / -2) calc(var(--cut) / 2) 0 calc(var(--cut) / 2) currentColor;
+  }
+
+  .cutout[data-corner="br"]::before {
+    top: calc(var(--cut) * -1);
+    right: 0;
+    border-bottom-right-radius: var(--cut);
+    box-shadow: calc(var(--cut) / 2) calc(var(--cut) / 2) 0 calc(var(--cut) / 2) currentColor;
+  }
+  .cutout[data-corner="br"]::after {
+    bottom: 0;
+    left: calc(var(--cut) * -1);
+    border-bottom-right-radius: var(--cut);
+    box-shadow: calc(var(--cut) / 2) calc(var(--cut) / 2) 0 calc(var(--cut) / 2) currentColor;
+  }
+</style>

--- a/packages/ui/src/components/ui/cutout/index.ts
+++ b/packages/ui/src/components/ui/cutout/index.ts
@@ -1,0 +1,2 @@
+export { default as Cutout } from "./cutout.svelte";
+export type { CutoutCorner, CutoutSurface } from "./cutout.svelte";

--- a/packages/ui/src/components/ui/local-icon/index.ts
+++ b/packages/ui/src/components/ui/local-icon/index.ts
@@ -1,0 +1,2 @@
+export { default as LocalIcon } from "./local-icon.svelte";
+export type { IconNode, LocalIconProps } from "./local-icon.svelte";

--- a/packages/ui/src/components/ui/local-icon/local-icon.svelte
+++ b/packages/ui/src/components/ui/local-icon/local-icon.svelte
@@ -1,0 +1,62 @@
+<script lang="ts" module>
+  import type { SVGAttributes } from "svelte/elements";
+
+  /**
+   * Icon geometry as data, mirroring `@lucide/svelte`'s `IconNode`: an array of
+   * `[svgTag, attributes]` tuples. Authoring an icon is pure data — no new
+   * component file — which keeps the local set extensible and tree-shakeable.
+   */
+  export type IconNode = [tag: string, attrs: Record<string, string | number>][];
+
+  export interface LocalIconProps extends SVGAttributes<SVGSVGElement> {
+    size?: number | string;
+    color?: string;
+    strokeWidth?: number | string;
+    absoluteStrokeWidth?: boolean;
+    iconNode?: IconNode;
+  }
+</script>
+
+<script lang="ts">
+  // Lucide-compatible custom-icon base. The prop surface matches a Lucide icon
+  // (`size` / `color` / `strokeWidth` / `absoluteStrokeWidth` / `class` +
+  // currentColor stroke), so a `<LocalIcon iconNode={…} />` drops into the same
+  // call sites and a `size-*` class overrides the width/height attrs via CSS.
+  // Documented exception to AGENTS.md §4 "Lucide icons only", alongside
+  // `brand-icons` — for first-party glyphs Lucide doesn't ship.
+  import { cn } from "@recast/ui/utils";
+  import type { Snippet } from "svelte";
+
+  let {
+    size = 24,
+    color = "currentColor",
+    strokeWidth = 2,
+    absoluteStrokeWidth = false,
+    iconNode = [],
+    class: className,
+    children,
+    ...rest
+  }: LocalIconProps & { children?: Snippet } = $props();
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke={color}
+  stroke-width={absoluteStrokeWidth
+    ? (Number(strokeWidth) * 24) / Number(size)
+    : strokeWidth}
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+  class={cn("shrink-0", className)}
+  {...rest}
+>
+  {#each iconNode as [tag, attrs], i (i)}
+    <svelte:element this={tag} {...attrs} />
+  {/each}
+  {@render children?.()}
+</svg>


### PR DESCRIPTION
- Cursor smoothing (O(N·window) Gaussian) runs in a Web Worker with debounce + supersede and a synchronous fallback, so the smoothing slider no longer freezes the preview on long recordings.
- autosave_project / clear_autosave / get_recoverable_sessions / suggest_zoom_regions are now async + spawn_blocking.
- Editor autosave is gated on isDirty so clean 30s ticks do no work; manual save paints before serializing.
- Undo/redo snapshots use $state.snapshot instead of a JSON stringify/parse round-trip, dropping the parse from the undo press (also fixes latent aliasing of shadow/cursor/audio/watermark settings).