### PR TITLE
feat(macos): add hardware acceleration and fix retina region scaling

### DIFF
--- a/.changeset/curly-waves-give.md
+++ b/.changeset/curly-waves-give.md
@@ -1,0 +1,6 @@
+---
+"recast-desktop": minor
+kind: added
+---
+
+Add Apple Silicon hardware acceleration and fix region capture scaling on Retina displays.

--- a/apps/desktop/src-tauri/src/commands/editor.rs
+++ b/apps/desktop/src-tauri/src/commands/editor.rs
@@ -1711,6 +1711,19 @@ pub async fn export_video(
             // isn't bound by real-time pacing — slower presets = smaller
             // files at the same quality.
             match crate::ffmpeg::preferred_h264_encoder() {
+                "h264_videotoolbox" => {
+                    args.extend([
+                        "-c:v".to_string(),
+                        "h264_videotoolbox".to_string(),
+                        "-profile:v".to_string(),
+                        "high".to_string(),
+                        "-pix_fmt".to_string(),
+                        "yuv420p".to_string(),
+                        // VideoToolbox uses -q:v (1-100, higher is better) for VBR
+                        "-q:v".to_string(),
+                        "65".to_string(),
+                    ]);
+                }
                 "h264_nvenc" => {
                     args.extend([
                         "-c:v".to_string(),

--- a/apps/desktop/src-tauri/src/commands/system.rs
+++ b/apps/desktop/src-tauri/src/commands/system.rs
@@ -1551,7 +1551,16 @@ pub async fn diagnose_ffmpeg() -> Result<FfmpegDiagnostics, String> {
             // Hardware encoders are informational, not required. Listing
             // every vendor-specific codec the bundled FFmpeg supports so
             // the diagnostics page reflects what's actually selectable.
-            for hw in ["h264_nvenc", "h264_amf", "h264_qsv"] {
+            for hw in [
+                "h264_videotoolbox",
+                "h264_nvenc",
+                "h264_amf",
+                "h264_qsv",
+                "hevc_videotoolbox",
+                "hevc_nvenc",
+                "hevc_amf",
+                "hevc_qsv",
+            ] {
                 if table.contains(hw) {
                     present.push(hw.to_string());
                 }

--- a/apps/desktop/src-tauri/src/encoder/mod.rs
+++ b/apps/desktop/src-tauri/src/encoder/mod.rs
@@ -154,6 +154,34 @@ fn recording_codec_args(encoder: &str, quality: RecordingQuality) -> Vec<String>
     let v = |args: &[&str]| args.iter().map(|s| s.to_string()).collect::<Vec<_>>();
     use RecordingQuality::*;
     match (encoder, quality) {
+        ("h264_videotoolbox", Balanced) => v(&[
+            "-c:v",
+            "h264_videotoolbox",
+            "-realtime",
+            "1",
+            "-pix_fmt",
+            "yuv420p",
+        ]),
+        ("h264_videotoolbox", High) => v(&[
+            "-c:v",
+            "h264_videotoolbox",
+            "-realtime",
+            "1",
+            "-q:v",
+            "65", // 1-100 quality scale
+            "-pix_fmt",
+            "yuv420p",
+        ]),
+        ("h264_videotoolbox", Pristine) => v(&[
+            "-c:v",
+            "h264_videotoolbox",
+            "-realtime",
+            "1",
+            "-q:v",
+            "80", // Pristine quality
+            "-pix_fmt",
+            "yuv420p",
+        ]),
         // NVIDIA NVENC — `cq` is constant-quality (lower = better, 0..51).
         ("h264_nvenc", Balanced) => v(&[
             "-c:v",
@@ -653,7 +681,13 @@ mod tests {
 
     #[test]
     fn higher_tiers_stay_420_and_add_quality_rate_control() {
-        for enc in ["h264_nvenc", "h264_amf", "h264_qsv", "libx264"] {
+        for enc in [
+            "h264_videotoolbox",
+            "h264_nvenc",
+            "h264_amf",
+            "h264_qsv",
+            "libx264",
+        ] {
             for q in [RecordingQuality::High, RecordingQuality::Pristine] {
                 let args = recording_codec_args(enc, q);
                 // Never emit a 4:4:4 pixel format — the editor preview can't
@@ -667,7 +701,7 @@ mod tests {
                 assert!(
                     args.iter().any(|a| matches!(
                         a.as_str(),
-                        "-cq" | "-qp_i" | "-global_quality" | "-crf"
+                        "-cq" | "-qp_i" | "-global_quality" | "-crf" | "-q:v"
                     )),
                     "{enc}/{q:?} must set an explicit quality target, got {args:?}"
                 );

--- a/apps/desktop/src-tauri/src/ffmpeg.rs
+++ b/apps/desktop/src-tauri/src/ffmpeg.rs
@@ -357,8 +357,13 @@ pub fn preferred_h264_encoder() -> &'static str {
     static CACHED: OnceLock<&'static str> = OnceLock::new();
     CACHED.get_or_init(|| {
         for (name, extra_args) in [
+            // Apple Silicon / macOS Hardware Encoder
+            ("h264_videotoolbox", &["-realtime", "1"][..]),
+            // NVIDIA
             ("h264_nvenc", &["-preset", "p1"][..]),
+            // AMD
             ("h264_amf", &["-quality", "speed"][..]),
+            // Intel
             ("h264_qsv", &["-preset", "veryfast"][..]),
         ] {
             if probe_encoder(name, extra_args) {
@@ -413,7 +418,15 @@ pub struct EncoderAvailability {
 pub fn probe_recordable_encoders() -> Vec<EncoderAvailability> {
     // (name, label, vendor, family, hardware, extra_args). H.264 first so
     // the `active` lookup below lands on the codec the recorder uses.
-    let candidates: [(&str, &str, &str, &str, bool, &[&str]); 8] = [
+    let candidates: [(&str, &str, &str, &str, bool, &[&str]); 10] = [
+        (
+            "h264_videotoolbox",
+            "Apple VideoToolbox",
+            "Apple",
+            "H.264",
+            true,
+            &["-realtime", "1"],
+        ),
         (
             "h264_nvenc",
             "NVIDIA NVENC",
@@ -439,6 +452,14 @@ pub fn probe_recordable_encoders() -> Vec<EncoderAvailability> {
             &["-preset", "veryfast"],
         ),
         ("libx264", "x264 (CPU)", "Software", "H.264", false, &[]),
+        (
+            "hevc_videotoolbox",
+            "Apple VideoToolbox",
+            "Apple",
+            "HEVC",
+            true,
+            &["-realtime", "1"],
+        ),
         (
             "hevc_nvenc",
             "NVIDIA NVENC",

--- a/apps/desktop/src-tauri/src/recording/mod.rs
+++ b/apps/desktop/src-tauri/src/recording/mod.rs
@@ -332,13 +332,30 @@ fn resolve_region_target(rect: RegionRect) -> Result<CaptureTarget> {
     let monitor = Monitor::all()?
         .into_iter()
         .find(|monitor| {
+            // The frontend Region Picker passes coordinates in PHYSICAL pixels,
+            // but xcap's Monitor bounds are in LOGICAL pixels.
+            // We must un-scale the physical center point to find the matching monitor.
+            let scale = display_scale_factor(monitor) as f32;
+            let cx = (center_x as f32 / scale).round() as i32;
+            let cy = (center_y as f32 / scale).round() as i32;
+
             let x = monitor.x().unwrap_or_default();
             let y = monitor.y().unwrap_or_default();
             let width = monitor.width().unwrap_or_default() as i32;
             let height = monitor.height().unwrap_or_default() as i32;
-            center_x >= x && center_x < x + width && center_y >= y && center_y < y + height
+            cx >= x && cx < x + width && cy >= y && cy < y + height
         })
         .context("unable to locate the display containing the selected region")?;
+
+    let scale = display_scale_factor(&monitor);
+    let scale_f32 = scale as f32;
+
+    // Convert the physical rect back to logical pixels so it shares the same
+    // coordinate space as the monitor for clamping.
+    let logical_x = (rect.x as f32 / scale_f32).round() as i32;
+    let logical_y = (rect.y as f32 / scale_f32).round() as i32;
+    let logical_w = (rect.width as f32 / scale_f32).round() as u32;
+    let logical_h = (rect.height as f32 / scale_f32).round() as u32;
 
     let monitor_id = monitor.id().unwrap_or_default();
     let mon_x = monitor.x().unwrap_or_default();
@@ -353,15 +370,15 @@ fn resolve_region_target(rect: RegionRect) -> Result<CaptureTarget> {
         height: mon_h,
     };
 
-    // Clamp the requested region to the source monitor's bounds so that the
-    // encoder crop is never outside the captured frame.
-    let clamped_x = rect.x.max(mon_x).min(mon_x + mon_w as i32);
-    let clamped_y = rect.y.max(mon_y).min(mon_y + mon_h as i32);
+    // Clamp the requested logical region to the source monitor's bounds
+    let clamped_x = logical_x.max(mon_x).min(mon_x + mon_w as i32);
+    let clamped_y = logical_y.max(mon_y).min(mon_y + mon_h as i32);
     let max_w = (mon_x + mon_w as i32 - clamped_x).max(0) as u32;
     let max_h = (mon_y + mon_h as i32 - clamped_y).max(0) as u32;
+
     // Encoder libx264 requires even dimensions.
-    let crop_w = (rect.width.min(max_w)) & !1u32;
-    let crop_h = (rect.height.min(max_h)) & !1u32;
+    let crop_w = (logical_w.min(max_w)) & !1u32;
+    let crop_h = (logical_h.min(max_h)) & !1u32;
     if crop_w == 0 || crop_h == 0 {
         return Err(anyhow!("region collapsed to zero after clamping"));
     }
@@ -377,15 +394,17 @@ fn resolve_region_target(rect: RegionRect) -> Result<CaptureTarget> {
         kind: CaptureKind::Region,
         id: monitor_id,
         display_id: monitor_id,
-        label: format!("Area {crop_w}×{crop_h}"),
+        // Use the original physical dimensions for the display label, ensuring they are even
+        label: format!("Area {}×{}", rect.width & !1u32, rect.height & !1u32),
         source,
         crop,
         scale_factor: 1.0,
     };
-    apply_device_scale(&mut target, display_scale_factor(&monitor));
+
+    // This scales both source and crop back up to physical pixels for the encoder!
+    apply_device_scale(&mut target, scale);
     Ok(target)
 }
-
 //  Recording stats and artifacts
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1070,6 +1089,14 @@ fn trim_video_pause_intervals(path: &Path, intervals: &[(u64, u64)]) -> Result<(
     // the same reason — quality is fine for a 720p camera bubble.
     let mut command = std::process::Command::new(crate::ffmpeg::ffmpeg_path());
     let codec_args: &[&str] = match crate::ffmpeg::preferred_h264_encoder() {
+        "h264_videotoolbox" => &[
+            "-c:v",
+            "h264_videotoolbox",
+            "-q:v",
+            "60", // Good quality for a 720p camera bubble
+            "-pix_fmt",
+            "yuv420p",
+        ],
         "h264_nvenc" => &[
             "-c:v",
             "h264_nvenc",


### PR DESCRIPTION
### What this PR does
This PR bundles two major macOS backend improvements for Apple Silicon and Retina displays.

### 1. End-to-End Apple Silicon Hardware Acceleration
Previously, Apple Silicon Macs were falling back to `libx264` (CPU encoding) because `h264_videotoolbox` was missing from the encoder priority lists. 
* Added `h264_videotoolbox` (and HEVC variants) to `ffmpeg.rs` detection.
* Added the codec arguments to `recording/mod.rs` (live capture) and `editor.rs` (export) using `-realtime 1` for capture and standard `-q:v` for exports.
* Added Apple encoders to `system.rs` so the Diagnostics page accurately reports hardware capabilities.
* Result: CPU usage during recording and exporting drops to near zero, and live capture is buttery smooth.

### 2. Retina Region Scaling Fix
Previously, selecting a region on a Mac threw `unable to locate the display containing the selected region`.
* **The Cause:** The frontend overlay sends physical pixels (e.g., scaled by 2.0 on Retina), but `xcap` evaluates monitor bounds in logical pixels.
* **The Fix:** Updated `resolve_region_target` in `recording/mod.rs` to un-scale the center coordinates to logical pixels to find the correct monitor, perform the bounds clamping in logical space, and then scale back up to physical pixels for the encoder. 
* Result: Region capture now correctly locks onto the drawn area on High-DPI displays.