### PR TITLE
feat(editor): professional timeline — density filmstrip, per-segmen, speed

### DIFF
--- a/apps/desktop/src-tauri/src/commands/editor.rs
+++ b/apps/desktop/src-tauri/src/commands/editor.rs
@@ -1012,7 +1012,7 @@ fn atempo_chain(speed: f64) -> String {
 
 /// Per-segment audio retime that matches the video warp: split the kept audio
 /// into one branch per segment, `atrim` each to its post-trim range, `atempo` to
-/// its speed, then `aconcat`. Replaces the cut-only `aselect`/`asetpts` path when
+/// its speed, then `concat` (audio mode). Replaces the cut-only `aselect`/`asetpts` path when
 /// any segment is sped. `amap` is the audio label to consume (e.g. "[0:a:0]").
 fn build_speed_audio_filter(amap: &str, segs: &[SpeedSegment]) -> String {
     let n = segs.len();
@@ -1032,10 +1032,9 @@ fn build_speed_audio_filter(amap: &str, segs: &[SpeedSegment]) -> String {
         ));
         seg_labels.push(out);
     }
-    parts.push(format!(
-        "{}aconcat=n={n}:v=0:a=1[acut]",
-        seg_labels.join("")
-    ));
+    // FFmpeg has no `aconcat`; audio is concatenated with the `concat` filter
+    // configured for audio only (v=0:a=1).
+    parts.push(format!("{}concat=n={n}:v=0:a=1[acut]", seg_labels.join("")));
     parts.join(";")
 }
 
@@ -1800,7 +1799,7 @@ pub async fn export_video(
         video_map_after_cursor = "[vcut]".to_string();
         if let Some(amap) = audio_map.take() {
             if speed_active {
-                // Per-segment atrim+atempo+aconcat keeps audio length matched to
+                // Per-segment atrim+atempo+concat keeps audio length matched to
                 // the warped video, pitch-preserved (atempo time-stretches).
                 complex.push_str(&format!(
                     ";{}",

--- a/apps/desktop/src-tauri/src/commands/editor.rs
+++ b/apps/desktop/src-tauri/src/commands/editor.rs
@@ -864,6 +864,181 @@ fn build_cut_select_expr(cuts: &[(f64, f64)]) -> String {
     format!("not({})", terms.join("+"))
 }
 
+// --- Per-segment speed (Cap-style "edit this cut differently") -------------
+//
+// Overlays (zoom/cursor/blur) are computed on the continuous post-trim timeline
+// and cuts are applied last as a pure frame-drop (see the main pass below), so
+// speed slots in at the same tail point as a timing warp — no evaluator needs to
+// change. The kept-segment + speed math mirrors the frontend time-map
+// (apps/desktop/src/lib/timeline/{segments,segment-speed,time-map}.ts) and is
+// parity-tested against the shared speed-parity.json fixture.
+
+/// Clamp mirroring MIN/MAX_SEGMENT_SPEED in segment-speed.ts; a bad value → 1×.
+fn clamp_segment_speed(speed: f64) -> f64 {
+    if !speed.is_finite() || speed <= 0.0 {
+        1.0
+    } else {
+        speed.clamp(0.25, 4.0)
+    }
+}
+
+/// A kept segment on the post-trim timeline (t=0 at trim_start) with its speed.
+#[derive(Debug, Clone, Copy)]
+struct SpeedSegment {
+    start: f64,
+    end: f64,
+    speed: f64,
+}
+
+fn make_speed_segment(
+    start: f64,
+    end: f64,
+    segment_speeds: &[crate::render::graph::SegmentSpeed],
+    trim_start: f64,
+) -> SpeedSegment {
+    // Anchors are ORIGINAL-recording seconds; a post-trim segment's original
+    // start is `start + trim_start`.
+    let anchor = start + trim_start;
+    let speed = segment_speeds
+        .iter()
+        .find(|sp| (sp.start - anchor).abs() <= CUT_MERGE_EPS)
+        .map(|sp| clamp_segment_speed(sp.speed))
+        .unwrap_or(1.0);
+    SpeedSegment { start, end, speed }
+}
+
+/// Derive the kept segments on the post-trim timeline with their speeds. `cuts`
+/// are the already-collected post-trim cut ranges; `split_points` and the speed
+/// anchors are ORIGINAL seconds (shifted by `trim_start`). Mirrors
+/// deriveSegments + segment-speed anchoring on the frontend.
+fn build_speed_segments(
+    duration: f64,
+    cuts: &[(f64, f64)],
+    split_points: &[f64],
+    segment_speeds: &[crate::render::graph::SegmentSpeed],
+    trim_start: f64,
+) -> Vec<SpeedSegment> {
+    // Kept intervals = [0, duration] minus the cuts.
+    let mut kept: Vec<(f64, f64)> = Vec::new();
+    let mut cursor = 0.0;
+    for (cs, ce) in cuts {
+        if cs - cursor > CUT_MERGE_EPS {
+            kept.push((cursor, *cs));
+        }
+        cursor = cursor.max(*ce);
+    }
+    if duration - cursor > CUT_MERGE_EPS {
+        kept.push((cursor, duration));
+    }
+    // Slice each kept interval at the split points strictly inside it.
+    let mut segs: Vec<SpeedSegment> = Vec::new();
+    for (s, e) in kept {
+        let mut inside: Vec<f64> = split_points
+            .iter()
+            .map(|p| p - trim_start)
+            .filter(|p| *p > s + CUT_MERGE_EPS && *p < e - CUT_MERGE_EPS)
+            .collect();
+        inside.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let mut from = s;
+        for p in inside {
+            segs.push(make_speed_segment(from, p, segment_speeds, trim_start));
+            from = p;
+        }
+        segs.push(make_speed_segment(from, e, segment_speeds, trim_start));
+    }
+    segs
+}
+
+/// Any segment off 1× — the guard that keeps the no-speed export path unchanged.
+fn has_speed_change(segs: &[SpeedSegment]) -> bool {
+    segs.iter().any(|s| (s.speed - 1.0).abs() > CUT_MERGE_EPS)
+}
+
+/// Warped output duration — the value the export and the frontend time-map must
+/// agree on. Only the parity test reads it (the FFmpeg pipeline expresses the
+/// same warp via `setpts`/`atempo`), so it's test-scoped.
+#[cfg(test)]
+fn warped_output_duration(segs: &[SpeedSegment]) -> f64 {
+    segs.iter().map(|s| (s.end - s.start) / s.speed).sum()
+}
+
+/// `setpts` seconds-expression mapping a survivor frame's post-trim source time
+/// `T` onto the warped output axis: within segment i it is
+/// `offset_i + (T - start_i)/speed_i`, selected by nested `if(lt(T,end_i),…)`
+/// with the last segment as the else branch. Caller wraps as `setpts=(EXPR)/TB`.
+fn build_speed_setpts_expr(segs: &[SpeedSegment]) -> String {
+    fn rec(segs: &[SpeedSegment], i: usize, offset: f64) -> String {
+        let s = &segs[i];
+        let here = format!("{:.6}+(T-{:.6})/{:.6}", offset, s.start, s.speed);
+        if i + 1 >= segs.len() {
+            here
+        } else {
+            let next_offset = offset + (s.end - s.start) / s.speed;
+            format!(
+                "if(lt(T,{:.6}),{},{})",
+                s.end,
+                here,
+                rec(segs, i + 1, next_offset)
+            )
+        }
+    }
+    if segs.is_empty() {
+        "T".to_string()
+    } else {
+        rec(segs, 0, 0.0)
+    }
+}
+
+/// FFmpeg `atempo` accepts 0.5..=2.0 per instance; chain stages to cover the
+/// 0.25..=4.0 speed range (e.g. 4× → "atempo=2.0,atempo=2.0").
+fn atempo_chain(speed: f64) -> String {
+    let mut remaining = speed;
+    let mut stages: Vec<f64> = Vec::new();
+    while remaining > 2.0 + 1e-9 {
+        stages.push(2.0);
+        remaining /= 2.0;
+    }
+    while remaining < 0.5 - 1e-9 {
+        stages.push(0.5);
+        remaining /= 0.5;
+    }
+    stages.push(remaining);
+    stages
+        .iter()
+        .map(|s| format!("atempo={s:.6}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Per-segment audio retime that matches the video warp: split the kept audio
+/// into one branch per segment, `atrim` each to its post-trim range, `atempo` to
+/// its speed, then `aconcat`. Replaces the cut-only `aselect`/`asetpts` path when
+/// any segment is sped. `amap` is the audio label to consume (e.g. "[0:a:0]").
+fn build_speed_audio_filter(amap: &str, segs: &[SpeedSegment]) -> String {
+    let n = segs.len();
+    let mut parts: Vec<String> = Vec::new();
+    let split_labels: Vec<String> = (0..n).map(|i| format!("[aspd{i}]")).collect();
+    parts.push(format!("{amap}asplit={n}{}", split_labels.join("")));
+    let mut seg_labels: Vec<String> = Vec::new();
+    for (i, s) in segs.iter().enumerate() {
+        let out = format!("[aseg{i}]");
+        parts.push(format!(
+            "{}atrim=start={:.6}:end={:.6},asetpts=PTS-STARTPTS,{}{}",
+            split_labels[i],
+            s.start,
+            s.end,
+            atempo_chain(s.speed),
+            out
+        ));
+        seg_labels.push(out);
+    }
+    parts.push(format!(
+        "{}aconcat=n={n}:v=0:a=1[acut]",
+        seg_labels.join("")
+    ));
+    parts.join(";")
+}
+
 #[tauri::command]
 pub async fn export_video(
     app: AppHandle,
@@ -1569,7 +1744,19 @@ pub async fn export_video(
     // select only removes frames, it never reinterprets time. GIF has its own
     // paletteuse tail, so cuts there would need separate handling; skipped.
     let export_cuts = collect_export_cuts(&request.render_state, trim_start, trim_end);
-    if !export_cuts.is_empty() && request.format != "gif" {
+    // Per-segment speed (Cap-style) warps the survivors' timing on top of the cut
+    // drop — same tail-of-chain point, so upstream overlays stay correct. The
+    // segments and their warped duration mirror the frontend time-map (parity).
+    let speed_segments = build_speed_segments(
+        duration,
+        &export_cuts,
+        &request.render_state.split_points,
+        &request.render_state.segment_speeds,
+        trim_start,
+    );
+    let speed_active = has_speed_change(&speed_segments);
+    if (!export_cuts.is_empty() || speed_active) && request.format != "gif" {
+        let has_cuts = !export_cuts.is_empty();
         let select_expr = build_cut_select_expr(&export_cuts);
         let (mut complex, video_label) = match filter_complex_after_cursor.take() {
             Some(existing) => (existing, video_map_after_cursor.clone()),
@@ -1592,14 +1779,38 @@ pub async fn export_video(
             complex.push(';');
         }
         complex.push_str(&video_label);
-        complex.push_str(&format!(
-            "select='{select_expr}',setpts=N/FRAME_RATE/TB[vcut]"
-        ));
+        // Drop cut frames (select), then re-time survivors. At 1× this is the
+        // uniform CFR re-stamp (unchanged); with speed it's the piecewise warp,
+        // and the output `-r` resamples the warped PTS back to CFR (dropping /
+        // duplicating frames as the speed demands).
+        let select_prefix = if has_cuts {
+            format!("select='{select_expr}',")
+        } else {
+            String::new()
+        };
+        let setpts = if speed_active {
+            // Single-quote the value: the warp expression contains commas
+            // (if(lt(T,…),…,…)) that the filtergraph parser would otherwise read
+            // as filter separators — same reason `select='…'` is quoted above.
+            format!("setpts='({})/TB'", build_speed_setpts_expr(&speed_segments))
+        } else {
+            "setpts=N/FRAME_RATE/TB".to_string()
+        };
+        complex.push_str(&format!("{select_prefix}{setpts}[vcut]"));
         video_map_after_cursor = "[vcut]".to_string();
         if let Some(amap) = audio_map.take() {
-            complex.push_str(&format!(
-                ";{amap}aselect='{select_expr}',asetpts=N/SR/TB[acut]"
-            ));
+            if speed_active {
+                // Per-segment atrim+atempo+aconcat keeps audio length matched to
+                // the warped video, pitch-preserved (atempo time-stretches).
+                complex.push_str(&format!(
+                    ";{}",
+                    build_speed_audio_filter(&amap, &speed_segments)
+                ));
+            } else {
+                complex.push_str(&format!(
+                    ";{amap}aselect='{select_expr}',asetpts=N/SR/TB[acut]"
+                ));
+            }
             audio_map = Some("[acut]".to_string());
         }
         filter_complex_after_cursor = Some(complex);
@@ -2531,8 +2742,11 @@ pub async fn suggest_zoom_regions(
 
 #[cfg(test)]
 mod cut_export_tests {
-    use super::{build_cut_select_expr, collect_export_cuts};
-    use crate::render::graph::{CutRange, RenderState};
+    use super::{
+        atempo_chain, build_cut_select_expr, build_speed_segments, build_speed_setpts_expr,
+        collect_export_cuts, warped_output_duration,
+    };
+    use crate::render::graph::{CutRange, RenderState, SegmentSpeed};
 
     fn cut(start: f64, end: f64) -> CutRange {
         CutRange {
@@ -2635,5 +2849,82 @@ mod cut_export_tests {
                 "parity case '{name}': export kept duration {kept} != expected {expected}"
             );
         }
+    }
+
+    #[test]
+    fn warped_duration_matches_shared_parity_fixtures() {
+        // Anti-drift guard for per-segment speed. Loads the SAME json the frontend
+        // asserts against (segment-speed.test.ts → "speed parity"). For every case
+        // the export's warped output duration must equal the frontend time-map's,
+        // or the two speed models have diverged. All cases use trimStart=0.
+        let raw = include_str!("../../../src/lib/timeline/__fixtures__/speed-parity.json");
+        let doc: serde_json::Value = serde_json::from_str(raw).expect("valid fixture json");
+        for case in doc["cases"].as_array().expect("cases array") {
+            let name = case["name"].as_str().unwrap_or("?");
+            let trim_end = case["trimEnd"].as_f64().unwrap();
+            let expected = case["expectedOutputDuration"].as_f64().unwrap();
+            let cuts: Vec<CutRange> = case["cuts"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|p| {
+                    let p = p.as_array().unwrap();
+                    cut(p[0].as_f64().unwrap(), p[1].as_f64().unwrap())
+                })
+                .collect();
+            let split_points: Vec<f64> = case["splitPoints"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|v| v.as_f64().unwrap())
+                .collect();
+            let speeds: Vec<SegmentSpeed> = case["segmentSpeeds"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|p| {
+                    let p = p.as_array().unwrap();
+                    SegmentSpeed {
+                        start: p[0].as_f64().unwrap(),
+                        speed: p[1].as_f64().unwrap(),
+                    }
+                })
+                .collect();
+
+            let merged = collect_export_cuts(&state_with_cuts(cuts), 0.0, trim_end);
+            let segs = build_speed_segments(trim_end, &merged, &split_points, &speeds, 0.0);
+            let got = warped_output_duration(&segs);
+            assert!(
+                (got - expected).abs() < 1e-6,
+                "speed parity '{name}': warped duration {got} != expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn atempo_chain_covers_the_speed_range() {
+        assert_eq!(atempo_chain(1.5), "atempo=1.500000");
+        assert_eq!(atempo_chain(4.0), "atempo=2.000000,atempo=2.000000");
+        assert_eq!(atempo_chain(0.25), "atempo=0.500000,atempo=0.500000");
+    }
+
+    #[test]
+    fn setpts_expr_warps_a_two_segment_clip() {
+        // [0,4]@1x then [4,10]@2x → second segment maps T into half-rate output.
+        let segs = build_speed_segments(
+            10.0,
+            &[],
+            &[4.0],
+            &[SegmentSpeed {
+                start: 4.0,
+                speed: 2.0,
+            }],
+            0.0,
+        );
+        let expr = build_speed_setpts_expr(&segs);
+        assert_eq!(
+            expr,
+            "if(lt(T,4.000000),0.000000+(T-0.000000)/1.000000,4.000000+(T-4.000000)/2.000000)"
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/render/graph.rs
+++ b/apps/desktop/src-tauri/src/render/graph.rs
@@ -33,6 +33,16 @@ pub struct CutRange {
     pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
+/// Per-segment speed override, anchored to a kept segment's ORIGINAL start time
+/// (see apps/desktop/src/lib/timeline/segment-speed.ts). A segment with no entry
+/// plays at 1×. Read by the export pipeline to warp the kept stream's timing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SegmentSpeed {
+    pub start: f64,
+    pub speed: f64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderState {
@@ -87,6 +97,14 @@ pub struct RenderState {
     /// User-accepted silence/manual cuts removed from the timeline.
     #[serde(default)]
     pub cuts: Vec<CutRange>,
+    /// Split markers (original-recording seconds) dividing the kept clip into
+    /// addressable segments. Editor-only on their own; here they bound the
+    /// segments that `segment_speeds` retimes.
+    #[serde(default)]
+    pub split_points: Vec<f64>,
+    /// Per-segment speed overrides (empty = every segment plays at 1×).
+    #[serde(default)]
+    pub segment_speeds: Vec<SegmentSpeed>,
     /// Annotation overlays (rect/ellipse for Phase 1, more to follow).
     /// Preview-only today; export integration lands with the cursor-overlay rewrite.
     #[serde(default)]
@@ -171,6 +189,8 @@ impl Default for RenderState {
             cursor_sway: 0.0,
             zoom_regions: Vec::new(),
             cuts: Vec::new(),
+            split_points: Vec::new(),
+            segment_speeds: Vec::new(),
             annotations: Vec::new(),
             shadow: ShadowSettings::default(),
             audio_settings: AudioSettings::default(),

--- a/apps/desktop/src/components/editor/EditorToolbar.svelte
+++ b/apps/desktop/src/components/editor/EditorToolbar.svelte
@@ -5,11 +5,9 @@
     LoaderCircle,
     PanelBottom,
     PanelRight,
-    Redo2,
     RotateCcw,
     Save,
     Sparkles,
-    Undo2,
     Upload,
     X,
   } from "@lucide/svelte";
@@ -212,50 +210,6 @@
         </Tooltip.Root>
       </div>
     {/if}
-
-    <Separator orientation="vertical" class="mx-0.5 h-3.5" />
-
-    <div
-      class="flex items-center gap-0.5 rounded-lg bg-muted/60 p-0.5 ring-1 ring-inset ring-border/40"
-    >
-      <Tooltip.Root>
-        <Tooltip.Trigger>
-          <button
-            type="button"
-            onclick={() => store.undo()}
-            disabled={!store.canUndo}
-            aria-label="Undo"
-            class="cursor-pointer flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-card hover:text-foreground disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
-          >
-            <Undo2 size={12} />
-          </button>
-        </Tooltip.Trigger>
-        <Tooltip.Content>
-          <span class="inline-flex items-center gap-1.5">
-            Undo <Kbd>Ctrl+Z</Kbd>
-          </span>
-        </Tooltip.Content>
-      </Tooltip.Root>
-
-      <Tooltip.Root>
-        <Tooltip.Trigger>
-          <button
-            type="button"
-            onclick={() => store.redo()}
-            disabled={!store.canRedo}
-            aria-label="Redo"
-            class="cursor-pointer flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-card hover:text-foreground disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
-          >
-            <Redo2 size={12} />
-          </button>
-        </Tooltip.Trigger>
-        <Tooltip.Content>
-          <span class="inline-flex items-center gap-1.5">
-            Redo <Kbd>Ctrl+Shift+Z</Kbd>
-          </span>
-        </Tooltip.Content>
-      </Tooltip.Root>
-    </div>
   </div>
 
   <div class="ml-auto flex items-center gap-1">

--- a/apps/desktop/src/components/editor/Timeline.svelte
+++ b/apps/desktop/src/components/editor/Timeline.svelte
@@ -15,13 +15,15 @@
   import TimelineZoomLane from "./_components/timeline/TimelineZoomLane.svelte";
   import {
     effectiveFps as effFps,
+    formatTimeByMode,
     frameStep as frameStepOf,
     greatestCommonDivisor,
     minClipDuration as minClipDurOf,
     quantizeToFrame as quantizeToFrameOf,
     type TimeMode,
   } from "./_components/timeline/timeline-helpers";
-  import { originalToOutput, outputToOriginal } from "$lib/timeline/cuts";
+  import { originalToOutput, outputToOriginal } from "$lib/timeline/time-map";
+  import type { TileProvider } from "$lib/timeline/filmstrip-source";
 
   // Orchestrator: owns the scroll container, sizing, transport (JKL/speed),
   // keyboard routing, and the click-to-seek scrubber. Subviews live under `_components/timeline/`.
@@ -29,13 +31,25 @@
   interface Props {
     store: EditorStore;
     videoEl?: HTMLVideoElement | null;
+    tileProvider?: TileProvider | null;
+    filmstripVersion?: number;
   }
 
-  let { store, videoEl = null }: Props = $props();
+  let {
+    store,
+    videoEl = null,
+    tileProvider = null,
+    filmstripVersion = 0,
+  }: Props = $props();
 
   let timelineEl: HTMLDivElement | undefined = $state();
   let isDraggingPlayhead = $state(false);
   let timelineWidth = $state(900);
+  // Horizontal scroll offset, tracked so the clip bar can virtualize its tiles.
+  let scrollLeft = $state(0);
+  // Left padding (px-2) between the scroller and the lane content the clip bar
+  // positions against — subtracted so the viewport lands in clip-bar coords.
+  const LANE_PAD = 8;
 
   const SPEEDS = [0.25, 0.5, 1.0, 1.5, 2.0] as const;
   let playbackSpeed = $state(1.0);
@@ -136,18 +150,21 @@
       const center = (region.start + region.end) * 0.5;
       timelineEl.scrollLeft = Math.max(
         0,
-        originalToOutput(cuts, center) * nextPps - timelineEl.clientWidth * 0.5,
+        originalToOutput(store.timeMap, center) * nextPps - timelineEl.clientWidth * 0.5,
       );
     });
   }
 
-  function clientXToTime(clientX: number): number {
-    if (!timelineEl || duration <= 0) return 0;
+  // Output seconds under the pointer, BEFORE the time-map. Trim drags map this
+  // through a map FROZEN at drag-start, so the collapsed clip's left edge (which
+  // sits at output 0) isn't a degenerate input.
+  function clientXToOutput(clientX: number): number {
+    if (!timelineEl || pixelsPerSecond <= 0) return 0;
     const rect = timelineEl.getBoundingClientRect();
-    const scrollLeft = timelineEl.scrollLeft;
-    const x = clientX - rect.left + scrollLeft;
-    // OUTPUT px → original time so the scrubber lands on kept content, skipping collapsed cuts.
-    return Math.max(0, Math.min(duration, tOf(x)));
+    return Math.max(
+      0,
+      (clientX - rect.left + timelineEl.scrollLeft) / pixelsPerSecond,
+    );
   }
 
   // For the global Alt+[ / Alt+] shortcuts (trim handles have their own arrows in TimelineClipBar).
@@ -173,10 +190,10 @@
   }
 
   const duration = $derived(store.metadata?.duration ?? 0);
-  // The axis is OUTPUT (post-cut) time: `originalToOutput` collapses cuts to zero
-  // width so later content slides left (NLE ripple). Trim isn't a cut, so head/tail handles remain.
-  const cuts = $derived(store.effectiveCuts);
-  const outputDuration = $derived(originalToOutput(cuts, duration));
+  // The axis is OUTPUT time via `store.timeMap`: cuts collapse to zero width (NLE
+  // ripple) and each kept segment is warped by its per-segment speed. Trimmed
+  // head/tail stay as 1x context, so the in/out handles still bracket the clip.
+  const outputDuration = $derived(store.timeMap.outputDuration);
   const pixelsPerSecond = $derived(
     outputDuration > 0 ? (timelineWidth * store.timelineZoom) / outputDuration : 100,
   );
@@ -184,8 +201,8 @@
     Math.max(outputDuration * pixelsPerSecond, timelineWidth),
   );
   // Canonical axis transforms — every lane positions with `xOf` and resolves pointers with `tOf`.
-  const xOf = (t: number) => originalToOutput(cuts, t) * pixelsPerSecond;
-  const tOf = (x: number) => outputToOriginal(cuts, x / pixelsPerSecond);
+  const xOf = (t: number) => originalToOutput(store.timeMap, t) * pixelsPerSecond;
+  const tOf = (x: number) => outputToOriginal(store.timeMap, x / pixelsPerSecond);
   const clipLeft = $derived(xOf(store.inPoint));
   const clipRight = $derived(xOf(store.outPoint));
   const clipWidth = $derived(Math.max(clipRight - clipLeft, 0));
@@ -229,12 +246,50 @@
   }
 
   function handleTimelinePointerMove(event: PointerEvent) {
+    updateHover(event.clientX);
     if (!isDraggingPlayhead) return;
     seekToPosition(event.clientX);
   }
 
   function handleTimelinePointerUp() {
     isDraggingPlayhead = false;
+  }
+
+  // Hover-scrub: a frame thumbnail (decoded by the filmstrip provider) follows
+  // the cursor over the timeline, with the output timecode under it.
+  let hover = $state<{
+    clientX: number;
+    top: number;
+    outputSec: number;
+    originalSec: number;
+  } | null>(null);
+  const hoverUrl = $derived.by(() => {
+    void filmstripVersion;
+    if (!hover || !tileProvider) return undefined;
+    return tileProvider.previewAt(hover.originalSec);
+  });
+
+  function updateHover(clientX: number) {
+    if (!timelineEl || isDraggingPlayhead || duration <= 0) {
+      hover = null;
+      return;
+    }
+    const rect = timelineEl.getBoundingClientRect();
+    const xInViewport = clientX - rect.left;
+    if (xInViewport < 0 || xInViewport > rect.width) {
+      hover = null;
+      return;
+    }
+    const outputSec = clientXToOutput(clientX);
+    hover = {
+      clientX,
+      top: rect.top,
+      outputSec,
+      originalSec: outputToOriginal(store.timeMap, outputSec),
+    };
+  }
+  function clearHover() {
+    hover = null;
   }
 
   function handleTimelineKeydown(event: KeyboardEvent) {
@@ -379,6 +434,10 @@
   function handleResize() {
     if (!timelineEl) return;
     timelineWidth = timelineEl.clientWidth;
+  }
+
+  function handleScroll() {
+    if (timelineEl) scrollLeft = timelineEl.scrollLeft;
   }
 
   function handleTimelineWheel(event: WheelEvent) {
@@ -654,6 +713,8 @@
       onpointerup={handleTimelinePointerUp}
       onpointercancel={handleTimelinePointerUp}
       onwheel={handleTimelineWheel}
+      onscroll={handleScroll}
+      onpointerleave={clearHover}
       onkeydown={handleTimelineKeydown}
     >
       <div
@@ -673,7 +734,11 @@
           {clipWidth}
           {thumbnailWidth}
           {timeMode}
-          {clientXToTime}
+          {clientXToOutput}
+          {tileProvider}
+          {filmstripVersion}
+          viewportLeftPx={Math.max(0, scrollLeft - LANE_PAD)}
+          viewportWidthPx={timelineWidth}
         />
 
         <TimelineZoomLane
@@ -712,6 +777,35 @@
     </div>
   </div>
 </div>
+
+<!-- Hover-scrub preview: fixed so it floats above the timeline without being
+     clipped by the scroller's overflow. Only with the WebCodecs filmstrip. -->
+{#if hover && tileProvider && !isDraggingPlayhead}
+  <div
+    class="pointer-events-none fixed z-50 flex -translate-x-1/2 -translate-y-full flex-col items-center gap-1"
+    style="left: {hover.clientX}px; top: {hover.top - 8}px;"
+  >
+    <div
+      class="overflow-hidden rounded-md border border-border/70 bg-card shadow-lg"
+    >
+      {#if hoverUrl}
+        <img
+          src={hoverUrl}
+          alt=""
+          class="block h-16 w-auto object-cover"
+          draggable="false"
+        />
+      {:else}
+        <div class="h-16 w-28 animate-pulse bg-muted/60"></div>
+      {/if}
+    </div>
+    <span
+      class="rounded bg-popover px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-foreground shadow-sm"
+    >
+      {formatTimeByMode(hover.outputSec, timeMode, effectiveFps())}
+    </span>
+  </div>
+{/if}
 
 <style>
   .custom-scrollbar::-webkit-scrollbar {

--- a/apps/desktop/src/components/editor/Timeline.svelte
+++ b/apps/desktop/src/components/editor/Timeline.svelte
@@ -65,12 +65,16 @@
   let reverseFrame = 0;
 
   $effect(() => {
-    if (videoEl) {
-      videoEl.playbackRate =
-        shuttleDirection === 1
-          ? SHUTTLE_SPEEDS[shuttleSpeedIndex] * playbackSpeed
-          : playbackSpeed;
-    }
+    if (!videoEl) return;
+    // Legacy <video> path: the element IS the clock, so per-segment clip speed
+    // must ride on its playbackRate (the warped output clock only exists on the
+    // WebCodecs path). Re-evaluated as the playhead crosses into each segment.
+    const segSpeed = store.segmentSpeedAtTime(store.currentTime);
+    const transport =
+      shuttleDirection === 1
+        ? SHUTTLE_SPEEDS[shuttleSpeedIndex] * playbackSpeed
+        : playbackSpeed;
+    videoEl.playbackRate = transport * segSpeed;
   });
 
   // Reverse-play loop. Held active only while shuttleDirection === -1.
@@ -240,13 +244,19 @@
   }
 
   function handleTimelinePointerDown(event: PointerEvent) {
+    // Razor mode owns the click: place an anchor / carve a cut, never seek/drag.
+    if (razorActive) {
+      event.preventDefault();
+      razorClickAt(event.clientX);
+      return;
+    }
     isDraggingPlayhead = true;
     (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
     seekToPosition(event.clientX);
   }
 
   function handleTimelinePointerMove(event: PointerEvent) {
-    updateHover(event.clientX);
+    updateHover(event.clientX, event.clientY);
     if (!isDraggingPlayhead) return;
     seekToPosition(event.clientX);
   }
@@ -255,10 +265,46 @@
     isDraggingPlayhead = false;
   }
 
+  // Razor (Cut) tool: when armed, the scroller stops seeking and instead takes
+  // two clicks to carve a manual cut. The first click sets `razorAnchor`; the
+  // second commits `addCut(lo, hi)`. Stays armed for repeated cuts until toggled
+  // off or Esc. While armed the cursor is a scissor and a destructive preview
+  // band shows the span that will be removed.
+  let razorActive = $state(false);
+  let razorAnchor = $state<number | null>(null);
+
+  function toggleRazor() {
+    razorActive = !razorActive;
+    razorAnchor = null;
+  }
+
+  // Original time under the pointer, clamped + frame-quantized — the razor's
+  // click resolution (so a cut lands on the same frame preview and export use).
+  function clientXToOriginal(clientX: number): number {
+    if (!timelineEl) return 0;
+    const rect = timelineEl.getBoundingClientRect();
+    const x = clientX - rect.left + timelineEl.scrollLeft;
+    return quantizeToFrame(Math.max(0, Math.min(duration, tOf(x))));
+  }
+
+  function razorClickAt(clientX: number) {
+    const t = clientXToOriginal(clientX);
+    if (razorAnchor === null) {
+      razorAnchor = t;
+      return;
+    }
+    const lo = Math.min(razorAnchor, t);
+    const hi = Math.max(razorAnchor, t);
+    razorAnchor = null;
+    // addCut drops sub-10ms ranges; merge folds it into any neighbour.
+    if (store.addCut(lo, hi, "manual")) store.mergeCuts();
+  }
+
   // Hover-scrub: a frame thumbnail (decoded by the filmstrip provider) follows
   // the cursor over the timeline, with the output timecode under it.
   let hover = $state<{
     clientX: number;
+    clientY: number;
     top: number;
     outputSec: number;
     originalSec: number;
@@ -269,7 +315,7 @@
     return tileProvider.previewAt(hover.originalSec);
   });
 
-  function updateHover(clientX: number) {
+  function updateHover(clientX: number, clientY = 0) {
     if (!timelineEl || isDraggingPlayhead || duration <= 0) {
       hover = null;
       return;
@@ -283,6 +329,7 @@
     const outputSec = clientXToOutput(clientX);
     hover = {
       clientX,
+      clientY,
       top: rect.top,
       outputSec,
       originalSec: outputToOriginal(store.timeMap, outputSec),
@@ -296,6 +343,19 @@
     if (duration <= 0) return;
 
     const mod = event.ctrlKey || event.metaKey;
+
+    // Razor (Cut) tool: C arms/disarms; Esc cancels a pending anchor, else disarms.
+    if (event.key === "Escape" && razorActive) {
+      event.preventDefault();
+      if (razorAnchor !== null) razorAnchor = null;
+      else razorActive = false;
+      return;
+    }
+    if ((event.key === "c" || event.key === "C") && !mod) {
+      event.preventDefault();
+      toggleRazor();
+      return;
+    }
 
     // Paste works anywhere in the timeline (cards own copy/duplicate — they need focus).
     if (mod && (event.key === "v" || event.key === "V")) {
@@ -634,8 +694,10 @@
     speeds={SPEEDS}
     {timeMode}
     hasSelectedRegion={!!store.selectedZoomRegionId}
+    {razorActive}
     onSetTrim={setTrimPoint}
     onSplit={() => store.splitAt(store.currentTime)}
+    onToggleRazor={toggleRazor}
     onAddFocusRegion={addFocusRegion}
     onResetTrim={resetTrim}
     onZoomTimeline={zoomTimeline}
@@ -662,37 +724,37 @@
         </div>
         <!-- Focus -->
         <div class="mt-1.5 flex min-h-9 items-center justify-between gap-1">
-          {@render railLabel(Target, "Focus", "bg-primary/15 text-primary")}
+          {@render railLabel(Target, "Zoom", "bg-primary/15 text-primary")}
           {@render railEye(
             store.focusEnabled,
             () => (store.focusEnabled = !store.focusEnabled),
             store.focusEnabled
-              ? "Disable focus (regions stay; preview & export ignore them)"
-              : "Enable focus",
+              ? "Disable zoom (regions stay; preview & export ignore them)"
+              : "Enable zoom",
           )}
         </div>
         <!-- Notes -->
         <div class="mt-1.5 flex min-h-9 items-center justify-between gap-1">
-          {@render railLabel(Pencil, "Notes", "bg-warning/15 text-warning")}
+          {@render railLabel(Pencil, "Markup", "bg-warning/15 text-warning")}
           {@render railEye(
             !store.annotationsGloballyHidden,
             () =>
               (store.annotationsGloballyHidden = !store.annotationsGloballyHidden),
             store.annotationsGloballyHidden
-              ? "Enable notes"
-              : "Disable notes (annotations stay; preview & export ignore them)",
+              ? "Enable markup"
+              : "Disable markup (it stays; preview & export ignore it)",
           )}
         </div>
         {#if experimentalStore.silenceDetection}
           <!-- Cuts -->
           <div class="mt-1.5 flex min-h-9 items-center justify-between gap-1">
-            {@render railLabel(Scissors, "Cuts", "bg-destructive/15 text-destructive")}
+            {@render railLabel(Scissors, "Silence", "bg-destructive/15 text-destructive")}
             {@render railEye(
               store.cutsEnabled,
               () => (store.cutsEnabled = !store.cutsEnabled),
               store.cutsEnabled
-                ? "Disable cuts (cuts stay; playback & export ignore them)"
-                : "Enable cuts",
+                ? "Disable silence cuts (cuts stay; playback & export ignore them)"
+                : "Enable silence cuts",
             )}
           </div>
         {/if}
@@ -708,6 +770,7 @@
       aria-valuemax={duration}
       aria-valuenow={store.currentTime}
       class="custom-scrollbar relative min-w-0 flex-1 overflow-x-auto overflow-y-hidden"
+      style={razorActive ? "cursor: none" : ""}
       onpointerdown={handleTimelinePointerDown}
       onpointermove={handleTimelinePointerMove}
       onpointerup={handleTimelinePointerUp}
@@ -773,14 +836,54 @@
         {timeMode}
         tall={experimentalStore.silenceDetection}
       />
+
+      <!-- Razor preview: a hairline at the pending click point, and once an anchor
+           is set, the destructive span that the second click will remove. -->
+      {#if razorActive && hover}
+        {@const anchorX =
+          razorAnchor !== null ? xOf(razorAnchor) : xOf(hover.originalSec)}
+        {@const hoverX = xOf(hover.originalSec)}
+        {#if razorAnchor !== null}
+          {@const left = Math.min(anchorX, hoverX)}
+          {@const w = Math.abs(hoverX - anchorX)}
+          <div
+            class="pointer-events-none absolute inset-y-0 z-20 border-x border-destructive/70 bg-destructive/15"
+            style="left: {left}px; width: {w}px; background-image: repeating-linear-gradient(45deg, transparent, transparent 5px, color-mix(in srgb, var(--destructive) 20%, transparent) 5px, color-mix(in srgb, var(--destructive) 20%, transparent) 10px);"
+          >
+            {#if w > 36}
+              <span
+                class="absolute left-1/2 top-1 -translate-x-1/2 whitespace-nowrap rounded bg-destructive px-1 py-0.5 font-mono text-[9px] font-bold text-destructive-foreground shadow-sm"
+              >
+                −{Math.abs(hover.originalSec - razorAnchor).toFixed(2)}s
+              </span>
+            {/if}
+          </div>
+        {/if}
+        <div
+          class="pointer-events-none absolute inset-y-0 z-20 w-px bg-destructive"
+          style="left: {anchorX}px;"
+        ></div>
+      {/if}
       </div>
     </div>
   </div>
 </div>
 
+<!-- Scissor cursor for the razor tool: the scroller hides its native cursor
+     (cursor:none) and this glyph rides the pointer instead, so the cursor
+     literally reads as a scissor while armed. -->
+{#if razorActive && hover}
+  <div
+    class="pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-1/2 text-destructive drop-shadow-md"
+    style="left: {hover.clientX}px; top: {hover.clientY}px;"
+  >
+    <Scissors class="size-5" />
+  </div>
+{/if}
+
 <!-- Hover-scrub preview: fixed so it floats above the timeline without being
      clipped by the scroller's overflow. Only with the WebCodecs filmstrip. -->
-{#if hover && tileProvider && !isDraggingPlayhead}
+{#if hover && tileProvider && !isDraggingPlayhead && !razorActive}
   <div
     class="pointer-events-none fixed z-50 flex -translate-x-1/2 -translate-y-full flex-col items-center gap-1"
     style="left: {hover.clientX}px; top: {hover.top - 8}px;"
@@ -817,12 +920,18 @@
   }
 
   .custom-scrollbar::-webkit-scrollbar-thumb {
-    background: rgba(120, 120, 128, 0.35);
+    background: color-mix(in srgb, var(--color-foreground) 14%, transparent);
     border-radius: 999px;
+    transition: background 0.2s cubic-bezier(0.625, 0.05, 0, 1);
+  }
+
+  .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in srgb, var(--color-foreground) 24%, transparent);
   }
 
   .custom-scrollbar {
     scrollbar-width: thin;
-    scrollbar-color: rgba(120, 120, 128, 0.35) transparent;
+    scrollbar-color: color-mix(in srgb, var(--color-foreground) 14%, transparent)
+      transparent;
   }
 </style>

--- a/apps/desktop/src/components/editor/Timeline.svelte
+++ b/apps/desktop/src/components/editor/Timeline.svelte
@@ -23,6 +23,8 @@
     type TimeMode,
   } from "./_components/timeline/timeline-helpers";
   import { originalToOutput, outputToOriginal } from "$lib/timeline/time-map";
+  import { buildSnapTargets, snapTime } from "./_components/timeline/timeline-snap";
+  import { storyboardCrop } from "$lib/timeline/storyboard";
   import type { TileProvider } from "$lib/timeline/filmstrip-source";
 
   // Orchestrator: owns the scroll container, sizing, transport (JKL/speed),
@@ -47,15 +49,63 @@
   let timelineWidth = $state(900);
   // Horizontal scroll offset, tracked so the clip bar can virtualize its tiles.
   let scrollLeft = $state(0);
-  // Left padding (px-2) between the scroller and the lane content the clip bar
-  // positions against — subtracted so the viewport lands in clip-bar coords.
-  const LANE_PAD = 8;
+  // Lane content shares the scroller's x-origin (no left padding), so the clip
+  // bar's viewport math needs no offset.
+  const LANE_PAD = 0;
 
   const SPEEDS = [0.25, 0.5, 1.0, 1.5, 2.0] as const;
   let playbackSpeed = $state(1.0);
 
   // Lives in the orchestrator so one click flips every timeline label at once.
   let timeMode = $state<TimeMode>("smpte");
+
+  // Layer visibility (the toolbar's Layers menu). The clip track is always shown
+  // (the editing spine); its content is thumbnails OR the waveform — never both,
+  // so they can't overlap. Zoom/Markup lanes show/hide independently. Persisted
+  // to localStorage so the choice survives reopening the editor.
+  type ClipContent = "thumbnails" | "waveform";
+  const VIEW_KEY = "recast.timeline.view";
+  function loadView(): {
+    clipContent: ClipContent;
+    zoom: boolean;
+    markup: boolean;
+  } {
+    if (typeof localStorage !== "undefined") {
+      try {
+        const raw = localStorage.getItem(VIEW_KEY);
+        if (raw) {
+          const v = JSON.parse(raw);
+          return {
+            clipContent: v.clipContent === "waveform" ? "waveform" : "thumbnails",
+            zoom: v.zoom !== false,
+            markup: v.markup !== false,
+          };
+        }
+      } catch {
+        /* fall through to defaults */
+      }
+    }
+    return { clipContent: "thumbnails", zoom: true, markup: true };
+  }
+  const _view = loadView();
+  let clipContent = $state<ClipContent>(_view.clipContent);
+  let showZoomLane = $state(_view.zoom);
+  let showMarkupLane = $state(_view.markup);
+  $effect(() => {
+    if (typeof localStorage === "undefined") return;
+    try {
+      localStorage.setItem(
+        VIEW_KEY,
+        JSON.stringify({
+          clipContent,
+          zoom: showZoomLane,
+          markup: showMarkupLane,
+        }),
+      );
+    } catch {
+      /* storage full / unavailable — view prefs are best-effort */
+    }
+  });
 
   // JKL transport (Avid/Premiere): consecutive L/J cycles 1×→2×→4×, K parks.
   // J drives reverse via a rAF loop (browsers don't reliably support negative playbackRate).
@@ -103,6 +153,21 @@
     } else if (shuttleDirection !== -1 && reverseFrame !== 0) {
       cancelAnimationFrame(reverseFrame);
       reverseFrame = 0;
+    }
+  });
+
+  // Auto-follow: while playing, keep the playhead in view. Only acts once the
+  // playhead crosses the leading/trailing margin, so manual scrolling mid-play
+  // is left alone until it actually runs off-screen; then we page it back near
+  // the left margin. No-op when everything already fits (scrollLeft stays 0).
+  $effect(() => {
+    if (!store.isPlaying || isDraggingPlayhead || !timelineEl) return;
+    const px = xOf(store.currentTime);
+    const view = timelineEl.clientWidth;
+    const left = timelineEl.scrollLeft;
+    const margin = Math.min(view * 0.12, 120);
+    if (px < left + margin || px > left + view - margin) {
+      timelineEl.scrollLeft = Math.max(0, px - margin);
     }
   });
 
@@ -244,6 +309,8 @@
   }
 
   function handleTimelinePointerDown(event: PointerEvent) {
+    // Right/middle button is for the context menu — never seek/razor on it.
+    if (event.button !== 0) return;
     // Razor mode owns the click: place an anchor / carve a cut, never seek/drag.
     if (razorActive) {
       event.preventDefault();
@@ -278,13 +345,40 @@
     razorAnchor = null;
   }
 
-  // Original time under the pointer, clamped + frame-quantized — the razor's
-  // click resolution (so a cut lands on the same frame preview and export use).
+  // Any other edit action exits the Cut tool, so the armed state always reflects
+  // the last action (clicking Split while Cut is armed switches to Split).
+  function disarmRazor() {
+    razorActive = false;
+    razorAnchor = null;
+  }
+
+  function splitAtPlayhead() {
+    disarmRazor();
+    store.splitAt(store.currentTime);
+  }
+
+  // Snap a razor point to the playhead, clip in/out, and zoom/markup region
+  // edges (falls through to the frame grid otherwise) so cuts land precisely.
+  function razorSnap(rawOriginal: number): number {
+    const targets = buildSnapTargets({
+      playhead: store.currentTime,
+      inPoint: store.inPoint,
+      outPoint: store.outPoint,
+      duration,
+      regions: store.zoomRegions,
+      annotations: store.annotations,
+    });
+    const tolerance = pixelsPerSecond > 0 ? 6 / pixelsPerSecond : 0;
+    return snapTime(rawOriginal, targets, tolerance, effectiveFps()).time;
+  }
+
+  // Original time under the pointer, clamped then snapped — the razor's click
+  // resolution (so a cut lands on the same frame preview and export use).
   function clientXToOriginal(clientX: number): number {
     if (!timelineEl) return 0;
     const rect = timelineEl.getBoundingClientRect();
     const x = clientX - rect.left + timelineEl.scrollLeft;
-    return quantizeToFrame(Math.max(0, Math.min(duration, tOf(x))));
+    return razorSnap(Math.max(0, Math.min(duration, tOf(x))));
   }
 
   function razorClickAt(clientX: number) {
@@ -309,10 +403,30 @@
     outputSec: number;
     originalSec: number;
   } | null>(null);
-  const hoverUrl = $derived.by(() => {
+  // Preferred hover image: a cell from the storyboard sprite (one decode for the
+  // whole clip, then every position is an instant CSS crop). The first read also
+  // kicks off the build. `previewAt` (per-position decode) is only the fallback
+  // shown for the brief moment before the sprite is ready.
+  const HOVER_PREVIEW_H = 64;
+  const hoverCell = $derived.by(() => {
     void filmstripVersion;
     if (!hover || !tileProvider) return undefined;
+    const sb = tileProvider.storyboard();
+    if (!sb || sb.count <= 0 || sb.durationSec <= 0 || sb.cellH <= 0) {
+      return undefined;
+    }
+    return { url: sb.url, ...storyboardCrop(sb, hover.originalSec, HOVER_PREVIEW_H) };
+  });
+  const hoverUrl = $derived.by(() => {
+    void filmstripVersion;
+    if (!hover || !tileProvider || hoverCell) return undefined;
     return tileProvider.previewAt(hover.originalSec);
+  });
+
+  // Snapped end of the live razor span (for the preview band) while armed.
+  const razorHoverTime = $derived.by(() => {
+    if (!razorActive || !hover) return null;
+    return razorSnap(Math.max(0, Math.min(duration, hover.originalSec)));
   });
 
   function updateHover(clientX: number, clientY = 0) {
@@ -435,12 +549,13 @@
     // Split the clip at the playhead (NLE razor — "S").
     if (event.key === "s" || event.key === "S") {
       event.preventDefault();
-      store.splitAt(store.currentTime);
+      splitAtPlayhead();
     }
 
     // Ripple-delete the selected clip (or the one under the playhead); store returns the join to land on a kept frame.
     if (event.key === "Delete" || event.key === "Backspace") {
       event.preventDefault();
+      disarmRazor();
       const target = store.selectedClipStart ?? store.currentTime;
       const joinAt = store.deleteSegmentAt(target);
       if (joinAt !== null) {
@@ -539,6 +654,7 @@
 
   function addFocusRegion() {
     if (duration <= 0) return;
+    disarmRazor();
     const start = Math.max(store.inPoint, store.currentTime - 0.35);
     const end = Math.min(
       store.outPoint,
@@ -549,6 +665,7 @@
 
   function setTrimPoint(kind: "in" | "out") {
     if (duration <= 0) return;
+    disarmRazor();
     store.pushUndoState();
     const min = minClipDuration();
     if (kind === "in") {
@@ -640,6 +757,7 @@
   }
 
   function resetTrim() {
+    disarmRazor();
     store.pushUndoState();
     store.trimStart = 0;
     store.trimEnd = duration;
@@ -654,12 +772,13 @@
   });
 </script>
 
-<!-- Track-header chip for the fixed left rail. -->
+<!-- Track-header chip for the fixed left rail: a square, icon stacked over the
+     label, so the rail stays narrow and every row header reads the same. -->
 {#snippet railLabel(Icon: typeof Film, label: string, chipClass: string)}
   <span
-    class="inline-flex items-center gap-1 rounded-sm px-1.5 py-px font-mono text-[8px] font-bold uppercase tracking-wider {chipClass}"
+    class="inline-flex min-h-9 min-w-9 flex-col items-center justify-center gap-0.5 rounded-md px-1 py-1 font-mono text-[7px] font-bold uppercase leading-none tracking-wide {chipClass}"
   >
-    <Icon class="size-2" />
+    <Icon class="size-3.5" />
     {label}
   </span>
 {/snippet}
@@ -695,8 +814,11 @@
     {timeMode}
     hasSelectedRegion={!!store.selectedZoomRegionId}
     {razorActive}
+    clipContent={clipContent}
+    {showZoomLane}
+    {showMarkupLane}
     onSetTrim={setTrimPoint}
-    onSplit={() => store.splitAt(store.currentTime)}
+    onSplit={splitAtPlayhead}
     onToggleRazor={toggleRazor}
     onAddFocusRegion={addFocusRegion}
     onResetTrim={resetTrim}
@@ -705,6 +827,9 @@
     onSetTimeMode={(mode) => (timeMode = mode)}
     onZoomToFit={zoomToFit}
     onZoomToSelection={zoomToSelection}
+    onSetClipContent={(c) => (clipContent = c)}
+    onToggleZoomLane={() => (showZoomLane = !showZoomLane)}
+    onToggleMarkupLane={() => (showMarkupLane = !showMarkupLane)}
   />
 
   <!-- Rail lives OUTSIDE the scroller so lane names never overlap a card at t≈0.
@@ -713,38 +838,25 @@
     class="relative flex overflow-hidden rounded-xl border border-border/60 bg-background/60 shadow-(--shadow-craft-inset)"
   >
     <div
-      class="relative z-10 flex w-20 shrink-0 flex-col border-r border-border/60 bg-card/50"
+      class="relative z-10 flex w-16 shrink-0 flex-col border-r border-border/60 bg-card/50"
     >
       <!-- Aligns with the ruler -->
       <div class="h-7 border-b border-border/60"></div>
-      <div class="px-1.5 pb-2 pt-1.5">
-        <!-- Clip (no toggle) -->
-        <div class="flex h-12 items-center">
+      <div class="px-1 pb-2 pt-1.5">
+        <!-- Headers are centered squares; enable/disable lives in the Layers menu. -->
+        <div class="flex h-12 items-center justify-center">
           {@render railLabel(Film, "Clip", "bg-foreground/10 text-foreground/80")}
         </div>
-        <!-- Focus -->
-        <div class="mt-1.5 flex min-h-9 items-center justify-between gap-1">
-          {@render railLabel(Target, "Zoom", "bg-primary/15 text-primary")}
-          {@render railEye(
-            store.focusEnabled,
-            () => (store.focusEnabled = !store.focusEnabled),
-            store.focusEnabled
-              ? "Disable zoom (regions stay; preview & export ignore them)"
-              : "Enable zoom",
-          )}
-        </div>
-        <!-- Notes -->
-        <div class="mt-1.5 flex min-h-9 items-center justify-between gap-1">
-          {@render railLabel(Pencil, "Markup", "bg-warning/15 text-warning")}
-          {@render railEye(
-            !store.annotationsGloballyHidden,
-            () =>
-              (store.annotationsGloballyHidden = !store.annotationsGloballyHidden),
-            store.annotationsGloballyHidden
-              ? "Enable markup"
-              : "Disable markup (it stays; preview & export ignore it)",
-          )}
-        </div>
+        {#if showZoomLane}
+          <div class="mt-1.5 flex min-h-9 items-center justify-center">
+            {@render railLabel(Target, "Zoom", "bg-primary/15 text-primary")}
+          </div>
+        {/if}
+        {#if showMarkupLane}
+          <div class="mt-1.5 flex min-h-9 items-center justify-center">
+            {@render railLabel(Pencil, "Markup", "bg-warning/15 text-warning")}
+          </div>
+        {/if}
         {#if experimentalStore.silenceDetection}
           <!-- Cuts -->
           <div class="mt-1.5 flex min-h-9 items-center justify-between gap-1">
@@ -780,13 +892,13 @@
       onpointerleave={clearHover}
       onkeydown={handleTimelineKeydown}
     >
-      <div
-        class="relative min-w-full"
-        style="width: {totalWidth}px; height: {experimentalStore.silenceDetection ? 250 : 204}px;"
-      >
+      <div class="relative min-w-full" style="width: {totalWidth}px;">
         <TimelineRuler duration={outputDuration} {pixelsPerSecond} />
 
-      <div class="relative px-2 pb-2 pt-1.5">
+      <!-- No horizontal padding: lanes must share the x-origin of the ruler and
+           playhead (both direct children at x=0), or every tile sits offset from
+           the ticks and the playhead line. -->
+      <div class="relative pb-2 pt-1.5">
         <TimelineClipBar
           {store}
           {videoEl}
@@ -797,6 +909,7 @@
           {clipWidth}
           {thumbnailWidth}
           {timeMode}
+          content={clipContent}
           {clientXToOutput}
           {tileProvider}
           {filmstripVersion}
@@ -804,24 +917,28 @@
           viewportWidthPx={timelineWidth}
         />
 
-        <TimelineZoomLane
-          {store}
-          {pixelsPerSecond}
-          fps={effectiveFps()}
-          {duration}
-          {timeMode}
-          onCopy={copyRegion}
-          onDuplicate={duplicateRegion}
-        />
+        {#if showZoomLane}
+          <TimelineZoomLane
+            {store}
+            {pixelsPerSecond}
+            fps={effectiveFps()}
+            {duration}
+            {timeMode}
+            onCopy={copyRegion}
+            onDuplicate={duplicateRegion}
+          />
+        {/if}
 
-        <TimelineAnnotationLane
-          {store}
-          {pixelsPerSecond}
-          fps={effectiveFps()}
-          {duration}
-          {timeMode}
-          onDuplicate={duplicateAnnotation}
-        />
+        {#if showMarkupLane}
+          <TimelineAnnotationLane
+            {store}
+            {pixelsPerSecond}
+            fps={effectiveFps()}
+            {duration}
+            {timeMode}
+            onDuplicate={duplicateAnnotation}
+          />
+        {/if}
 
         {#if experimentalStore.silenceDetection}
           <TimelineCutLane {store} {pixelsPerSecond} {duration} />
@@ -834,15 +951,14 @@
         fps={effectiveFps()}
         isDragging={isDraggingPlayhead}
         {timeMode}
-        tall={experimentalStore.silenceDetection}
       />
 
       <!-- Razor preview: a hairline at the pending click point, and once an anchor
            is set, the destructive span that the second click will remove. -->
       {#if razorActive && hover}
-        {@const anchorX =
-          razorAnchor !== null ? xOf(razorAnchor) : xOf(hover.originalSec)}
-        {@const hoverX = xOf(hover.originalSec)}
+        {@const endT = razorHoverTime ?? hover.originalSec}
+        {@const anchorX = razorAnchor !== null ? xOf(razorAnchor) : xOf(endT)}
+        {@const hoverX = xOf(endT)}
         {#if razorAnchor !== null}
           {@const left = Math.min(anchorX, hoverX)}
           {@const w = Math.abs(hoverX - anchorX)}
@@ -854,7 +970,7 @@
               <span
                 class="absolute left-1/2 top-1 -translate-x-1/2 whitespace-nowrap rounded bg-destructive px-1 py-0.5 font-mono text-[9px] font-bold text-destructive-foreground shadow-sm"
               >
-                −{Math.abs(hover.originalSec - razorAnchor).toFixed(2)}s
+                −{Math.abs(endT - razorAnchor).toFixed(2)}s
               </span>
             {/if}
           </div>
@@ -891,7 +1007,13 @@
     <div
       class="overflow-hidden rounded-md border border-border/70 bg-card shadow-lg"
     >
-      {#if hoverUrl}
+      {#if hoverCell}
+        <!-- One cell of the storyboard sprite, cropped via background-position. -->
+        <div
+          class="h-16"
+          style="width: {hoverCell.dispW}px; background-image: url('{hoverCell.url}'); background-repeat: no-repeat; background-size: {hoverCell.bgW}px {hoverCell.bgH}px; background-position: -{hoverCell.offX}px -{hoverCell.offY}px;"
+        ></div>
+      {:else if hoverUrl}
         <img
           src={hoverUrl}
           alt=""

--- a/apps/desktop/src/components/editor/VideoPlayerControls.svelte
+++ b/apps/desktop/src/components/editor/VideoPlayerControls.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { EditorStore } from "$lib/stores/editor-store.svelte";
-	import { originalToOutput, outputToOriginal } from "$lib/timeline/cuts";
+	import { originalToOutput, outputToOriginal } from "$lib/timeline/time-map";
 	import {
 	  Camera,
 	  LoaderCircle,
@@ -95,10 +95,10 @@
 
 	// OUTPUT (post-cut) time: readout/scrubber reflect the edited length and can't land
 	// in a removed region. `store.currentTime` stays the source of truth (original time); we map to output only for display + seek.
-	const cuts = $derived(store.effectiveCuts);
+	const timeMap = $derived(store.timeMap);
 	const fullDuration = $derived(store.metadata?.duration ?? 0);
-	const outputDuration = $derived(originalToOutput(cuts, fullDuration));
-	const currentOutput = $derived(originalToOutput(cuts, store.currentTime));
+	const outputDuration = $derived(originalToOutput(timeMap, fullDuration));
+	const currentOutput = $derived(originalToOutput(timeMap, store.currentTime));
 
 	const currentTimeFormatted = $derived(formatTime(currentOutput));
 	const durationFormatted = $derived(formatTime(outputDuration));
@@ -128,7 +128,7 @@
 			0,
 			Math.min(currentOutput + frameDuration * direction, outputDuration),
 		);
-		const orig = outputToOriginal(cuts, nextOut);
+		const orig = outputToOriginal(timeMap, nextOut);
 		if (videoEl) videoEl.currentTime = orig;
 		store.currentTime = orig;
 	}
@@ -137,7 +137,7 @@
 		const target = e.target as HTMLInputElement;
 		// The scrubber is in output time; map back to original time (skipping over
 		// collapsed cuts) before driving the transport.
-		const orig = outputToOriginal(cuts, parseFloat(target.value));
+		const orig = outputToOriginal(timeMap, parseFloat(target.value));
 		if (videoEl) videoEl.currentTime = orig;
 		store.currentTime = orig;
 	}

--- a/apps/desktop/src/components/editor/VideoPreview.svelte
+++ b/apps/desktop/src/components/editor/VideoPreview.svelte
@@ -29,7 +29,7 @@
 	import { buildGradientUniforms } from "./gradient.logic";
 	import { WebCodecsVideoSource } from "$lib/playback/webcodecs-source";
 	import { PlaybackClock } from "$lib/playback/clock";
-	import { originalToOutput, outputToOriginal } from "$lib/timeline/cuts";
+	import { originalToOutput, outputToOriginal } from "$lib/timeline/time-map";
 	import AnnotationOverlay from "./_components/AnnotationOverlay.svelte";
 	import AnnotationStatusRail from "./_components/AnnotationStatusRail.svelte";
 	import CameraOverlay from "./_components/CameraOverlay.svelte";
@@ -983,13 +983,13 @@ void main() {
 			// values WE wrote.)
 			if (Math.abs(store.currentTime - lastPublishedTime) > 0.05) {
 				picClock.seek(
-					originalToOutput(store.effectiveCuts, store.currentTime),
+					originalToOutput(store.timeMap, store.currentTime),
 				);
 				lastPublishedTime = store.currentTime;
 				endHandled = false;
 			}
 			// Playing: the gapless output clock is the master.
-			playbackTime = outputToOriginal(store.effectiveCuts, picClock.time);
+			playbackTime = outputToOriginal(store.timeMap, picClock.time);
 			// Reached the end of the edited timeline → stop cleanly. The clock
 			// clamps at its duration, so without this the picture would freeze on
 			// the last frame while still "playing" (and the decoder would sit idle).
@@ -1106,7 +1106,7 @@ void main() {
 			activeCuts.length > 0
 		) {
 			const lookaheadOrig = outputToOriginal(
-				store.effectiveCuts,
+				store.timeMap,
 				picClock.time + WC_PREFETCH_LOOKAHEAD,
 			);
 			const upcoming = activeCuts.find(
@@ -1592,10 +1592,10 @@ void main() {
 				// the WebCodecs path (which may happen mid-playback, once demux
 				// finishes) doesn't jump.
 				picClock.setDuration(
-					originalToOutput(store.effectiveCuts, store.outPoint),
+					originalToOutput(store.timeMap, store.outPoint),
 				);
 				picClock.seek(
-					originalToOutput(store.effectiveCuts, videoEl?.currentTime ?? 0),
+					originalToOutput(store.timeMap, videoEl?.currentTime ?? 0),
 				);
 				if (store.isPlaying) picClock.play();
 				requestRedraw();
@@ -1665,7 +1665,7 @@ void main() {
 				// Duration = output (post-cut) length of the kept region, so the
 				// clock clamps at the true end of the edited timeline.
 				picClock.setDuration(
-					originalToOutput(store.effectiveCuts, store.outPoint),
+					originalToOutput(store.timeMap, store.outPoint),
 				);
 				// Restart from the top if we'd just finished; otherwise resume from
 				// the current transport position. (Seeding blindly from the <video>
@@ -1673,7 +1673,7 @@ void main() {
 				picClock.seek(
 					wasAtEnd
 						? 0
-						: originalToOutput(store.effectiveCuts, videoEl?.currentTime ?? 0),
+						: originalToOutput(store.timeMap, videoEl?.currentTime ?? 0),
 				);
 				picClock.play();
 				endHandled = false;
@@ -1692,7 +1692,7 @@ void main() {
 		// picture clock to it. During play the clock is the master, so ignore the
 		// `seeked` events our own drift-correction triggers.
 		if (experimentalStore.webcodecsPreview && !store.isPlaying && videoEl) {
-			picClock.seek(originalToOutput(store.effectiveCuts, videoEl.currentTime));
+			picClock.seek(originalToOutput(store.timeMap, videoEl.currentTime));
 		}
 		requestRedraw();
 		onSeeked?.();

--- a/apps/desktop/src/components/editor/_components/timeline/AnnotationLayerCard.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/AnnotationLayerCard.svelte
@@ -21,7 +21,6 @@
   interface Props {
     store: EditorStore;
     annotation: Annotation;
-    index: number;
     pixelsPerSecond: number;
     fps: number;
     duration: number;
@@ -34,7 +33,6 @@
   let {
     store,
     annotation,
-    index,
     pixelsPerSecond,
     fps,
     duration,
@@ -227,7 +225,8 @@
   style="
     left: {left}px;
     width: {width}px;
-    top: {2 + index * 2}px;
+    top: 50%;
+    margin-top: -13px;
     height: 26px;
   "
 >
@@ -240,7 +239,7 @@
       if (e.button !== 0) return;
       beginDrag("move", e);
     }}
-    class="absolute inset-0 overflow-hidden rounded border bg-card/85 text-left backdrop-blur-sm transition-all duration-150 hover:bg-card hover:shadow-craft-sm focus:outline-none focus:ring-1 focus:ring-ring {isSelected
+    class="absolute inset-0 overflow-hidden rounded-md border bg-warning/10 text-left backdrop-blur-sm transition-all duration-150 hover:bg-warning/20 hover:shadow-craft-sm focus:outline-none focus:ring-1 focus:ring-ring {isSelected
       ? 'border-warning/80 cursor-grabbing shadow-[inset_3px_0_0_0_var(--color-warning)] hover:shadow-[inset_3px_0_0_0_var(--color-warning)]'
       : 'border-warning/40 hover:border-warning/70 cursor-grab'} {drag?.mode ===
     'move'
@@ -253,7 +252,7 @@
       aria-label={`${kindLabel(annotation)} annotation from ${formatTimeByMode(annotation.start, timeMode, fps)} to ${formatTimeByMode(annotation.end, timeMode, fps)}. Click to select; drag to move; drag the edges to resize.`}
     >
       <span
-        class="flex size-4 shrink-0 items-center justify-center rounded text-warning"
+        class="flex size-5 shrink-0 items-center justify-center rounded-md bg-warning/20 text-warning"
       >
         <Icon class="size-3" />
       </span>

--- a/apps/desktop/src/components/editor/_components/timeline/AnnotationLayerCard.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/AnnotationLayerCard.svelte
@@ -4,7 +4,7 @@
     Annotation,
     EditorStore,
   } from "$lib/stores/editor-store.svelte";
-  import { originalToOutput, outputToOriginal } from "$lib/timeline/cuts";
+  import { originalToOutput, outputToOriginal } from "$lib/timeline/time-map";
   import { X } from "@lucide/svelte";
   import { cubicOut } from "svelte/easing";
   import { fade, fly } from "svelte/transition";
@@ -62,9 +62,9 @@
   const isSelected = $derived(annotation.id === store.selectedAnnotationId);
   // Output (post-cut) axis — see ZoomLayerCard for the rationale.
   const xOf = (t: number) =>
-    originalToOutput(store.effectiveCuts, t) * pixelsPerSecond;
+    originalToOutput(store.timeMap, t) * pixelsPerSecond;
   const tOf = (xPx: number) =>
-    outputToOriginal(store.effectiveCuts, xPx / pixelsPerSecond);
+    outputToOriginal(store.timeMap, xPx / pixelsPerSecond);
   const left = $derived(xOf(annotation.start));
   // 28px keeps a one-frame annotation grabbable.
   const width = $derived(

--- a/apps/desktop/src/components/editor/_components/timeline/AnnotationLayerCard.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/AnnotationLayerCard.svelte
@@ -241,8 +241,8 @@
       beginDrag("move", e);
     }}
     class="absolute inset-0 overflow-hidden rounded border bg-card/85 text-left backdrop-blur-sm transition-all duration-150 hover:bg-card hover:shadow-craft-sm focus:outline-none focus:ring-1 focus:ring-ring {isSelected
-      ? 'border-amber-500/80 cursor-grabbing shadow-[inset_3px_0_0_0_rgba(245,158,11,0.9)] hover:shadow-[inset_3px_0_0_0_rgba(245,158,11,0.9)]'
-      : 'border-amber-500/40 hover:border-amber-500/70 cursor-grab'} {drag?.mode ===
+      ? 'border-warning/80 cursor-grabbing shadow-[inset_3px_0_0_0_var(--color-warning)] hover:shadow-[inset_3px_0_0_0_var(--color-warning)]'
+      : 'border-warning/40 hover:border-warning/70 cursor-grab'} {drag?.mode ===
     'move'
       ? 'cursor-grabbing shadow-craft-floating'
       : ''}"
@@ -253,7 +253,7 @@
       aria-label={`${kindLabel(annotation)} annotation from ${formatTimeByMode(annotation.start, timeMode, fps)} to ${formatTimeByMode(annotation.end, timeMode, fps)}. Click to select; drag to move; drag the edges to resize.`}
     >
       <span
-        class="flex size-4 shrink-0 items-center justify-center rounded text-amber-600 dark:text-amber-400"
+        class="flex size-4 shrink-0 items-center justify-center rounded text-warning"
       >
         <Icon class="size-3" />
       </span>
@@ -298,7 +298,7 @@
     class="absolute inset-y-0 left-0 z-10 w-2 cursor-ew-resize"
   >
     <div
-      class="mx-auto h-full w-0.5 rounded-l-sm bg-amber-500/70 opacity-0 transition-opacity {isSelected ||
+      class="mx-auto h-full w-0.5 rounded-l-sm bg-warning/70 opacity-0 transition-opacity {isSelected ||
       drag?.mode === 'resize-start'
         ? 'opacity-100!'
         : ''}"
@@ -319,7 +319,7 @@
     class="absolute inset-y-0 right-0 z-10 w-2 cursor-ew-resize"
   >
     <div
-      class="ml-auto h-full w-0.5 rounded-r-sm bg-amber-500/70 opacity-0 transition-opacity {isSelected ||
+      class="ml-auto h-full w-0.5 rounded-r-sm bg-warning/70 opacity-0 transition-opacity {isSelected ||
       drag?.mode === 'resize-end'
         ? 'opacity-100!'
         : ''}"

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineAnnotationLane.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineAnnotationLane.svelte
@@ -56,11 +56,10 @@
       Annotations you draw on the preview appear here as draggable layers
     </div>
   {:else}
-    {#each store.annotations as annotation, index (annotation.id)}
+    {#each store.annotations as annotation (annotation.id)}
       <AnnotationLayerCard
         {store}
         {annotation}
-        {index}
         {pixelsPerSecond}
         {fps}
         {duration}

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineAnnotationLane.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineAnnotationLane.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Annotation, EditorStore } from "$lib/stores/editor-store.svelte";
-  import { originalToOutput } from "$lib/timeline/cuts";
+  import { originalToOutput } from "$lib/timeline/time-map";
   import type { TimeMode } from "./timeline-helpers";
   import { buildSnapTargets, snapLabel, type SnapTarget } from "./timeline-snap";
   import AnnotationLayerCard from "./AnnotationLayerCard.svelte";
@@ -28,7 +28,7 @@
   let activeSnap = $state<SnapTarget | null>(null);
   const snapX = $derived(
     activeSnap
-      ? originalToOutput(store.effectiveCuts, activeSnap.time) * pixelsPerSecond
+      ? originalToOutput(store.timeMap, activeSnap.time) * pixelsPerSecond
       : 0,
   );
 

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineClipBar.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineClipBar.svelte
@@ -7,7 +7,8 @@
   } from "$lib/timeline/filmstrip";
   import type { TileProvider } from "$lib/timeline/filmstrip-source";
   import { deriveSeams } from "$lib/timeline/segments";
-  import { Gauge, Trash2 } from "@lucide/svelte";
+  import { Gauge, RotateCcw, SquareSplitHorizontal, Trash2 } from "@lucide/svelte";
+  import * as ContextMenu from "@recast/ui/context-menu";
   import { fade } from "svelte/transition";
   import {
     formatTimeByMode,
@@ -32,6 +33,8 @@
     clipWidth: number;
     thumbnailWidth: number;
     timeMode: TimeMode;
+    /** What fills the clip bar — thumbnails or the audio waveform, never both. */
+    content: "thumbnails" | "waveform";
     /** Pointer clientX → output seconds (pre-map); trim maps it via a frozen map. */
     clientXToOutput: (clientX: number) => number;
     // Density-based filmstrip. When null, the stretched Rust strip is rendered.
@@ -51,6 +54,7 @@
     clipWidth,
     thumbnailWidth,
     timeMode,
+    content,
     clientXToOutput,
     tileProvider,
     filmstripVersion,
@@ -165,6 +169,42 @@
     store.currentTime = joinAt;
     if (videoEl) videoEl.currentTime = joinAt;
   }
+
+  // Right-click menu: original time the menu was opened at (set on pointerdown,
+  // which fires for the right button before `contextmenu`), so "Split here"
+  // splits exactly where you clicked rather than at the playhead.
+  const SPEED_PRESETS = [0.5, 1, 1.5, 2] as const;
+  let menuTime = $state(0);
+  function rememberMenuTime(clientX: number) {
+    menuTime = outputToOriginal(store.timeMap, clientXToOutput(clientX));
+  }
+
+  // Faint audio envelope over the footage, so you can see where to cut. Built in
+  // output-pixel space (each bucket at `xOf(bucketTime)`) over the kept range
+  // only; buckets inside a removed cut collapse onto the seam like the cut lane.
+  const WAVE_H = 48;
+  const waveformPath = $derived.by(() => {
+    const w = store.waveform;
+    const n = w.length;
+    if (n < 2 || duration <= 0) return "";
+    const mid = WAVE_H / 2;
+    const amp = WAVE_H / 2 - 3;
+    const kept: number[] = [];
+    for (let i = 0; i < n; i++) {
+      const t = (i / n) * duration;
+      if (t < store.inPoint - 0.001 || t > store.outPoint + 0.001) continue;
+      kept.push(i);
+    }
+    if (kept.length < 2) return "";
+    const xAt = (i: number) => xOf((i / n) * duration).toFixed(2);
+    let d = `M ${xAt(kept[0])} ${mid}`;
+    for (const i of kept) d += ` L ${xAt(i)} ${(mid - w[i] * amp).toFixed(2)}`;
+    for (let k = kept.length - 1; k >= 0; k--) {
+      const i = kept[k];
+      d += ` L ${xAt(i)} ${(mid + w[i] * amp).toFixed(2)}`;
+    }
+    return `${d} Z`;
+  });
 
   let activeTrimHandle = $state<"in" | "out" | null>(null);
   // Output-x of the active trim snap target (playhead/region/etc.), or null.
@@ -325,21 +365,30 @@
       store.selectedClipStart !== null &&
       Math.abs(store.selectedClipStart - block.start) < 1e-4}
     {@const speed = store.segmentSpeedAt(block.start)}
-    <!-- Select on POINTERDOWN, not click: the timeline scroller calls
-         setPointerCapture on its own pointerdown, which redirects pointerup and
-         makes the synthesised click land on the scroller (seek) instead of here.
-         We don't stop propagation, so the click still seeks too (select + seek). -->
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      role="button"
-      tabindex="-1"
-      onpointerdown={() => (store.selectedClipStart = block.start)}
-      class="group/clip absolute inset-y-0 cursor-pointer overflow-hidden rounded-md border bg-primary/5 transition-[box-shadow,border-color] {selected
-        ? 'border-primary ring-2 ring-primary/50'
-        : 'border-primary/40 hover:border-primary/70'}"
-      style="left: {block.left}px; width: {block.width}px;"
-    >
-      {#if tileProvider}
+    <ContextMenu.Root>
+      <ContextMenu.Trigger>
+        {#snippet child({ props })}
+          <!-- Select on POINTERDOWN, not click: the timeline scroller calls
+               setPointerCapture on its own pointerdown, which redirects pointerup
+               and makes the synthesised click land on the scroller (seek) instead
+               of here. We don't stop propagation, so the click still seeks too
+               (select + seek). Right-click records the time for "Split here". -->
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div
+            {...props}
+            role="button"
+            tabindex="-1"
+            onpointerdown={(e) => {
+              rememberMenuTime(e.clientX);
+              if (e.button === 0) store.selectedClipStart = block.start;
+            }}
+            class="group/clip absolute inset-y-0 cursor-pointer overflow-hidden rounded-md border bg-primary/5 transition-[box-shadow,border-color] {selected
+              ? 'border-primary ring-2 ring-primary/50'
+              : 'border-primary/40 hover:border-primary/70'}"
+            style="left: {block.left}px; width: {block.width}px;"
+          >
+      {#if content === "thumbnails"}
+        {#if tileProvider}
         {#each tilesByBlock.get(block.key) ?? [] as tile (tile.cacheKey)}
           {@const url = tileUrls.get(tile.cacheKey)}
           <div
@@ -381,6 +430,7 @@
         >
           Generating thumbnails…
         </div>
+        {/if}
       {/if}
 
       <!-- Read-only speed badge (the editable control lives in the Clip panel). -->
@@ -407,8 +457,67 @@
           <Trash2 class="size-2.5" />
         </button>
       {/if}
-    </div>
+          </div>
+        {/snippet}
+      </ContextMenu.Trigger>
+      <ContextMenu.Content size="sm" class="w-48">
+        <ContextMenu.Item onSelect={() => store.splitAt(menuTime)}>
+          <SquareSplitHorizontal />
+          Split here
+        </ContextMenu.Item>
+        <ContextMenu.Sub>
+          <ContextMenu.SubTrigger>
+            <Gauge />
+            Speed
+          </ContextMenu.SubTrigger>
+          <ContextMenu.SubContent>
+            <ContextMenu.RadioGroup
+              value={String(speed)}
+              onValueChange={(v) =>
+                store.setSegmentSpeed(block.start, parseFloat(v))}
+            >
+              {#each SPEED_PRESETS as preset (preset)}
+                <ContextMenu.RadioItem value={String(preset)}>
+                  {formatSpeed(preset)}
+                </ContextMenu.RadioItem>
+              {/each}
+            </ContextMenu.RadioGroup>
+          </ContextMenu.SubContent>
+        </ContextMenu.Sub>
+        <ContextMenu.Item
+          disabled={speed === 1}
+          onSelect={() => store.setSegmentSpeed(block.start, 1)}
+        >
+          <RotateCcw />
+          Reset speed
+        </ContextMenu.Item>
+        {#if clipBlocks.length > 1}
+          <ContextMenu.Separator />
+          <ContextMenu.Item
+            variant="destructive"
+            onSelect={() => deleteSegment(block.start, block.end)}
+          >
+            <Trash2 />
+            Delete clip
+          </ContextMenu.Item>
+        {/if}
+      </ContextMenu.Content>
+    </ContextMenu.Root>
   {/each}
+
+  <!-- Audio waveform fills the clip bar when it's the chosen content (the radio
+       in the Layers menu), so it never overlaps the thumbnails. -->
+  {#if content === "waveform" && waveformPath && clipWidth > 0}
+    <svg
+      class="pointer-events-none absolute inset-y-0 left-0"
+      style="width: {clipWidth}px;"
+      viewBox="0 0 {clipWidth} {WAVE_H}"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <path d={waveformPath} class="fill-primary/45" />
+    </svg>
+  {/if}
 
   <!-- Removed section collapsed to a restorable seam (click to restore). -->
   {#each seamMarkers as seam (seam.gapStart)}

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineClipBar.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineClipBar.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
   import type { EditorStore } from "$lib/stores/editor-store.svelte";
-  import { originalToOutput } from "$lib/timeline/cuts";
+  import { originalToOutput, outputToOriginal } from "$lib/timeline/time-map";
+  import {
+    type FilmstripTile,
+    planFilmstrip,
+  } from "$lib/timeline/filmstrip";
+  import type { TileProvider } from "$lib/timeline/filmstrip-source";
   import { deriveSeams } from "$lib/timeline/segments";
-  import { Trash2 } from "@lucide/svelte";
+  import { Gauge, Trash2 } from "@lucide/svelte";
   import { fade } from "svelte/transition";
   import {
     formatTimeByMode,
@@ -12,9 +17,10 @@
     quantizeToFrame,
     type TimeMode,
   } from "./timeline-helpers";
+  import { buildSnapTargets, snapTime } from "./timeline-snap";
 
   // Clip bar with thumbnails and in/out trim handles. Owns its drag state;
-  // the parent only supplies `clientXToTime` (handles scroll offset) to resolve pointer X.
+  // the parent only supplies `clientXToOutput` (handles scroll offset) to resolve pointer X.
 
   interface Props {
     store: EditorStore;
@@ -26,7 +32,13 @@
     clipWidth: number;
     thumbnailWidth: number;
     timeMode: TimeMode;
-    clientXToTime: (clientX: number) => number;
+    /** Pointer clientX → output seconds (pre-map); trim maps it via a frozen map. */
+    clientXToOutput: (clientX: number) => number;
+    // Density-based filmstrip. When null, the stretched Rust strip is rendered.
+    tileProvider: TileProvider | null;
+    filmstripVersion: number;
+    viewportLeftPx: number;
+    viewportWidthPx: number;
   }
 
   let {
@@ -39,13 +51,25 @@
     clipWidth,
     thumbnailWidth,
     timeMode,
-    clientXToTime,
+    clientXToOutput,
+    tileProvider,
+    filmstripVersion,
+    viewportLeftPx,
+    viewportWidthPx,
   }: Props = $props();
+
+  // Target tile width and the cache-key height namespace; overscan decodes a bit
+  // beyond the viewport so tiles are ready just before they scroll in.
+  const TILE_TARGET_W = 96;
+  const TILE_KEY_HEIGHT = 48;
+  const FILMSTRIP_OVERSCAN = 240;
+
+  const formatSpeed = (s: number) => `${s}×`;
 
   // One block per kept segment on the OUTPUT (post-cut) axis: a cut occupies zero
   // width and later clips slide left to close the gap. `xOf` maps original time onto that axis.
   const pps = $derived(pixelsPerSecond);
-  const xOf = (t: number) => originalToOutput(store.effectiveCuts, t) * pps;
+  const xOf = (t: number) => originalToOutput(store.timeMap, t) * pps;
   // Thumbnail strip is laid across this; each block is internally cut-free, so it shows its slice via a margin offset.
   const clipDuration = $derived(Math.max(0.0001, store.outPoint - store.inPoint));
   const stripFullWidth = $derived(clipDuration * pps);
@@ -66,6 +90,53 @@
       stripOffset: -(seg.start - store.inPoint) * pps,
     })),
   );
+  // Density-based filmstrip tiles, planned per kept block and virtualized to the
+  // viewport. Empty (fallback to the stretched strip) when there's no provider.
+  const filmstripTiles = $derived(
+    tileProvider
+      ? planFilmstrip(
+          clipBlocks.map((b) => ({
+            key: b.key,
+            leftPx: b.left,
+            widthPx: b.width,
+            originalStart: b.start,
+            originalEnd: b.end,
+          })),
+          { leftPx: viewportLeftPx, widthPx: viewportWidthPx },
+          {
+            tileWidthPx: TILE_TARGET_W,
+            tileHeightPx: TILE_KEY_HEIGHT,
+            overscanPx: FILMSTRIP_OVERSCAN,
+          },
+        )
+      : [],
+  );
+  const tilesByBlock = $derived.by(() => {
+    const map = new Map<number, FilmstripTile[]>();
+    for (const tile of filmstripTiles) {
+      const list = map.get(tile.blockKey);
+      if (list) list.push(tile);
+      else map.set(tile.blockKey, [tile]);
+    }
+    return map;
+  });
+  // Tile URLs, re-resolved whenever a freshly decoded tile bumps the version.
+  const tileUrls = $derived.by(() => {
+    void filmstripVersion;
+    const map = new Map<string, string | undefined>();
+    if (tileProvider) {
+      for (const tile of filmstripTiles) {
+        map.set(tile.cacheKey, tileProvider.get(tile));
+      }
+    }
+    return map;
+  });
+  $effect(() => {
+    if (tileProvider && filmstripTiles.length > 0) {
+      tileProvider.request(filmstripTiles);
+    }
+  });
+
   const splitMarkers = $derived(
     store.splitPoints
       .filter((p) => p > store.inPoint && p < store.outPoint)
@@ -96,19 +167,24 @@
   }
 
   let activeTrimHandle = $state<"in" | "out" | null>(null);
+  // Output-x of the active trim snap target (playhead/region/etc.), or null.
+  let trimSnapX = $state<number | null>(null);
 
   // `originalAt` = the handle value at pointer-down, for the frames-delta tooltip.
   let trimDragContext = $state<{
     which: "in" | "out";
     originalAt: number;
   } | null>(null);
-
   function startTrimDrag(event: PointerEvent, which: "in" | "out") {
     if (duration <= 0) return;
     event.preventDefault();
     event.stopPropagation();
     // Single undo entry per drag.
     store.pushUndoState();
+    // Un-collapse the axis for the drag: the clip un-brackets to the full
+    // recording (trimmed head/tail ghosted), the handle follows the cursor, and
+    // dragging outward restores. Reverts to the collapsed view on pointer-up.
+    store.isTrimming = true;
     activeTrimHandle = which;
     trimDragContext = {
       which,
@@ -123,6 +199,8 @@
     const onUp = (e: PointerEvent) => {
       activeTrimHandle = null;
       trimDragContext = null;
+      trimSnapX = null;
+      store.isTrimming = false;
       document.body.style.cursor = "";
       try {
         (event.currentTarget as Element).releasePointerCapture(e.pointerId);
@@ -138,13 +216,38 @@
     window.addEventListener("pointercancel", onUp);
   }
 
+  // Snap the dragged handle to the playhead, clip edges, and region/annotation
+  // boundaries (not its own point); falls through to the frame grid otherwise.
+  function snapTrim(raw: number, which: "in" | "out"): number {
+    const targets = buildSnapTargets({
+      playhead: store.currentTime,
+      inPoint: store.inPoint,
+      outPoint: store.outPoint,
+      duration,
+      regions: store.zoomRegions,
+      annotations: store.annotations,
+    }).filter((target) =>
+      which === "in"
+        ? target.kind !== "in-point"
+        : target.kind !== "out-point",
+    );
+    const tolerance = pps > 0 ? 6 / pps : 0;
+    const result = snapTime(raw, targets, tolerance, fps);
+    // Surface the active snap as a guide line at the target's position.
+    trimSnapX = result.target ? xOf(result.target.time) : null;
+    return result.time;
+  }
+
   function updateTrimFromPointer(
     clientX: number,
     which: "in" | "out",
     scrub = false,
   ) {
-    const raw = clientXToTime(clientX);
-    const t = quantizeToFrame(raw, fps);
+    // Output px → original time. While trimming, store.timeMap is the full
+    // recording axis (stable, not collapsing under the drag), so absolute
+    // mapping tracks the cursor and lets the handle move across the whole source.
+    const raw = outputToOriginal(store.timeMap, clientXToOutput(clientX));
+    const t = snapTrim(raw, which);
     const min = minClipDuration(fps);
     if (which === "in") {
       const next = Math.max(0, Math.min(t, store.outPoint - min));
@@ -196,21 +299,67 @@
 </script>
 
 <div class="relative h-12">
+  <!-- Ghost bands: while trimming, the axis un-collapses to the full recording
+       and the trimmed head/tail show dimmed, so you can see and re-drag them. -->
+  {#if store.isTrimming}
+    {#if clipLeft > 1}
+      <div
+        class="pointer-events-none absolute inset-y-0 left-0 z-8 rounded-l-md border border-border/40 bg-background/60"
+        style="width: {clipLeft}px;"
+      ></div>
+    {/if}
+    <div
+      class="pointer-events-none absolute inset-y-0 right-0 z-8 rounded-r-md border border-border/40 bg-background/60"
+      style="left: {clipLeft + clipWidth}px;"
+    ></div>
+    {#if trimSnapX !== null}
+      <div
+        class="pointer-events-none absolute inset-y-0 z-9 w-px bg-primary"
+        style="left: {trimSnapX}px;"
+      ></div>
+    {/if}
+  {/if}
+
   {#each clipBlocks as block (block.key)}
     {@const selected =
       store.selectedClipStart !== null &&
       Math.abs(store.selectedClipStart - block.start) < 1e-4}
-    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+    {@const speed = store.segmentSpeedAt(block.start)}
+    <!-- Select on POINTERDOWN, not click: the timeline scroller calls
+         setPointerCapture on its own pointerdown, which redirects pointerup and
+         makes the synthesised click land on the scroller (seek) instead of here.
+         We don't stop propagation, so the click still seeks too (select + seek). -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       role="button"
       tabindex="-1"
-      onclick={() => (store.selectedClipStart = block.start)}
+      onpointerdown={() => (store.selectedClipStart = block.start)}
       class="group/clip absolute inset-y-0 cursor-pointer overflow-hidden rounded-md border bg-primary/5 transition-[box-shadow,border-color] {selected
         ? 'border-primary ring-2 ring-primary/50'
         : 'border-primary/40 hover:border-primary/70'}"
       style="left: {block.left}px; width: {block.width}px;"
     >
-      {#if store.thumbnailStrip.length > 0}
+      {#if tileProvider}
+        {#each tilesByBlock.get(block.key) ?? [] as tile (tile.cacheKey)}
+          {@const url = tileUrls.get(tile.cacheKey)}
+          <div
+            class="absolute inset-y-0 overflow-hidden"
+            style="left: {tile.offsetPx}px; width: {tile.widthPx}px;"
+          >
+            {#if url}
+              <img
+                in:fade={{ duration: 120 }}
+                src={url}
+                alt=""
+                class="h-full w-full object-cover"
+                draggable="false"
+              />
+            {:else}
+              <div class="h-full w-full bg-muted/40"></div>
+            {/if}
+          </div>
+        {/each}
+      {:else if store.thumbnailStrip.length > 0}
         <div
           class="flex h-full"
           style="width: {stripFullWidth}px; margin-left: {block.stripOffset}px;"
@@ -231,6 +380,17 @@
           class="flex h-full items-center justify-center text-[10px] text-muted-foreground"
         >
           Generating thumbnails…
+        </div>
+      {/if}
+
+      <!-- Read-only speed badge (the editable control lives in the Clip panel). -->
+      {#if speed !== 1}
+        <div
+          title="Clip speed — edit in the Clip panel"
+          class="pointer-events-none absolute left-1 top-1 z-7 flex h-4 items-center gap-0.5 rounded bg-primary/90 px-1 font-mono text-[9px] font-bold text-primary-foreground"
+        >
+          <Gauge class="size-2.5" />
+          {formatSpeed(speed)}
         </div>
       {/if}
 

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineCutLane.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineCutLane.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
   import type { EditorStore } from "$lib/stores/editor-store.svelte";
-  import {
-    originalToOutput,
-    outputToOriginal,
-    type TimelineCut,
-  } from "$lib/timeline/cuts";
+  import { type TimelineCut } from "$lib/timeline/cuts";
+  import { originalToOutput, outputToOriginal } from "$lib/timeline/time-map";
   import { X } from "@lucide/svelte";
 
   // Hosts cut bands. Drag empty lane space to carve a cut; drag a band's edges or body to adjust it.
@@ -22,10 +19,10 @@
 
   let laneEl = $state<HTMLDivElement | null>(null);
 
-  // Output (post-cut) axis. An applied cut collapses to zero width (rendered as a
-  // seam); an unapplied cut (lane off → not in effectiveCuts) keeps its width as an editable band.
-  const cuts = $derived(store.effectiveCuts);
-  const xOf = (t: number) => originalToOutput(cuts, t) * pixelsPerSecond;
+  // Output axis via the shared display map. An applied cut collapses to zero
+  // width (rendered as a seam); an unapplied cut (lane off → not in the map's
+  // cuts) keeps its width as an editable band.
+  const xOf = (t: number) => originalToOutput(store.timeMap, t) * pixelsPerSecond;
   const axisWidth = $derived(xOf(duration));
 
   type DragMode = "create" | "move" | "resize-l" | "resize-r";
@@ -44,7 +41,7 @@
     if (!laneEl) return 0;
     const x = clientX - laneEl.getBoundingClientRect().left;
     // Pointer is in OUTPUT pixels → output seconds → original time.
-    return Math.min(duration, Math.max(0, outputToOriginal(cuts, x / pixelsPerSecond)));
+    return Math.min(duration, Math.max(0, outputToOriginal(store.timeMap, x / pixelsPerSecond)));
   }
 
   function onLaneDown(e: PointerEvent) {

--- a/apps/desktop/src/components/editor/_components/timeline/TimelinePlayhead.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelinePlayhead.svelte
@@ -11,41 +11,32 @@
     fps: number;
     isDragging: boolean;
     timeMode: TimeMode;
-    /** When false (cut lane hidden), the guide line stops at the annotation lane. */
-    tall?: boolean;
   }
 
-  let {
-    currentTime,
-    leftPx,
-    fps,
-    isDragging,
-    timeMode,
-    tall = true,
-  }: Props = $props();
+  let { currentTime, leftPx, fps, isDragging, timeMode }: Props = $props();
 
   const playheadLeft = $derived(leftPx);
 </script>
 
+<!-- Spans the full track height via inset-y-0 so it tracks however many lanes are
+     shown; the guide line flexes to fill below the head. -->
 <div
-  class="absolute top-0 z-30 transition-[left] ease-out"
+  class="absolute inset-y-0 z-30 transition-[left] ease-out"
   style="left: {playheadLeft}px; transition-duration: {isDragging
     ? '0ms'
     : '90ms'};"
 >
-  <div class="relative -translate-x-1/2">
+  <div class="relative flex h-full flex-col -translate-x-1/2">
     <div
       class="absolute left-1/2 top-1 -translate-x-1/2 rounded border border-border bg-foreground px-1.5 py-0.5 font-mono text-[9px] tabular-nums text-background shadow-craft-sm"
     >
       {formatTimeByMode(currentTime, timeMode, fps)}
     </div>
     <div
-      class="mx-auto mt-6 size-2 rounded-full border border-background bg-primary ring-1 ring-primary/30"
+      class="mx-auto mt-6 size-2 shrink-0 rounded-full border border-background bg-primary ring-1 ring-primary/30"
     ></div>
     <div
-      class="mx-auto w-px bg-primary/70 pointer-events-none"
-      class:h-57={tall}
-      class:h-45={!tall}
+      class="mx-auto w-px flex-1 bg-primary/70 pointer-events-none"
       id="timeline-control"
     ></div>
   </div>

--- a/apps/desktop/src/components/editor/_components/timeline/TimelinePlayhead.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelinePlayhead.svelte
@@ -35,15 +35,15 @@
 >
   <div class="relative -translate-x-1/2">
     <div
-      class="absolute left-1/2 top-1 -translate-x-1/2 rounded border border-border bg-foreground px-1.5 py-0.5 font-mono text-[9px] tabular-nums text-background"
+      class="absolute left-1/2 top-1 -translate-x-1/2 rounded border border-border bg-foreground px-1.5 py-0.5 font-mono text-[9px] tabular-nums text-background shadow-craft-sm"
     >
       {formatTimeByMode(currentTime, timeMode, fps)}
     </div>
     <div
-      class="mx-auto mt-6 size-2 rounded-full border border-background bg-primary"
+      class="mx-auto mt-6 size-2 rounded-full border border-background bg-primary ring-1 ring-primary/30"
     ></div>
     <div
-      class="mx-auto w-px bg-primary/60 pointer-events-none"
+      class="mx-auto w-px bg-primary/70 pointer-events-none"
       class:h-57={tall}
       class:h-45={!tall}
       id="timeline-control"

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineToolbar.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineToolbar.svelte
@@ -4,10 +4,9 @@
   import type { EditorStore } from "$lib/stores/editor-store.svelte";
   import {
     Clock,
-    Gauge,
+    FastForward,
     Keyboard,
     Maximize2,
-    RotateCcw,
     Scissors,
     Search,
     SlidersHorizontal,
@@ -21,14 +20,14 @@
   import * as DropdownMenu from "@recast/ui/dropdown-menu";
   import { Kbd } from "@recast/ui/kbd";
   import * as Popover from "@recast/ui/popover";
-  import { SliderControl } from "@recast/ui/slider-control";
   import { cn } from "@recast/ui/utils";
   import SilenceReviewPopover from "../../SilenceReviewPopover.svelte";
   import ZoomSuggestionsPopover from "../../ZoomSuggestionsPopover.svelte";
   import { formatTimeByMode, type TimeMode } from "./timeline-helpers";
 
-  // Popovers (Suggest, Remove-silence, Speed) must be portalled: the timeline
-  // sits in an `overflow-hidden` slide wrapper that would clip an in-DOM popover.
+  // Three clusters: EDIT (split + trim to playhead) · INSERT (focus/suggest/
+  // silence) · VIEW (zoom + display options). Popovers are portalled — the
+  // timeline lives in an `overflow-hidden` slide wrapper that would clip them.
 
   interface Props {
     store: EditorStore;
@@ -72,7 +71,7 @@
     onZoomToSelection,
   }: Props = $props();
 
-  const trimHint = `Set trim points to exclude parts of the clip from export, or add focus regions to highlight important moments. You can also ask Trace to suggest focus regions based on where you moved the cursor.`;
+  const trimHint = `Set in/out points (I/O) to keep only part of the clip, split at the playhead (S) to cut a section out, or add focus regions to highlight moments. Trace can also suggest focus regions from your cursor activity.`;
 
   let suggestOpen = $state(false);
   let showSilence = $state(false);
@@ -95,20 +94,29 @@
     "flex h-6 items-center gap-1 rounded-md border border-border/40 bg-muted/40 px-2 text-[11px] font-semibold text-muted-foreground transition-colors duration-150 hover:bg-card hover:text-foreground disabled:opacity-40";
 
   const speedLabel = (s: number) => `${s.toFixed(2).replace(/\.?0+$/, "")}×`;
-
-  const SPEED_MIN = 0.25;
-  const SPEED_MAX = 2;
 </script>
 
 <div class="mb-2 flex flex-wrap items-center justify-between gap-2 text-[11px]">
+  <!-- EDIT + INSERT -->
   <div class="flex items-center gap-1">
     <InspectorHint content={trimHint} />
 
+    <!-- Edit: split + trim to playhead -->
     <div class={GROUP}>
       <button
         type="button"
+        onclick={onSplit}
+        title="Split the clip at the playhead (S)"
+        class={SEG}
+      >
+        <SquareSplitHorizontal class="size-3" />
+        <span class="hidden sm:inline">Split</span>
+        <Kbd class="ml-0.5">S</Kbd>
+      </button>
+      <button
+        type="button"
         onclick={() => onSetTrim("in")}
-        title="Cut everything before the playhead (I)"
+        title="Trim the start to the playhead (I)"
         class={SEG}
       >
         <span class="hidden sm:inline">Start here</span>
@@ -118,7 +126,7 @@
       <button
         type="button"
         onclick={() => onSetTrim("out")}
-        title="Cut everything after the playhead (O)"
+        title="Trim the end to the playhead (O)"
         class={SEG}
       >
         <span class="hidden sm:inline">End here</span>
@@ -127,17 +135,19 @@
       </button>
     </div>
 
-    <button
-      type="button"
-      onclick={onSplit}
-      title="Split the clip at the playhead (S)"
-      class={SOLO}
-    >
-      <SquareSplitHorizontal class="size-3" />
-      <span class="hidden sm:inline">Split</span>
-      <Kbd class="ml-0.5">S</Kbd>
-    </button>
+    {#if hasTrim}
+      <button
+        type="button"
+        onclick={onResetTrim}
+        title="Restore the full recording — undo all trims"
+        class={SOLO}
+      >
+        <Scissors class="size-3" />
+        <span class="hidden sm:inline">Use full clip</span>
+      </button>
+    {/if}
 
+    <!-- Insert: focus regions, suggestions, silence removal -->
     <div class={GROUP}>
       <button type="button" onclick={onAddFocusRegion} class={SEG}>
         <Search class="size-3" />
@@ -205,77 +215,19 @@
         </Popover.Content>
       </Popover.Root>
     {/if}
-
-    {#if hasTrim}
-      <button
-        type="button"
-        onclick={onResetTrim}
-        title="Restore the full recording — undo all cuts"
-        class={SOLO}
-      >
-        <Scissors class="size-3" />
-        Use full clip
-      </button>
-    {/if}
-
-    <!-- Inline discoverability for the core clip keys; hidden on narrow rails. -->
-    <span
-      class="ml-1 hidden items-center gap-1 text-[10px] text-muted-foreground xl:inline-flex"
-    >
-      <Kbd>S</Kbd>
-      split
-      <Kbd>⌫</Kbd>
-      remove
-    </span>
   </div>
 
+  <!-- VIEW -->
   <div class="flex items-center gap-1.5 text-muted-foreground">
-    <Popover.Root>
-      <Popover.Trigger>
-        {#snippet child({ props })}
-          <button {...props} type="button" aria-label="Playback speed" class={SOLO}>
-            <Gauge class="size-3" />
-            <span class="font-mono tabular-nums">{speedLabel(playbackSpeed)}</span>
-          </button>
-        {/snippet}
-      </Popover.Trigger>
-      <Popover.Content side="top" align="end" class="w-56">
-        <div class="flex flex-col gap-2.5">
-          <SliderControl
-            label="Playback speed"
-            value={playbackSpeed}
-            min={SPEED_MIN}
-            max={SPEED_MAX}
-            step={0.05}
-            unit="×"
-            formatValue={(v) => speedLabel(v)}
-            onchange={(v) => onSelectSpeed(v)}
-          >
-            {#snippet icon()}
-              <Gauge class="size-3" />
-            {/snippet}
-          </SliderControl>
-          <div class="flex items-center gap-1">
-            {#each speeds as speed (speed)}
-              {@const active = Math.abs(playbackSpeed - speed) < 0.001}
-              <button
-                type="button"
-                onclick={() => onSelectSpeed(speed)}
-                aria-pressed={active}
-                class={cn(
-                  "flex-1 rounded-md border px-1.5 py-1 font-mono text-[10px] font-semibold tabular-nums transition-colors",
-                  active
-                    ? "border-primary/60 bg-primary/10 text-primary"
-                    : "border-border/60 bg-card/40 text-muted-foreground hover:border-border hover:text-foreground",
-                )}
-              >
-                {speedLabel(speed)}
-              </button>
-            {/each}
-          </div>
-        </div>
-      </Popover.Content>
-    </Popover.Root>
+    {#if hasTrim}
+      <span
+        class="inline-flex h-6 items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-2 font-mono text-[10px] font-semibold tabular-nums text-primary"
+        title="Length of the kept clip"
+      >
+        <Scissors class="size-2.5" />
+        {formatTimeByMode(store.clipDuration, timeMode, fps)}
+      </span>
+    {/if}
 
     <div class={GROUP}>
       <button
@@ -322,16 +274,6 @@
       </button>
     </div>
 
-    {#if hasTrim}
-      <span
-        class="inline-flex h-6 items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-2 font-mono text-[10px] font-semibold tabular-nums text-primary"
-        title="Length of the kept clip"
-      >
-        <Scissors class="size-2.5" />
-        {formatTimeByMode(store.clipDuration, timeMode, fps)}
-      </span>
-    {/if}
-
     <DropdownMenu.Root>
       <DropdownMenu.Trigger>
         <button type="button" aria-label="View options" class={SOLO}>
@@ -340,6 +282,25 @@
         </button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content size="sm" align="end" class="w-52">
+        <!-- Preview rate is a VIEWING aid only (not the export) — kept here, away
+             from the per-clip Clip speed in the sidebar, so the two never read alike. -->
+        <DropdownMenu.Label class="flex items-center gap-1.5">
+          <FastForward class="size-3" />
+          Preview rate
+        </DropdownMenu.Label>
+        <DropdownMenu.RadioGroup
+          value={String(playbackSpeed)}
+          onValueChange={(v) => onSelectSpeed(parseFloat(v))}
+        >
+          {#each speeds as speed (speed)}
+            <DropdownMenu.RadioItem value={String(speed)}>
+              {speedLabel(speed)}
+            </DropdownMenu.RadioItem>
+          {/each}
+        </DropdownMenu.RadioGroup>
+
+        <DropdownMenu.Separator />
+
         <DropdownMenu.Label class="flex items-center gap-1.5">
           <Clock class="size-3" />
           Time display

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineToolbar.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineToolbar.svelte
@@ -3,16 +3,22 @@
   import { experimentalStore } from "$lib/stores/experimental.svelte";
   import type { EditorStore } from "$lib/stores/editor-store.svelte";
   import {
+    AudioLines,
     Clock,
     Expand,
     FastForward,
+    ImageIcon,
     Keyboard,
+    Layers,
     Maximize2,
+    Pencil,
+    Redo2,
     Scissors,
     Search,
     SlidersHorizontal,
     SquareSplitHorizontal,
     Target,
+    Undo2,
     VolumeX,
     Wand2,
     ZoomIn,
@@ -41,9 +47,15 @@
     timeMode: TimeMode;
     hasSelectedRegion: boolean;
     razorActive: boolean;
+    clipContent: "thumbnails" | "waveform";
+    showZoomLane: boolean;
+    showMarkupLane: boolean;
     onSetTrim: (kind: "in" | "out") => void;
     onSplit: () => void;
     onToggleRazor: () => void;
+    onSetClipContent: (content: "thumbnails" | "waveform") => void;
+    onToggleZoomLane: () => void;
+    onToggleMarkupLane: () => void;
     onAddFocusRegion: () => void;
     onResetTrim: () => void;
     onZoomTimeline: (dir: number) => void;
@@ -64,9 +76,15 @@
     timeMode,
     hasSelectedRegion,
     razorActive,
+    clipContent,
+    showZoomLane,
+    showMarkupLane,
     onSetTrim,
     onSplit,
     onToggleRazor,
+    onSetClipContent,
+    onToggleZoomLane,
+    onToggleMarkupLane,
     onAddFocusRegion,
     onResetTrim,
     onZoomTimeline,
@@ -105,6 +123,30 @@
   <!-- EDIT + INSERT -->
   <div class="flex items-center gap-1">
     <InspectorHint content={trimHint} />
+
+    <!-- History -->
+    <div class={GROUP}>
+      <button
+        type="button"
+        onclick={() => store.undo()}
+        disabled={!store.canUndo}
+        title="Undo (Ctrl+Z)"
+        aria-label="Undo"
+        class={SEG_ICON}
+      >
+        <Undo2 class="size-3" />
+      </button>
+      <button
+        type="button"
+        onclick={() => store.redo()}
+        disabled={!store.canRedo}
+        title="Redo (Ctrl+Shift+Z)"
+        aria-label="Redo"
+        class={SEG_ICON}
+      >
+        <Redo2 class="size-3" />
+      </button>
+    </div>
 
     <!-- Edit: split + trim to playhead -->
     <div class={GROUP}>
@@ -294,6 +336,74 @@
         <Target class="size-3" />
       </button>
     </div>
+
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger>
+        <button
+          type="button"
+          aria-label="Layers"
+          title="Show or hide timeline layers"
+          class={SOLO}
+        >
+          <Layers class="size-3" />
+          <span class="hidden md:inline">Layers</span>
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content size="sm" align="end" class="w-48">
+        <DropdownMenu.Label>Clip content</DropdownMenu.Label>
+        <DropdownMenu.RadioGroup
+          value={clipContent}
+          onValueChange={(v) =>
+            onSetClipContent(v === "waveform" ? "waveform" : "thumbnails")}
+        >
+          <DropdownMenu.RadioItem value="thumbnails">
+            <ImageIcon class="size-3" />
+            Thumbnails
+          </DropdownMenu.RadioItem>
+          <DropdownMenu.RadioItem value="waveform">
+            <AudioLines class="size-3" />
+            Waveform
+          </DropdownMenu.RadioItem>
+        </DropdownMenu.RadioGroup>
+
+        <DropdownMenu.Separator />
+
+        <DropdownMenu.Label>Show lanes</DropdownMenu.Label>
+        <DropdownMenu.CheckboxItem
+          checked={showZoomLane}
+          onCheckedChange={onToggleZoomLane}
+        >
+          <Target class="size-3" />
+          Zoom
+        </DropdownMenu.CheckboxItem>
+        <DropdownMenu.CheckboxItem
+          checked={showMarkupLane}
+          onCheckedChange={onToggleMarkupLane}
+        >
+          <Pencil class="size-3" />
+          Markup
+        </DropdownMenu.CheckboxItem>
+
+        <DropdownMenu.Separator />
+
+        <DropdownMenu.Label>Apply to video</DropdownMenu.Label>
+        <DropdownMenu.CheckboxItem
+          checked={store.focusEnabled}
+          onCheckedChange={() => (store.focusEnabled = !store.focusEnabled)}
+        >
+          <Target class="size-3" />
+          Zoom effects
+        </DropdownMenu.CheckboxItem>
+        <DropdownMenu.CheckboxItem
+          checked={!store.annotationsGloballyHidden}
+          onCheckedChange={() =>
+            (store.annotationsGloballyHidden = !store.annotationsGloballyHidden)}
+        >
+          <Pencil class="size-3" />
+          Markup
+        </DropdownMenu.CheckboxItem>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
 
     <DropdownMenu.Root>
       <DropdownMenu.Trigger>

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineToolbar.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineToolbar.svelte
@@ -4,6 +4,7 @@
   import type { EditorStore } from "$lib/stores/editor-store.svelte";
   import {
     Clock,
+    Expand,
     FastForward,
     Keyboard,
     Maximize2,
@@ -39,8 +40,10 @@
     speeds: readonly number[];
     timeMode: TimeMode;
     hasSelectedRegion: boolean;
+    razorActive: boolean;
     onSetTrim: (kind: "in" | "out") => void;
     onSplit: () => void;
+    onToggleRazor: () => void;
     onAddFocusRegion: () => void;
     onResetTrim: () => void;
     onZoomTimeline: (dir: number) => void;
@@ -60,8 +63,10 @@
     speeds,
     timeMode,
     hasSelectedRegion,
+    razorActive,
     onSetTrim,
     onSplit,
+    onToggleRazor,
     onAddFocusRegion,
     onResetTrim,
     onZoomTimeline,
@@ -71,7 +76,7 @@
     onZoomToSelection,
   }: Props = $props();
 
-  const trimHint = `Set in/out points (I/O) to keep only part of the clip, split at the playhead (S) to cut a section out, or add focus regions to highlight moments. Trace can also suggest focus regions from your cursor activity.`;
+  const trimHint = `Set in/out points (I/O) to keep only part of the clip, split at the playhead (S) to cut a section out, or add zoom regions to highlight moments. Trace can also suggest zoom regions from your cursor activity.`;
 
   let suggestOpen = $state(false);
   let showSilence = $state(false);
@@ -115,6 +120,17 @@
       </button>
       <button
         type="button"
+        onclick={onToggleRazor}
+        aria-pressed={razorActive}
+        title="Cut tool (C) — click two points on the timeline to remove a section; Esc or click again to exit"
+        class={cn(SEG, razorActive && SEG_ACTIVE)}
+      >
+        <Scissors class="size-3" />
+        <span class="hidden sm:inline">Cut</span>
+        <Kbd class="ml-0.5">C</Kbd>
+      </button>
+      <button
+        type="button"
         onclick={() => onSetTrim("in")}
         title="Trim the start to the playhead (I)"
         class={SEG}
@@ -142,16 +158,21 @@
         title="Restore the full recording — undo all trims"
         class={SOLO}
       >
-        <Scissors class="size-3" />
+        <Expand class="size-3" />
         <span class="hidden sm:inline">Use full clip</span>
       </button>
     {/if}
 
     <!-- Insert: focus regions, suggestions, silence removal -->
     <div class={GROUP}>
-      <button type="button" onclick={onAddFocusRegion} class={SEG}>
+      <button
+        type="button"
+        onclick={onAddFocusRegion}
+        title="Punch in on the moment at the playhead (zoom region)"
+        class={SEG}
+      >
         <Search class="size-3" />
-        Focus
+        Zoom
       </button>
       <Popover.Root open={suggestOpen} onOpenChange={(v) => (suggestOpen = v)}>
         <Popover.Trigger>

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineZoomLane.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineZoomLane.svelte
@@ -58,7 +58,7 @@
     <div
       class="flex h-6 items-center justify-center text-[10px] text-muted-foreground"
     >
-      Add a focus region to punch in during playback
+      Add a zoom region to punch in during playback
     </div>
   {:else}
     {#each store.zoomRegions as region, index (region.id)}

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineZoomLane.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineZoomLane.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { EditorStore } from "$lib/stores/editor-store.svelte";
-  import { originalToOutput } from "$lib/timeline/cuts";
+  import { originalToOutput } from "$lib/timeline/time-map";
   import type { TimeMode } from "./timeline-helpers";
   import { buildSnapTargets, snapLabel, type SnapTarget } from "./timeline-snap";
   import ZoomLayerCard from "./ZoomLayerCard.svelte";
@@ -33,7 +33,7 @@
   // Snap targets are original times; place the guide on the output axis.
   const snapX = $derived(
     activeSnap
-      ? originalToOutput(store.effectiveCuts, activeSnap.time) * pixelsPerSecond
+      ? originalToOutput(store.timeMap, activeSnap.time) * pixelsPerSecond
       : 0,
   );
 

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineZoomLane.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineZoomLane.svelte
@@ -61,11 +61,10 @@
       Add a zoom region to punch in during playback
     </div>
   {:else}
-    {#each store.zoomRegions as region, index (region.id)}
+    {#each store.zoomRegions as region (region.id)}
       <ZoomLayerCard
         {store}
         {region}
-        {index}
         {pixelsPerSecond}
         {fps}
         {duration}

--- a/apps/desktop/src/components/editor/_components/timeline/ZoomLayerCard.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/ZoomLayerCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { EditorStore, ZoomRegion } from "$lib/stores/editor-store.svelte";
-  import { originalToOutput, outputToOriginal } from "$lib/timeline/cuts";
+  import { originalToOutput, outputToOriginal } from "$lib/timeline/time-map";
   import { X } from "@lucide/svelte";
   import { cubicOut } from "svelte/easing";
   import { fade, fly } from "svelte/transition";
@@ -76,9 +76,9 @@
   // Output (post-cut) axis so regions sit on the same gapless line as clips;
   // a region overlapping a cut renders narrower (correct NLE behaviour).
   const xOf = (t: number) =>
-    originalToOutput(store.effectiveCuts, t) * pixelsPerSecond;
+    originalToOutput(store.timeMap, t) * pixelsPerSecond;
   const tOf = (xPx: number) =>
-    outputToOriginal(store.effectiveCuts, xPx / pixelsPerSecond);
+    outputToOriginal(store.timeMap, xPx / pixelsPerSecond);
   const left = $derived(xOf(region.start));
   // 32px floor keeps even sub-frame regions clickable.
   const width = $derived(Math.max(xOf(region.end) - xOf(region.start), 32));

--- a/apps/desktop/src/components/editor/_components/timeline/ZoomLayerCard.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/ZoomLayerCard.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import type { EditorStore, ZoomRegion } from "$lib/stores/editor-store.svelte";
   import { originalToOutput, outputToOriginal } from "$lib/timeline/time-map";
-  import { X } from "@lucide/svelte";
+  import { Search, X } from "@lucide/svelte";
   import { cubicOut } from "svelte/easing";
   import { fade, fly } from "svelte/transition";
   import {
     formatTimeByMode,
     frameStep,
-    zoomSparklinePath,
     type TimeMode,
   } from "./timeline-helpers";
   import { snapTime, type SnapResult, type SnapTarget } from "./timeline-snap";
@@ -19,7 +18,6 @@
   interface Props {
     store: EditorStore;
     region: ZoomRegion;
-    index: number;
     pixelsPerSecond: number;
     fps: number;
     duration: number;
@@ -33,7 +31,6 @@
   let {
     store,
     region,
-    index,
     pixelsPerSecond,
     fps,
     duration,
@@ -43,17 +40,6 @@
     onCopy,
     onDuplicate,
   }: Props = $props();
-
-  // Reuse the clip bar's thumbnail strip (already loaded) for the frame nearest this region's start.
-  const cardThumb = $derived.by(() => {
-    const strip = store.thumbnailStrip;
-    if (!strip.length || duration <= 0) return null;
-    const idx = Math.min(
-      strip.length - 1,
-      Math.max(0, Math.floor((region.start / duration) * strip.length)),
-    );
-    return strip[idx] ?? null;
-  });
 
   // Floor so a card can't collapse to zero width (0.1s ≈ 6 frames at 60fps).
   const MIN_DURATION = 0.1;
@@ -82,8 +68,7 @@
   const left = $derived(xOf(region.start));
   // 32px floor keeps even sub-frame regions clickable.
   const width = $derived(Math.max(xOf(region.end) - xOf(region.start), 32));
-  const showThumb = $derived(width >= 110);
-  const showSubtitle = $derived(width >= 130);
+  const showSubtitle = $derived(width >= 110);
 
   function beginDrag(mode: DragMode, event: PointerEvent) {
     if (duration <= 0) return;
@@ -254,7 +239,8 @@
   style="
     left: {left}px;
     width: {width}px;
-    top: {2 + index * 2}px;
+    top: 50%;
+    margin-top: -15px;
     height: 30px;
   "
 >
@@ -271,44 +257,30 @@
       if (e.button !== 0) return;
       beginDrag("move", e);
     }}
-    class="absolute inset-0 overflow-hidden rounded border bg-card/85 text-left backdrop-blur-sm transition-all duration-150 hover:bg-card hover:shadow-craft-sm focus:outline-none focus:ring-1 focus:ring-ring {isSelected
+    class="absolute inset-0 overflow-hidden rounded-md border bg-primary/10 text-left backdrop-blur-sm transition-all duration-150 hover:bg-primary/20 hover:shadow-craft-sm focus:outline-none focus:ring-1 focus:ring-ring {isSelected
       ? 'border-primary cursor-grabbing shadow-[inset_3px_0_0_0_var(--color-primary)] hover:shadow-[inset_3px_0_0_0_var(--color-primary)]'
-      : 'border-border hover:border-primary/50 cursor-grab'} {drag?.mode === 'move'
+      : 'border-primary/30 hover:border-primary/60 cursor-grab'} {drag?.mode === 'move'
       ? 'cursor-grabbing shadow-craft-floating'
       : ''}"
   >
-    <svg
-      viewBox="0 0 100 18"
-      preserveAspectRatio="none"
-      class="pointer-events-none absolute inset-x-0 bottom-0 h-3 w-full text-primary/60"
-    >
-      <path
-        d={zoomSparklinePath(region)}
-        stroke="currentColor"
-        stroke-width="1.2"
-        fill="none"
-      />
-    </svg>
     <div
       class="relative flex h-full items-center gap-1.5 px-1.5"
       id={`zoom-region-${region.id}`}
       aria-label={`Focus region from ${formatTimeByMode(region.start, timeMode, fps)} to ${formatTimeByMode(region.end, timeMode, fps)}, scale ${region.scale.toFixed(1)}x. Click to select; drag to move; drag the edges to resize.`}
     >
-      {#if showThumb && cardThumb}
-        <img
-          src={cardThumb}
-          alt=""
-          aria-hidden="true"
-          draggable="false"
-          class="pointer-events-none h-6 w-9 shrink-0 rounded-sm border border-border/50 object-cover"
-        />
-      {/if}
+      <span
+        class="flex size-5 shrink-0 items-center justify-center rounded-md bg-primary/20 text-primary"
+      >
+        <Search class="size-3" />
+      </span>
       <div class="min-w-0 flex-1 pointer-events-none">
         <p class="truncate text-[10px] font-semibold leading-tight text-foreground">
-          {region.scale.toFixed(1)}× Focus
+          Zoom <span class="text-primary">{region.scale.toFixed(1)}×</span>
         </p>
         {#if showSubtitle}
-          <p class="truncate text-[9px] leading-tight text-muted-foreground">
+          <p
+            class="truncate text-[9px] leading-tight tabular-nums text-muted-foreground"
+          >
             {formatTimeByMode(region.start, timeMode, fps)}
           </p>
         {/if}

--- a/apps/desktop/src/components/editor/_components/timeline/timeline-helpers.ts
+++ b/apps/desktop/src/components/editor/_components/timeline/timeline-helpers.ts
@@ -1,6 +1,3 @@
-import type { Easing } from "$lib/easing/cubic-bezier";
-import type { ZoomRegion } from "$lib/stores/editor-store.svelte";
-
 // Pure helpers extracted from Timeline.svelte so subviews share them and they stay unit-testable.
 
 export function effectiveFps(metadataFps: number | undefined): number {
@@ -79,47 +76,6 @@ export function greatestCommonDivisor(a: number, b: number): number {
 		right = next;
 	}
 	return left || 1;
-}
-
-// Polynomial-in-t approximation; indistinguishable from the real Newton-Raphson solve at sparkline resolution.
-export function approxEaseY(easing: Easing, x: number): number {
-	const a = 1 - 3 * easing.y2 + 3 * easing.y1;
-	const b = 3 * easing.y2 - 6 * easing.y1;
-	const c = 3 * easing.y1;
-	return ((a * x + b) * x + c) * x;
-}
-
-// SVG path (100×18 viewBox) of the region's scale curve, normalised so peak scale hits the top.
-export function zoomSparklinePath(r: ZoomRegion): string {
-	const duration = Math.max(0.001, r.end - r.start);
-	const half = duration * 0.5;
-	const rampIn = Math.min(Math.max(0, r.rampIn), half);
-	const rampOut = Math.min(Math.max(0, r.rampOut), half);
-	const holdStart = rampIn;
-	const holdEnd = duration - rampOut;
-	const peak = Math.max(r.scale, 1.0);
-	const norm = (s: number) => (peak === 1 ? 0 : (s - 1) / (peak - 1));
-	const W = 100;
-	const H = 18;
-	const pts: string[] = [];
-	const N = 48;
-	for (let i = 0; i <= N; i++) {
-		const t = (i / N) * duration;
-		let s = 1.0;
-		if (t < holdStart) {
-			const phase = rampIn > 0 ? t / rampIn : 1;
-			s = 1 + (r.scale - 1) * approxEaseY(r.easeIn, phase);
-		} else if (t > holdEnd) {
-			const phase = rampOut > 0 ? (duration - t) / rampOut : 1;
-			s = 1 + (r.scale - 1) * approxEaseY(r.easeOut, phase);
-		} else {
-			s = r.scale;
-		}
-		const x = (t / duration) * W;
-		const y = H - norm(s) * (H - 2) - 1;
-		pts.push(`${i === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)}`);
-	}
-	return pts.join(" ");
 }
 
 export interface TimeMarker {

--- a/apps/desktop/src/components/editor/_components/timeline/timeline-snap.test.ts
+++ b/apps/desktop/src/components/editor/_components/timeline/timeline-snap.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { buildSnapTargets, snapTime, type SnapTarget } from "./timeline-snap";
+
+const fps = 30;
+
+describe("snapTime", () => {
+	const targets: SnapTarget[] = [
+		{ time: 5, kind: "playhead" },
+		{ time: 10, kind: "region-start" },
+	];
+
+	it("snaps to a target inside the tolerance", () => {
+		const r = snapTime(5.05, targets, 0.1, fps);
+		expect(r.time).toBe(5);
+		expect(r.target?.kind).toBe("playhead");
+	});
+
+	it("picks the nearest target when several are in range", () => {
+		const r = snapTime(9.6, targets, 1, fps);
+		expect(r.time).toBe(10);
+		expect(r.target?.kind).toBe("region-start");
+	});
+
+	it("falls through to the frame grid when nothing is in range", () => {
+		const r = snapTime(7.013, targets, 0.05, fps);
+		expect(r.target).toBeNull();
+		// quantised to the nearest 1/30s frame
+		expect(r.time).toBeCloseTo(Math.round(7.013 * fps) / fps, 6);
+	});
+
+	it("treats a target exactly at the tolerance edge as in range", () => {
+		const r = snapTime(5.1, targets, 0.1, fps);
+		expect(r.target?.kind).toBe("playhead");
+		expect(r.time).toBe(5);
+	});
+
+	it("returns the frame-quantised candidate with no targets", () => {
+		const r = snapTime(3.337, [], 0.1, fps);
+		expect(r.target).toBeNull();
+		expect(r.time).toBeCloseTo(Math.round(3.337 * fps) / fps, 6);
+	});
+});
+
+describe("buildSnapTargets", () => {
+	const base = {
+		playhead: 4,
+		inPoint: 1,
+		outPoint: 9,
+		duration: 12,
+		regions: [{ id: "r1", start: 2, end: 6 }],
+		annotations: [{ id: "a1", start: 3, end: 5 }],
+	};
+
+	it("always includes playhead, in/out, origin and duration", () => {
+		const kinds = buildSnapTargets({ ...base, regions: [], annotations: [] }).map(
+			(t) => t.kind,
+		);
+		expect(kinds).toEqual([
+			"playhead",
+			"in-point",
+			"out-point",
+			"origin",
+			"duration",
+		]);
+	});
+
+	it("adds both edges of every region and annotation", () => {
+		const targets = buildSnapTargets(base);
+		expect(targets).toContainEqual({ time: 2, kind: "region-start" });
+		expect(targets).toContainEqual({ time: 6, kind: "region-end" });
+		expect(targets).toContainEqual({ time: 3, kind: "annotation-start" });
+		expect(targets).toContainEqual({ time: 5, kind: "annotation-end" });
+	});
+
+	it("excludes the dragged region's own edges", () => {
+		const targets = buildSnapTargets({ ...base, excludeRegionId: "r1" });
+		expect(targets.some((t) => t.kind === "region-start")).toBe(false);
+		expect(targets.some((t) => t.kind === "region-end")).toBe(false);
+		// annotation edges remain
+		expect(targets.some((t) => t.kind === "annotation-start")).toBe(true);
+	});
+
+	it("excludes the dragged annotation's own edges", () => {
+		const targets = buildSnapTargets({ ...base, excludeAnnotationId: "a1" });
+		expect(targets.some((t) => t.kind.startsWith("annotation"))).toBe(false);
+		expect(targets.some((t) => t.kind === "region-start")).toBe(true);
+	});
+});

--- a/apps/desktop/src/components/editor/properity-panel/ClipPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/ClipPanel.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import { clockCentis } from "$lib/format/time";
+  import type { EditorStore } from "$lib/stores/editor-store.svelte";
+  import {
+    MAX_SEGMENT_SPEED,
+    MIN_SEGMENT_SPEED,
+  } from "$lib/timeline/segment-speed";
+  import { Gauge, RotateCcw, SquareSplitHorizontal, Trash2 } from "@lucide/svelte";
+  import { Button } from "@recast/ui/button";
+  import { Kbd } from "@recast/ui/kbd";
+  import { SliderControl } from "@recast/ui/slider-control";
+  import { cn } from "@recast/ui/utils";
+  import PanelSection from "./PanelSection.svelte";
+
+  // Contextual controls for the clip/segment selected on the timeline. Auto-opened
+  // by PropertiesPanel when `selectedClipStart` is set (mirrors the Focus tab for
+  // zoom regions). Speed writes go through `store.setSegmentSpeed` (coalesced undo).
+
+  interface Props {
+    store: EditorStore;
+  }
+  let { store }: Props = $props();
+
+  const SPEED_PRESETS = [0.5, 1, 1.5, 2];
+  const fmtSpeed = (s: number) => `${s}×`;
+
+  // The selected kept segment, matched by its original start anchor.
+  const selected = $derived.by(() => {
+    const start = store.selectedClipStart;
+    if (start === null) return null;
+    return store.segments.find((s) => Math.abs(s.start - start) < 1e-4) ?? null;
+  });
+  const speed = $derived(selected ? store.segmentSpeedAt(selected.start) : 1);
+  const isSped = $derived(Math.abs(speed - 1) > 1e-4);
+
+  function setSpeed(v: number) {
+    if (selected) store.setSegmentSpeed(selected.start, v);
+  }
+  function splitHere() {
+    store.splitAt(store.currentTime);
+  }
+  function deleteClip() {
+    if (!selected) return;
+    const joinAt = store.deleteSegmentAt((selected.start + selected.end) / 2);
+    if (joinAt !== null) store.currentTime = joinAt;
+  }
+</script>
+
+{#if !selected}
+  <div class="flex flex-col items-center justify-center gap-2 px-3 py-12 text-center">
+    <SquareSplitHorizontal class="size-6 text-muted-foreground/50" />
+    <p class="text-[11px] leading-snug text-muted-foreground">
+      Select a clip on the timeline to change its speed, split it, or remove it.
+    </p>
+  </div>
+{:else}
+  {@const duration = selected.end - selected.start}
+  <div class="space-y-3">
+    <div class="rounded-lg border border-border/60 bg-card/40 px-3 py-2">
+      <div class="flex items-baseline justify-between">
+        <span class="text-[11px] text-muted-foreground">Clip duration</span>
+        <span class="font-mono text-[12px] tabular-nums text-foreground">
+          {clockCentis(duration)}
+        </span>
+      </div>
+      {#if isSped}
+        <div class="mt-0.5 flex items-baseline justify-between text-[10px] text-muted-foreground">
+          <span>Plays in</span>
+          <span class="font-mono tabular-nums text-primary">
+            {clockCentis(duration / speed)} at {fmtSpeed(speed)}
+          </span>
+        </div>
+      {/if}
+    </div>
+
+    <PanelSection
+      title="Clip speed"
+      hint="Changes how fast this clip plays — in the preview AND the export. 1× is normal."
+    >
+      {#snippet action()}
+        {#if isSped}
+          <button
+            type="button"
+            onclick={() => setSpeed(1)}
+            class="flex items-center gap-1 text-[10px] text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <RotateCcw class="size-2.5" />
+            Reset
+          </button>
+        {/if}
+      {/snippet}
+      <div class="grid grid-cols-4 gap-1">
+        {#each SPEED_PRESETS as preset (preset)}
+          {@const active = Math.abs(speed - preset) < 1e-4}
+          <button
+            type="button"
+            onclick={() => setSpeed(preset)}
+            aria-pressed={active}
+            class={cn(
+              "rounded-md border px-1.5 py-1 font-mono text-[11px] font-semibold tabular-nums transition-colors",
+              active
+                ? "border-primary/60 bg-primary/10 text-primary"
+                : "border-border/60 bg-card/40 text-muted-foreground hover:border-border hover:text-foreground",
+            )}
+          >
+            {fmtSpeed(preset)}
+          </button>
+        {/each}
+      </div>
+      <SliderControl
+        label="Fine"
+        value={speed}
+        min={MIN_SEGMENT_SPEED}
+        max={MAX_SEGMENT_SPEED}
+        step={0.05}
+        unit="×"
+        formatValue={(v) => `${v.toFixed(2)}×`}
+        onchange={(v) => setSpeed(v)}
+      >
+        {#snippet icon()}
+          <Gauge class="size-3" />
+        {/snippet}
+      </SliderControl>
+    </PanelSection>
+
+    <div class="space-y-1.5">
+      <Button
+        variant="outline"
+        size="sm"
+        class="w-full justify-start gap-2"
+        onclick={splitHere}
+      >
+        <SquareSplitHorizontal class="size-3.5" />
+        Split at playhead
+        <Kbd class="ml-auto">S</Kbd>
+      </Button>
+      {#if store.segments.length > 1}
+        <Button
+          variant="outline"
+          size="sm"
+          class="w-full justify-start gap-2 text-destructive hover:text-destructive"
+          onclick={deleteClip}
+        >
+          <Trash2 class="size-3.5" />
+          Delete clip
+        </Button>
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/apps/desktop/src/components/editor/properity-panel/CursorPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/CursorPanel.svelte
@@ -17,13 +17,13 @@
   import { SegmentedToggle } from "@recast/ui/segmented";
   import { SliderControl } from "@recast/ui/slider-control";
   import { cn } from "@recast/ui/utils";
+  import { Image } from "@unpic/svelte";
   import { cubicOut } from "svelte/easing";
   import { fade, fly, scale } from "svelte/transition";
   import BezierEditor from "../_components/BezierEditor.svelte";
   import CursorTrajectoryMap from "../_components/CursorTrajectoryMap.svelte";
   import InspectorHint from "../InspectorHint.svelte";
   import PanelSection from "./PanelSection.svelte";
-
   const highlightColors = [
     "#3b82f6",
     "#ef4444",
@@ -108,7 +108,12 @@
         {#each registry.list("cursor") as style, i (style.id)}
           {@const isActive = store.cursorSettings.style === style.id}
           <button
-            in:fly={{ y: 6, duration: 240, delay: 60 + i * 35, easing: cubicOut }}
+            in:fly={{
+              y: 6,
+              duration: 240,
+              delay: 60 + i * 35,
+              easing: cubicOut,
+            }}
             type="button"
             aria-pressed={isActive}
             aria-label={`${style.label} cursor`}
@@ -116,31 +121,26 @@
               store.pushUndoState();
               store.updateCursorSettings({ style: style.id });
             }}
-            title={style.description ? `${style.label} — ${style.description}` : style.label}
+            title={style.description
+              ? `${style.label} — ${style.description}`
+              : style.label}
             class={cn(
-              "group relative aspect-square overflow-hidden rounded-md border transition-all duration-150",
+              "inline-flex items-center justify-center group relative aspect-square overflow-hidden rounded-md border transition-all duration-150",
               "focus:outline-none focus:ring-2 focus:ring-ring/40",
               isActive
                 ? "border-primary/60 bg-primary/8 text-foreground"
                 : "border-transparent bg-background/40 text-foreground/80 hover:border-border hover:bg-background/80 hover:text-foreground",
             )}
           >
-            <span
-              class={cn(
-                "absolute inset-0 flex items-center justify-center transition-transform duration-150",
-                isActive
-                  ? "scale-100"
-                  : "scale-90 opacity-85 group-hover:scale-100 group-hover:opacity-100",
-              )}
+            <Image
+              src={svgSwatchUrl(style.value.svg)}
+              alt={style.label}
+              draggable="false"
+              class="size-10"
+              layout="constrained"
               aria-hidden="true"
-            >
-              <img
-                src={svgSwatchUrl(style.value.svg)}
-                alt=""
-                draggable="false"
-                class="h-[60%] w-[60%]"
-              />
-            </span>
+            />
+          
             {#if isActive}
               <span
                 aria-hidden="true"
@@ -215,7 +215,12 @@
               store.cursorSettings.snapWindowMs === preset.value.snapWindowMs}
             <span
               class="inline-flex"
-              in:scale={{ start: 0.92, duration: 220, delay: 80 + i * 30, easing: cubicOut }}
+              in:scale={{
+                start: 0.92,
+                duration: 220,
+                delay: 80 + i * 30,
+                easing: cubicOut,
+              }}
             >
               <Button
                 type="button"
@@ -338,7 +343,12 @@
               {/each}
             </div>
 
-            <PanelSection title="Custom curve" flush collapsible defaultOpen={false}>
+            <PanelSection
+              title="Custom curve"
+              flush
+              collapsible
+              defaultOpen={false}
+            >
               <div class="pt-1">
                 <BezierEditor
                   value={cur}
@@ -491,7 +501,12 @@
             {@const isSelected = store.cursorSettings.highlightColor === color}
             <span
               class="inline-flex"
-              in:scale={{ start: 0.85, duration: 220, delay: 60 + i * 25, easing: cubicOut }}
+              in:scale={{
+                start: 0.85,
+                duration: 220,
+                delay: 60 + i * 25,
+                easing: cubicOut,
+              }}
             >
               <Button
                 variant="raw"

--- a/apps/desktop/src/components/editor/properity-panel/FocusPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/FocusPanel.svelte
@@ -221,7 +221,7 @@
         >
           <Target size={16} />
         </div>
-        <p class="text-[11px] font-medium text-foreground">No focus regions yet</p>
+        <p class="text-[11px] font-medium text-foreground">No zoom regions yet</p>
         <p class="text-[10px] leading-snug text-muted-foreground">
           Park the playhead where you want to zoom, then press Add.
         </p>

--- a/apps/desktop/src/components/editor/properity-panel/PropertiesPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/PropertiesPanel.svelte
@@ -39,10 +39,10 @@
   // flips back to true. The CameraPanel component itself is intact.
   // See apps/desktop/docs/camera-recording-todo.md.
   const tabs: TabType[] = [
-    { id: "clip", label: "Clip", icon: SquareSplitHorizontal },
+    // { id: "clip", label: "Clip", icon: SquareSplitHorizontal },
     { id: "background", label: "Background", icon: ImageIcon },
-    { id: "focus", label: "Focus", icon: Target },
-    { id: "annotations", label: "Annotations", icon: Pencil },
+    { id: "focus", label: "Zoom", icon: Target },
+    { id: "annotations", label: "Markup", icon: Pencil },
     { id: "cursor", label: "Cursor", icon: MousePointer },
     ...(CAMERA_OVERLAY_UI_ENABLED
       ? [{ id: "camera" as PanelTab, label: "Camera", icon: Video }]

--- a/apps/desktop/src/components/editor/properity-panel/PropertiesPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/PropertiesPanel.svelte
@@ -7,6 +7,7 @@
     Info,
     MousePointer,
     Pencil,
+    SquareSplitHorizontal,
     Target,
     Video,
     Volume2,
@@ -18,6 +19,7 @@
   import AudioPanel from "./AudioPanel.svelte";
   import BackgroundPicker from "./BackgroundPicker.svelte";
   import CameraPanel from "./CameraPanel.svelte";
+  import ClipPanel from "./ClipPanel.svelte";
   import CursorPanel from "./CursorPanel.svelte";
   import ExtensionsPanel from "./ExtensionsPanel.svelte";
   import FocusPanel from "./FocusPanel.svelte";
@@ -37,6 +39,7 @@
   // flips back to true. The CameraPanel component itself is intact.
   // See apps/desktop/docs/camera-recording-todo.md.
   const tabs: TabType[] = [
+    { id: "clip", label: "Clip", icon: SquareSplitHorizontal },
     { id: "background", label: "Background", icon: ImageIcon },
     { id: "focus", label: "Focus", icon: Target },
     { id: "annotations", label: "Annotations", icon: Pencil },
@@ -50,6 +53,13 @@
   ];
 
   let { store, cameraPath = null }: Props = $props();
+
+  // Switch to Clip when a clip/segment is selected from the timeline.
+  $effect(() => {
+    if (store.selectedClipStart !== null) {
+      store.activePanel = "clip";
+    }
+  });
 
   // Switch to Focus when a zoom region is selected from the timeline.
   $effect(() => {
@@ -118,6 +128,10 @@
         {activeTabLabel}
       </span>
     </div>
+
+    <Tabs.Content value="clip" class={tabContentClass}>
+      <ClipPanel {store} />
+    </Tabs.Content>
 
     <Tabs.Content value="background" class={tabContentClass}>
       <BackgroundPicker {store} />

--- a/apps/desktop/src/lib/playback/audio-engine.ts
+++ b/apps/desktop/src/lib/playback/audio-engine.ts
@@ -106,12 +106,15 @@ export class AudioTimelineEngine {
 			const bufDur = t.buffer.duration;
 			for (const c of chunks) {
 				// A track may be shorter than the timeline (e.g. mic stopped early);
-				// clamp the slice to the available buffer.
+				// clamp the slice to the available buffer (in SOURCE seconds).
 				if (c.bufferOffset >= bufDur) continue;
 				const playDur = Math.min(c.duration, bufDur - c.bufferOffset);
 				if (playDur <= 0) continue;
 				const node = this.#ctx.createBufferSource();
 				node.buffer = t.buffer;
+				// Per-segment speed: play the slice faster/slower (pitch shifts —
+				// matches the sped-up video; pitch-preserved stretch is a follow-up).
+				node.playbackRate.value = c.rate;
 				node.connect(t.gain);
 				node.onended = () => {
 					const i = this.#active.indexOf(node);

--- a/apps/desktop/src/lib/playback/audio-schedule.test.ts
+++ b/apps/desktop/src/lib/playback/audio-schedule.test.ts
@@ -47,8 +47,8 @@ describe("planAudioSchedule", () => {
 	it("schedules every region from the start of playback", () => {
 		const plan = planAudioSchedule(regions, 0);
 		expect(plan).toEqual([
-			{ whenDelay: 0, bufferOffset: 0, duration: 3, outStart: 0, outEnd: 3 },
-			{ whenDelay: 3, bufferOffset: 5, duration: 5, outStart: 3, outEnd: 8 },
+			{ whenDelay: 0, bufferOffset: 0, duration: 3, rate: 1, outStart: 0, outEnd: 3 },
+			{ whenDelay: 3, bufferOffset: 5, duration: 5, rate: 1, outStart: 3, outEnd: 8 },
 		]);
 	});
 
@@ -56,7 +56,7 @@ describe("planAudioSchedule", () => {
 		// Output time 4 is 1s into the second region (orig 5..10) → buffer offset 6.
 		const plan = planAudioSchedule(regions, 4);
 		expect(plan).toEqual([
-			{ whenDelay: 0, bufferOffset: 6, duration: 4, outStart: 3, outEnd: 8 },
+			{ whenDelay: 0, bufferOffset: 6, duration: 4, rate: 1, outStart: 3, outEnd: 8 },
 		]);
 	});
 
@@ -74,5 +74,43 @@ describe("planAudioSchedule", () => {
 
 	it("returns nothing once playback is past the end", () => {
 		expect(planAudioSchedule(regions, 8)).toEqual([]);
+	});
+});
+
+describe("planAudioSchedule with per-segment speed", () => {
+	it("a 2x region occupies half the output and plays at rate 2", () => {
+		// [0,4] source at 2x → output 0–2; whole 4s of source plays at rate 2.
+		const plan = planAudioSchedule([{ start: 0, end: 4, speed: 2 }], 0);
+		expect(plan).toEqual([
+			{ whenDelay: 0, bufferOffset: 0, duration: 4, rate: 2, outStart: 0, outEnd: 2 },
+		]);
+	});
+
+	it("warps later regions' output positions by upstream speeds", () => {
+		// [0,4]@1 (output 0–4) then [4,8]@2 (output 4–6).
+		const plan = planAudioSchedule(
+			[
+				{ start: 0, end: 4, speed: 1 },
+				{ start: 4, end: 8, speed: 2 },
+			],
+			0,
+		);
+		expect(plan).toEqual([
+			{ whenDelay: 0, bufferOffset: 0, duration: 4, rate: 1, outStart: 0, outEnd: 4 },
+			{ whenDelay: 4, bufferOffset: 4, duration: 4, rate: 2, outStart: 4, outEnd: 6 },
+		]);
+	});
+
+	it("starts mid sped-up region at the speed-scaled buffer offset", () => {
+		// [0,4]@2 → output 0–2. From output 1 (half-way) → 2s of source consumed.
+		const plan = planAudioSchedule([{ start: 0, end: 4, speed: 2 }], 1);
+		expect(plan).toEqual([
+			{ whenDelay: 0, bufferOffset: 2, duration: 2, rate: 2, outStart: 0, outEnd: 2 },
+		]);
+	});
+
+	it("treats absent/zero speed as 1x", () => {
+		expect(planAudioSchedule([{ start: 0, end: 2, speed: 0 }], 0)[0].rate).toBe(1);
+		expect(planAudioSchedule([{ start: 0, end: 2 }], 0)[0].rate).toBe(1);
 	});
 });

--- a/apps/desktop/src/lib/playback/audio-schedule.ts
+++ b/apps/desktop/src/lib/playback/audio-schedule.ts
@@ -20,6 +20,10 @@ export interface Region {
 	start: number;
 	/** End (seconds). */
 	end: number;
+	/** Playback speed (>0); 1 = normal. A 2× region plays its audio twice as
+	 *  fast (and occupies half the output time), matching the per-segment clip
+	 *  speed. Optional — absent/≤0 means 1×. */
+	speed?: number;
 }
 
 /**
@@ -60,15 +64,19 @@ export function keptRegions(
 	return regions;
 }
 
-/** One scheduled audio chunk: play the buffer slice `[bufferOffset, +duration]`
- * starting `whenDelay` seconds from "now" (the moment scheduling begins). */
+/** One scheduled audio chunk: play `duration` SOURCE seconds of the buffer from
+ * `bufferOffset` at `rate`, starting `whenDelay` output-seconds from "now". The
+ * audio clock runs in output (== wall) time, so a 2× chunk consumes twice the
+ * source per output-second and is positioned on the warped output axis. */
 export interface ScheduledChunk {
-	/** Seconds from now to begin this chunk (0 = immediately, mid-region). */
+	/** Output-seconds from now to begin this chunk (0 = immediately, mid-region). */
 	whenDelay: number;
 	/** Offset into the (original-time) audio buffer to start playing from. */
 	bufferOffset: number;
-	/** How long to play. */
+	/** SOURCE seconds of buffer to play (wall time = duration / rate). */
 	duration: number;
+	/** Playback rate (= region speed). */
+	rate: number;
 	/** Output-time span this chunk occupies (for resync/debugging). */
 	outStart: number;
 	outEnd: number;
@@ -76,9 +84,10 @@ export interface ScheduledChunk {
 
 /**
  * Plan the chunks to schedule so playback continues from OUTPUT time
- * `fromOutputTime`. Output time is gapless: region N starts where region N-1
- * ended. Regions already fully behind the playhead are skipped; the region the
- * playhead is inside starts immediately (`whenDelay` 0) at the right offset.
+ * `fromOutputTime`. Output time is gapless and SPEED-WARPED: a region of source
+ * length L at speed s occupies L/s on the output axis. Region N starts where
+ * region N-1 ended. Regions fully behind the playhead are skipped; the region
+ * the playhead is inside starts immediately (`whenDelay` 0) at the right offset.
  */
 export function planAudioSchedule(
 	regions: ReadonlyArray<Region>,
@@ -87,21 +96,26 @@ export function planAudioSchedule(
 	const out: ScheduledChunk[] = [];
 	let outCursor = 0;
 	for (const region of regions) {
-		const dur = region.end - region.start;
-		if (dur <= EPS) continue;
+		const sourceDur = region.end - region.start;
+		if (sourceDur <= EPS) continue;
+		const rate = region.speed && region.speed > 0 ? region.speed : 1;
+		const outDur = sourceDur / rate;
 		const outStart = outCursor;
-		const outEnd = outCursor + dur;
+		const outEnd = outCursor + outDur;
 		outCursor = outEnd;
 		if (outEnd <= fromOutputTime + EPS) continue; // already played
 
-		const intoRegion = Math.max(0, fromOutputTime - outStart);
+		const intoOutput = Math.max(0, fromOutputTime - outStart);
 		const whenDelay = Math.max(0, outStart - fromOutputTime);
-		const duration = dur - intoRegion;
+		// Output time into the region maps to source seconds at `rate`.
+		const sourceInto = intoOutput * rate;
+		const duration = sourceDur - sourceInto;
 		if (duration <= EPS) continue;
 		out.push({
 			whenDelay,
-			bufferOffset: region.start + intoRegion,
+			bufferOffset: region.start + sourceInto,
 			duration,
+			rate,
 			outStart,
 			outEnd,
 		});

--- a/apps/desktop/src/lib/playback/mp4-demux.ts
+++ b/apps/desktop/src/lib/playback/mp4-demux.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared whole-file MP4 demux for the WebCodecs workers.
+ *
+ * Both the preview decoder (webcodecs-worker.ts) and the filmstrip decoder
+ * (../timeline/filmstrip-worker.ts) need the same first step: mp4box parses the
+ * file into encoded samples (decode order) plus the codec config. This owns that
+ * one dance so neither worker reimplements it. The progressive (HTTP-range) path
+ * stays in webcodecs-worker.ts — only whole-file ingestion is shared.
+ */
+
+import {
+	createFile,
+	DataStream,
+	type ISOFile,
+	MP4BoxBuffer,
+	type Movie,
+	type Sample,
+	type Track,
+} from "mp4box";
+import type { ChunkMeta } from "./frame-index";
+
+export interface DemuxResult {
+	/** Encoded samples in decode order. */
+	chunks: ChunkMeta[];
+	/** Decoder config (codec + description), already checked as supported. */
+	config: VideoDecoderConfig;
+	/** Display width (px). */
+	width: number;
+	/** Display height (px). */
+	height: number;
+	/** Track duration (seconds). */
+	durationSec: number;
+	/** Average frame rate (samples / duration). */
+	fps: number;
+}
+
+/**
+ * Demux an in-memory MP4 into its sample table and decoder config. Throws if the
+ * WebView lacks WebCodecs, the file has no decodable video track, or the codec
+ * isn't supported — the caller should fall back to a non-WebCodecs path.
+ */
+export async function demuxWholeFile(ab: ArrayBuffer): Promise<DemuxResult> {
+	if (typeof VideoDecoder === "undefined") {
+		throw new Error("WebCodecs VideoDecoder unavailable");
+	}
+	const file = createFile();
+	const collected: ChunkMeta[] = [];
+
+	// Resolve with track + config so they reach the linear flow as non-null
+	// locals — TS can't see assignments inside these mp4box callbacks.
+	const ready = new Promise<{ track: Track; cfg: VideoDecoderConfig }>(
+		(resolve, reject) => {
+			let track: Track | null = null;
+			let cfg: VideoDecoderConfig | null = null;
+			file.onError = (e: string) => reject(new Error(`mp4box: ${e}`));
+			file.onReady = (info: Movie) => {
+				const vtrack =
+					info.videoTracks?.[0] ??
+					info.tracks.find((t) => t.type === "video") ??
+					null;
+				if (!vtrack) {
+					reject(new Error("no video track in source"));
+					return;
+				}
+				track = vtrack;
+				cfg = {
+					codec: vtrack.codec,
+					description: extractDescription(file, vtrack.id),
+					// Throughput over latency: a latency-optimised decoder serialises
+					// and can tank to single-digit fps.
+					hardwareAcceleration: "prefer-hardware",
+					optimizeForLatency: false,
+				};
+				file.setExtractionOptions(vtrack.id, null, { nbSamples: Infinity });
+				file.start();
+			};
+			file.onSamples = (_id: number, _user: unknown, samples: Sample[]) => {
+				for (const s of samples) {
+					const ts = s.timescale || 1;
+					collected.push({
+						ctsUs: Math.round((s.cts / ts) * 1e6),
+						durUs: Math.round((s.duration / ts) * 1e6),
+						key: s.is_sync,
+						data: s.data ? s.data.slice() : new Uint8Array(0),
+					});
+				}
+				if (track && cfg && collected.length >= track.nb_samples)
+					resolve({ track, cfg });
+			};
+		},
+	);
+
+	file.appendBuffer(MP4BoxBuffer.fromArrayBuffer(ab, 0), true);
+	file.flush();
+	const { track, cfg } = await ready;
+
+	if (collected.length === 0) throw new Error("demux produced no samples");
+	const support = await VideoDecoder.isConfigSupported(cfg);
+	if (!support.supported) throw new Error(`codec not supported: ${cfg.codec}`);
+
+	const durationSec =
+		track.movie_timescale > 0 ? track.movie_duration / track.movie_timescale : 0;
+	const width = track.video?.width ?? track.track_width;
+	const height = track.video?.height ?? track.track_height;
+	return {
+		chunks: collected,
+		config: cfg,
+		width,
+		height,
+		durationSec,
+		fps: durationSec > 0 ? track.nb_samples / durationSec : 30,
+	};
+}
+
+/**
+ * Pull the codec config (avcC / hvcC / av1C / vpcC) out of the sample
+ * description as the raw box payload WebCodecs expects (box contents minus the
+ * 8-byte size+type header).
+ */
+export function extractDescription(file: ISOFile, trackId: number): Uint8Array {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const trak = file.getTrackById(trackId) as any;
+	const entries = trak?.mdia?.minf?.stbl?.stsd?.entries ?? [];
+	for (const entry of entries) {
+		const box = entry.avcC ?? entry.hvcC ?? entry.av1C ?? entry.vpcC;
+		if (box) {
+			// Default endianness is BIG_ENDIAN (network order), as avcC requires.
+			const stream = new DataStream(undefined, 0);
+			box.write(stream);
+			return new Uint8Array(stream.buffer, 8);
+		}
+	}
+	throw new Error("no codec description (avcC/hvcC/...) in sample table");
+}

--- a/apps/desktop/src/lib/playback/webcodecs-worker.ts
+++ b/apps/desktop/src/lib/playback/webcodecs-worker.ts
@@ -13,15 +13,7 @@
  * feeding from the playhead time the main thread sends.
  */
 
-import {
-	createFile,
-	DataStream,
-	type ISOFile,
-	MP4BoxBuffer,
-	type Movie,
-	type Sample,
-	type Track,
-} from "mp4box";
+import { createFile, type ISOFile, MP4BoxBuffer, type Movie } from "mp4box";
 import {
 	buildKeyframes,
 	buildPresOrder,
@@ -32,6 +24,7 @@ import {
 } from "./frame-index";
 import { frameBudget } from "./frame-budget";
 import { GopByteBudget } from "./gop-byte-budget";
+import { demuxWholeFile, extractDescription } from "./mp4-demux";
 import {
 	buildSampleTable,
 	gopByteRange,
@@ -129,92 +122,21 @@ function post(msg: FromWorker, transfer: Transferable[] = []): void {
 }
 
 async function init(ab: ArrayBuffer): Promise<void> {
-	if (typeof VideoDecoder === "undefined") {
-		post({ type: "error", message: "WebCodecs VideoDecoder unavailable" });
-		return;
-	}
 	try {
-		const file = createFile();
-		const collected: ChunkMeta[] = [];
-
-		// Resolve with track + config so they reach the linear flow as non-null
-		// locals — TS can't see assignments inside these mp4box callbacks.
-		const ready = new Promise<{ track: Track; cfg: VideoDecoderConfig }>((resolve, reject) => {
-			let track: Track | null = null;
-			let cfg: VideoDecoderConfig | null = null;
-			file.onError = (e: string) => reject(new Error(`mp4box: ${e}`));
-			file.onReady = (info: Movie) => {
-				const vtrack =
-					info.videoTracks?.[0] ??
-					info.tracks.find((t) => t.type === "video") ??
-					null;
-				if (!vtrack) {
-					reject(new Error("no video track in source"));
-					return;
-				}
-				track = vtrack;
-				cfg = {
-					codec: vtrack.codec,
-					description: extractDescription(file, vtrack.id),
-					// Editor playback wants throughput, not low latency: a
-					// latency-optimised decoder serialises and can tank to
-					// single-digit fps. Prefer hardware and let it pipeline.
-					hardwareAcceleration: "prefer-hardware",
-					optimizeForLatency: false,
-					// codedWidth/Height omitted: the container reports
-					// the DISPLAY size (1920x1080) but the coded size is padded
-					// (1920x1088); a mismatched hint can confuse the decoder. It
-					// derives the true size from the SPS in `description`.
-				};
-				file.setExtractionOptions(vtrack.id, null, { nbSamples: Infinity });
-				file.start();
-			};
-			file.onSamples = (_id: number, _user: unknown, samples: Sample[]) => {
-				for (const s of samples) {
-					const ts = s.timescale || 1;
-					collected.push({
-						ctsUs: Math.round((s.cts / ts) * 1e6),
-						durUs: Math.round((s.duration / ts) * 1e6),
-						key: s.is_sync,
-						data: s.data ? s.data.slice() : new Uint8Array(0),
-					});
-				}
-				if (track && cfg && collected.length >= track.nb_samples)
-					resolve({ track, cfg });
-			};
-		});
-
-		file.appendBuffer(MP4BoxBuffer.fromArrayBuffer(ab, 0), true);
-		file.flush();
-		const { track, cfg } = await ready;
-
-		if (collected.length === 0) throw new Error("demux produced no samples");
-
-		const support = await VideoDecoder.isConfigSupported(cfg);
-		if (!support.supported) {
-			throw new Error(`codec not supported: ${cfg.codec}`);
-		}
-
-		chunks = collected;
+		const res = await demuxWholeFile(ab);
+		chunks = res.chunks;
 		keyframes = buildKeyframes(chunks);
 		presOrder = buildPresOrder(chunks);
-		config = cfg;
+		config = res.config;
 		decoder = makeDecoder();
 		decoder.configure(config);
-
-		const durationSec =
-			track.movie_timescale > 0
-				? track.movie_duration / track.movie_timescale
-				: 0;
-		const vw = track.video?.width ?? track.track_width;
-		const vh = track.video?.height ?? track.track_height;
-		decodeAhead = frameBudget(vw, vh).decodeAhead;
+		decodeAhead = frameBudget(res.width, res.height).decodeAhead;
 		post({
 			type: "ready",
-			width: vw,
-			height: vh,
-			durationSec,
-			fps: durationSec > 0 ? track.nb_samples / durationSec : 30,
+			width: res.width,
+			height: res.height,
+			durationSec: res.durationSec,
+			fps: res.fps,
 		});
 	} catch (err) {
 		post({ type: "error", message: err instanceof Error ? err.message : String(err) });
@@ -625,24 +547,3 @@ ctx.onmessage = (e: MessageEvent<ToWorker>) => {
 			break;
 	}
 };
-
-/**
- * Pull the codec config (avcC / hvcC / av1C / vpcC) out of the sample
- * description as the raw box payload WebCodecs expects (box contents minus the
- * 8-byte size+type header).
- */
-function extractDescription(file: ISOFile, trackId: number): Uint8Array {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const trak = file.getTrackById(trackId) as any;
-	const entries = trak?.mdia?.minf?.stbl?.stsd?.entries ?? [];
-	for (const entry of entries) {
-		const box = entry.avcC ?? entry.hvcC ?? entry.av1C ?? entry.vpcC;
-		if (box) {
-			// Default endianness is BIG_ENDIAN (network order), as avcC requires.
-			const stream = new DataStream(undefined, 0);
-			box.write(stream);
-			return new Uint8Array(stream.buffer, 8);
-		}
-	}
-	throw new Error("no codec description (avcC/hvcC/...) in sample table");
-}

--- a/apps/desktop/src/lib/stores/editor-store.svelte.ts
+++ b/apps/desktop/src/lib/stores/editor-store.svelte.ts
@@ -11,6 +11,14 @@ import { log } from '../logger';
 import { resolveBackgroundWireValue } from '../registry/resolve';
 import { totalCutDuration, type CutSource, type TimelineCut } from '../timeline/cuts';
 import { deriveSegments, planDeleteSegment, planSplit, segmentAt, type Segment } from '../timeline/segments';
+import {
+	buildSpeedOf,
+	pruneSegmentSpeeds,
+	type SegmentSpeed,
+	segmentSpeedAt as speedAtAnchor,
+	setSegmentSpeed as upsertSegmentSpeed,
+} from '../timeline/segment-speed';
+import { displayTimeMap, timeMapFromSegments } from '../timeline/time-map';
 import { experimentalStore } from './experimental.svelte';
 
 export type BackgroundType = 'wallpaper' | 'image' | 'color' | 'gradient';
@@ -489,6 +497,9 @@ export interface EditorRenderState {
 	 *  individually deletable segments. Editor-only — has no export effect on
 	 *  its own; deleting a segment is what produces a cut. */
 	splitPoints?: number[];
+	/** Per-segment speed overrides, anchored to a segment's original start. A
+	 *  segment with no entry plays at 1×. */
+	segmentSpeeds?: SegmentSpeed[];
 	/** Whether zoom regions apply in preview/export. */
 	focusEnabled?: boolean;
 	/** Whether annotations render in preview/export. Negation of the
@@ -581,7 +592,7 @@ export function aspectRatio(a: OutputAspect): number | null {
 
 export type EditorWindowBehavior = 'navigate' | 'new-window';
 
-export type PanelTab = 'background' | 'focus' | 'annotations' | 'cursor' | 'camera' | 'audio' | 'extensions' | 'info';
+export type PanelTab = 'clip' | 'background' | 'focus' | 'annotations' | 'cursor' | 'camera' | 'audio' | 'extensions' | 'info';
 
 // Wallpapers 19–23 were moved into the installable "Waves" extension pack
 // (extensions/packs/waves-wallpapers) — keep the built-in default set at 18 so
@@ -735,6 +746,11 @@ export function createEditorStore() {
 	// individually deletable segments. Purely an editing aid — no export effect
 	// until a segment between two boundaries is ripple-deleted (→ a manual cut).
 	let splitPoints = $state<number[]>([]);
+	let segmentSpeeds = $state<SegmentSpeed[]>([]);
+	// Transient (not serialized): true only while a trim handle is being dragged.
+	// Flips the timeline onto the full-recording axis so the handle can move
+	// across the whole source and reveal the trimmed head/tail (Cap-style ghost).
+	let isTrimming = $state(false);
 	// Transient UI selection: the start time of the highlighted clip block, or
 	// null. Not serialized (mirrors selectedZoomRegionId).
 	let selectedClipStart = $state<number | null>(null);
@@ -922,6 +938,7 @@ export function createEditorStore() {
 			zoomRegions,
 			cuts,
 			splitPoints,
+			segmentSpeeds,
 			autoZoomEnabled,
 			autoZoomApplied,
 			annotations,
@@ -1025,6 +1042,7 @@ export function createEditorStore() {
 		autoZoomApplied = s.autoZoomApplied ?? autoZoomApplied;
 		cuts = (s.cuts ?? []).map((c: TimelineCut) => ({ ...c }));
 		splitPoints = [...(s.splitPoints ?? [])];
+		segmentSpeeds = (s.segmentSpeeds ?? []).map((o: SegmentSpeed) => ({ ...o }));
 		// Annotation undo: restore the captured array. Each entry already
 		// carries its own id from the snapshot — we keep them so refs from
 		// `selectedAnnotationId` etc. survive the undo cleanly.
@@ -1430,6 +1448,7 @@ export function createEditorStore() {
 		selectedZoomRegionId = null;
 		cuts = [];
 		splitPoints = [];
+		segmentSpeeds = [];
 		cutsEnabled = true;
 		focusEnabled = true;
 		dismissedSilences = [];
@@ -1589,6 +1608,44 @@ export function createEditorStore() {
 		});
 	}
 
+	/** The timeline axis: the KEPT clip only (trimmed head/tail collapse away,
+	 * Cap-style), with each kept segment warped by its per-segment speed and cuts
+	 * closed to seams. `output 0 == inPoint`; the clip fills the track from the
+	 * left. Every lane, the playhead, and the preview clock position against this.
+	 * At all-1× speeds it's the cut translation map restricted to [inPoint,outPoint]. */
+	function currentTimeMap() {
+		const segs = currentSegments();
+		const speedOf = buildSpeedOf(segs, segmentSpeeds);
+		// While trimming, un-collapse onto the full recording so the handle can
+		// move across the whole source (and reveal/restore the trimmed head/tail).
+		if (isTrimming) {
+			const { start, end } = clipBounds();
+			return displayTimeMap({
+				trimStart: start,
+				trimEnd: end,
+				durationSec: metadata?.duration ?? end,
+				segments: segs,
+				cuts: effectiveCutList(),
+				speedOf,
+			});
+		}
+		return timeMapFromSegments(segs, speedOf);
+	}
+
+	/** Speed of the segment anchored at original `start` (1 when unset). */
+	function segmentSpeedAtStart(start: number): number {
+		return speedAtAnchor(segmentSpeeds, start);
+	}
+
+	/** Set the speed of the segment anchored at original `start`. Coalesced into
+	 * one undo entry per anchor while a slider drags; orphaned anchors are pruned. */
+	function setSegmentSpeed(start: number, speed: number) {
+		pushUndoStateCoalesced(`segment-speed-${start.toFixed(3)}`, 400);
+		const next = upsertSegmentSpeed(segmentSpeeds, start, speed);
+		segmentSpeeds = pruneSegmentSpeeds(next, currentSegments());
+		isDirty = true;
+	}
+
 	/** Split the clip at original time `t`. Returns true if a split was added. */
 	function splitAt(t: number): boolean {
 		const { start, end } = clipBounds();
@@ -1713,6 +1770,8 @@ export function createEditorStore() {
 			autoZoomEnabled,
 			cuts: cuts.map((cut) => ({ ...cut })),
 			splitPoints: [...splitPoints],
+			// Prune orphaned anchors on save so the section diffs cleanly.
+			segmentSpeeds: pruneSegmentSpeeds(segmentSpeeds, currentSegments()),
 			cutsEnabled,
 			focusEnabled,
 			annotationsEnabled: !annotationsGloballyHidden,
@@ -1801,6 +1860,7 @@ export function createEditorStore() {
 		}));
 		cutsEnabled = state.cutsEnabled ?? true;
 		splitPoints = [...(state.splitPoints ?? [])];
+		segmentSpeeds = (state.segmentSpeeds ?? []).map((o) => ({ ...o }));
 		focusEnabled = state.focusEnabled ?? true;
 		if (state.annotationsEnabled !== undefined) {
 			annotationsGloballyHidden = !state.annotationsEnabled;
@@ -1974,6 +2034,15 @@ export function createEditorStore() {
 		// — both empty out when timeline editing is opted off.
 		get segments() { return currentSegments(); },
 		get splitPoints() { return activeSplitPoints(); },
+		get segmentSpeeds() { return segmentSpeeds; },
+		// Warped output axis (kept segments × per-segment speed). Reduces to the
+		// cut translation map when every segment is 1×. Un-collapses to the full
+		// recording while `isTrimming` so a trim drag can reveal the trimmed parts.
+		get timeMap() { return currentTimeMap(); },
+		get isTrimming() { return isTrimming; },
+		set isTrimming(v: boolean) { isTrimming = v; },
+		segmentSpeedAt: segmentSpeedAtStart,
+		setSegmentSpeed,
 		get selectedClipStart() { return selectedClipStart; },
 		set selectedClipStart(v: number | null) { selectedClipStart = v; },
 		get focusEnabled() { return focusEnabled; },

--- a/apps/desktop/src/lib/stores/editor-store.svelte.ts
+++ b/apps/desktop/src/lib/stores/editor-store.svelte.ts
@@ -16,6 +16,7 @@ import {
 	pruneSegmentSpeeds,
 	type SegmentSpeed,
 	segmentSpeedAt as speedAtAnchor,
+	segmentSpeedAtTime as speedAtTime,
 	setSegmentSpeed as upsertSegmentSpeed,
 } from '../timeline/segment-speed';
 import { displayTimeMap, timeMapFromSegments } from '../timeline/time-map';
@@ -1637,6 +1638,14 @@ export function createEditorStore() {
 		return speedAtAnchor(segmentSpeeds, start);
 	}
 
+	/** Speed of the segment that CONTAINS original time `t` (1 when none / unset).
+	 * The legacy `<video>` preview reads this to set `playbackRate` per segment,
+	 * since that path plays at the element's native rate rather than the warped
+	 * output clock. Tolerant at seams: forward-biased onto the next segment. */
+	function segmentSpeedAtTime(t: number): number {
+		return speedAtTime(currentSegments(), segmentSpeeds, t);
+	}
+
 	/** Set the speed of the segment anchored at original `start`. Coalesced into
 	 * one undo entry per anchor while a slider drags; orphaned anchors are pruned. */
 	function setSegmentSpeed(start: number, speed: number) {
@@ -2042,6 +2051,7 @@ export function createEditorStore() {
 		get isTrimming() { return isTrimming; },
 		set isTrimming(v: boolean) { isTrimming = v; },
 		segmentSpeedAt: segmentSpeedAtStart,
+		segmentSpeedAtTime,
 		setSegmentSpeed,
 		get selectedClipStart() { return selectedClipStart; },
 		set selectedClipStart(v: number | null) { selectedClipStart = v; },

--- a/apps/desktop/src/lib/timeline/__fixtures__/speed-parity.json
+++ b/apps/desktop/src/lib/timeline/__fixtures__/speed-parity.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "SHARED per-segment-speed parity fixtures. Loaded by BOTH the frontend (apps/desktop/src/lib/timeline/segment-speed.test.ts) and the Rust export pipeline (apps/desktop/src-tauri/src/commands/editor.rs, cut_export_tests::warped_duration_matches_shared_parity_fixtures). For each case `expectedOutputDuration` MUST equal both (a) the frontend playback time-map's outputDuration = timeMapFromSegments(deriveSegments(...), buildSpeedOf(...)) and (b) the export's warped_output_duration(build_speed_segments(...)). All cases use trimStart=0 so original time == post-trim time (the trim offset is orthogonal and covered by cut-parity.json). Times are seconds; cuts are [start,end]; segmentSpeeds are [start,speed] anchored at a segment's original start.",
+  "cases": [
+    { "name": "no speed", "trimEnd": 10, "duration": 10, "cuts": [], "splitPoints": [], "segmentSpeeds": [], "expectedOutputDuration": 10 },
+    { "name": "whole clip 2x", "trimEnd": 10, "duration": 10, "cuts": [], "splitPoints": [], "segmentSpeeds": [[0, 2]], "expectedOutputDuration": 5 },
+    { "name": "split, second half 2x", "trimEnd": 10, "duration": 10, "cuts": [], "splitPoints": [5], "segmentSpeeds": [[5, 2]], "expectedOutputDuration": 7.5 },
+    { "name": "split, first half 0.5x", "trimEnd": 10, "duration": 10, "cuts": [], "splitPoints": [5], "segmentSpeeds": [[0, 0.5]], "expectedOutputDuration": 15 },
+    { "name": "cut then first segment 2x", "trimEnd": 10, "duration": 10, "cuts": [[4, 6]], "splitPoints": [], "segmentSpeeds": [[0, 2]], "expectedOutputDuration": 6 },
+    { "name": "4x clamp range", "trimEnd": 8, "duration": 8, "cuts": [], "splitPoints": [], "segmentSpeeds": [[0, 4]], "expectedOutputDuration": 2 },
+    { "name": "middle of three at 2x", "trimEnd": 10, "duration": 10, "cuts": [], "splitPoints": [3, 7], "segmentSpeeds": [[3, 2]], "expectedOutputDuration": 8 }
+  ]
+}

--- a/apps/desktop/src/lib/timeline/filmstrip-protocol.ts
+++ b/apps/desktop/src/lib/timeline/filmstrip-protocol.ts
@@ -1,0 +1,29 @@
+/**
+ * Message protocol between the filmstrip provider (filmstrip-source.ts) and its
+ * decode worker (filmstrip-worker.ts). Separate module so both sides share one
+ * definition without importing the other's runtime code.
+ */
+
+/** Provider → worker. */
+export type ToFilmstripWorker =
+	/** The whole MP4, fetched on the main thread and transferred in, plus the
+	 *  device-pixel tile height to downscale each thumbnail to. */
+	| { type: "init"; buffer: ArrayBuffer; tileHeightPx: number }
+	/** A batch of thumbnails to decode. Each `id` correlates the reply. The worker
+	 *  groups them by GOP so one keyframe decode serves every tile in it. */
+	| { type: "decode"; requests: Array<{ id: number; originalSec: number }> }
+	| { type: "dispose" };
+
+/** Worker → provider. */
+export type FromFilmstripWorker =
+	| {
+			type: "ready";
+			width: number;
+			height: number;
+			durationSec: number;
+			fps: number;
+	  }
+	/** A decoded, downscaled thumbnail as a compressed blob (cheap to clone; the
+	 *  provider turns it into an object URL for an `<img>`). */
+	| { type: "tile"; id: number; blob: Blob }
+	| { type: "error"; message: string };

--- a/apps/desktop/src/lib/timeline/filmstrip-protocol.ts
+++ b/apps/desktop/src/lib/timeline/filmstrip-protocol.ts
@@ -12,6 +12,10 @@ export type ToFilmstripWorker =
 	/** A batch of thumbnails to decode. Each `id` correlates the reply. The worker
 	 *  groups them by GOP so one keyframe decode serves every tile in it. */
 	| { type: "decode"; requests: Array<{ id: number; originalSec: number }> }
+	/** Build a YouTube-style storyboard: one sprite sheet packing evenly-spaced
+	 *  frames into a grid, so hover-scrub crops a cell instead of decoding a frame
+	 *  per position. The worker picks the cell count/grid from the duration. */
+	| { type: "storyboard" }
 	| { type: "dispose" };
 
 /** Worker → provider. */
@@ -26,4 +30,17 @@ export type FromFilmstripWorker =
 	/** A decoded, downscaled thumbnail as a compressed blob (cheap to clone; the
 	 *  provider turns it into an object URL for an `<img>`). */
 	| { type: "tile"; id: number; blob: Blob }
+	/** The finished storyboard sprite: a single image of `cols`×`rows` cells, each
+	 *  `cellW`×`cellH`, holding `count` frames evenly spaced across `durationSec`.
+	 *  Cell `i` (col `i%cols`, row `i/cols`) samples time `((i+0.5)/count)·dur`. */
+	| {
+			type: "storyboard";
+			blob: Blob;
+			cols: number;
+			rows: number;
+			cellW: number;
+			cellH: number;
+			count: number;
+			durationSec: number;
+	  }
 	| { type: "error"; message: string };

--- a/apps/desktop/src/lib/timeline/filmstrip-source.ts
+++ b/apps/desktop/src/lib/timeline/filmstrip-source.ts
@@ -14,6 +14,19 @@ import { chooseIngestion } from "../playback/mp4-sample-table";
 import { type FilmstripTile, LruCache } from "./filmstrip";
 import type { FromFilmstripWorker, ToFilmstripWorker } from "./filmstrip-protocol";
 
+/** A built storyboard sprite — one image of `cols`×`rows` cells (`cellW`×`cellH`
+ *  each) holding `count` frames evenly spaced across `durationSec`. Cell `i`
+ *  (col `i%cols`, row `i/cols`) samples `((i+0.5)/count)·durationSec`. */
+export interface Storyboard {
+	url: string;
+	cols: number;
+	rows: number;
+	cellW: number;
+	cellH: number;
+	count: number;
+	durationSec: number;
+}
+
 export interface TileProvider {
 	/** The image URL for a planned tile, or undefined while it's still decoding. */
 	get(tile: FilmstripTile): string | undefined;
@@ -22,6 +35,9 @@ export interface TileProvider {
 	/** A decoded frame URL near `originalSec` for hover-scrub, or undefined while
 	 *  it decodes (the call also queues the decode). */
 	previewAt(originalSec: number): string | undefined;
+	/** The storyboard sprite for instant hover-scrub, or undefined until built —
+	 *  the first call kicks off the one-time build. */
+	storyboard(): Storyboard | undefined;
 	dispose(): void;
 }
 
@@ -46,6 +62,9 @@ class WebCodecsTileProvider implements TileProvider {
 	#pending = new Map<string, number>();
 	#flushScheduled = false;
 	#disposed = false;
+	/** Built storyboard sprite, and whether its one-time build is requested. */
+	#storyboard: Storyboard | undefined;
+	#storyboardRequested = false;
 
 	private constructor(worker: Worker, onChange: () => void) {
 		this.#worker = worker;
@@ -120,6 +139,17 @@ class WebCodecsTileProvider implements TileProvider {
 		return undefined;
 	}
 
+	storyboard(): Storyboard | undefined {
+		if (this.#disposed) return undefined;
+		// First request kicks off the one-time build; the reply lands in #onMessage.
+		if (!this.#storyboard && !this.#storyboardRequested) {
+			this.#storyboardRequested = true;
+			const msg: ToFilmstripWorker = { type: "storyboard" };
+			this.#worker.postMessage(msg);
+		}
+		return this.#storyboard;
+	}
+
 	#scheduleFlush(): void {
 		if (this.#pending.size > 0 && !this.#flushScheduled) {
 			this.#flushScheduled = true;
@@ -147,6 +177,20 @@ class WebCodecsTileProvider implements TileProvider {
 			console.error("filmstrip worker:", msg.message);
 			return;
 		}
+		if (msg.type === "storyboard") {
+			if (this.#disposed) return;
+			this.#storyboard = {
+				url: URL.createObjectURL(msg.blob),
+				cols: msg.cols,
+				rows: msg.rows,
+				cellW: msg.cellW,
+				cellH: msg.cellH,
+				count: msg.count,
+				durationSec: msg.durationSec,
+			};
+			this.#onChange();
+			return;
+		}
 		if (msg.type !== "tile") return;
 		const cacheKey = this.#idToKey.get(msg.id);
 		this.#idToKey.delete(msg.id);
@@ -168,6 +212,8 @@ class WebCodecsTileProvider implements TileProvider {
 		}
 		this.#worker.terminate();
 		this.#cache.clear(); // revokes every object URL
+		if (this.#storyboard) URL.revokeObjectURL(this.#storyboard.url);
+		this.#storyboard = undefined;
 		this.#inflight.clear();
 		this.#idToKey.clear();
 		this.#pending.clear();

--- a/apps/desktop/src/lib/timeline/filmstrip-source.ts
+++ b/apps/desktop/src/lib/timeline/filmstrip-source.ts
@@ -1,0 +1,211 @@
+/**
+ * Filmstrip tile providers — the main-thread side of the clip-bar thumbnails.
+ *
+ * The clip bar plans virtualized tiles (./filmstrip.ts) and asks the provider
+ * for each tile's image URL. WebCodecsTileProvider decodes per-tile frames in
+ * filmstrip-worker.ts, downscaled, cached as object URLs (sharp, density-aware);
+ * whole-file inputs only. `createTileProvider` returns null for huge/progressive
+ * files or a WebView without WebCodecs — the clip bar then keeps its existing
+ * stretched Rust-strip rendering. Only on-screen tiles are ever requested, so
+ * decode work tracks what virtualization shows.
+ */
+
+import { chooseIngestion } from "../playback/mp4-sample-table";
+import { type FilmstripTile, LruCache } from "./filmstrip";
+import type { FromFilmstripWorker, ToFilmstripWorker } from "./filmstrip-protocol";
+
+export interface TileProvider {
+	/** The image URL for a planned tile, or undefined while it's still decoding. */
+	get(tile: FilmstripTile): string | undefined;
+	/** Ensure these (already virtualized) tiles get decoded. */
+	request(tiles: FilmstripTile[]): void;
+	/** A decoded frame URL near `originalSec` for hover-scrub, or undefined while
+	 *  it decodes (the call also queues the decode). */
+	previewAt(originalSec: number): string | undefined;
+	dispose(): void;
+}
+
+/** Hover-scrub time bucket (seconds) — coarser than the filmstrip so dragging the
+ *  cursor doesn't decode a frame per pixel. */
+const HOVER_QUANTUM = 0.05;
+
+/** Decoded thumbnail URLs kept resident. Covers a wide viewport plus overscan
+ *  across a couple of zoom levels; eviction revokes the object URL. */
+const MAX_TILES = 240;
+
+class WebCodecsTileProvider implements TileProvider {
+	#worker: Worker;
+	#cache: LruCache<string>;
+	/** cacheKeys currently being decoded by the worker. */
+	#inflight = new Set<string>();
+	/** Worker request id → cacheKey, to file the reply. */
+	#idToKey = new Map<number, string>();
+	#nextId = 0;
+	#onChange: () => void;
+	/** cacheKey → sample time, batched and flushed once per frame. */
+	#pending = new Map<string, number>();
+	#flushScheduled = false;
+	#disposed = false;
+
+	private constructor(worker: Worker, onChange: () => void) {
+		this.#worker = worker;
+		this.#onChange = onChange;
+		this.#cache = new LruCache<string>(MAX_TILES, (url) =>
+			URL.revokeObjectURL(url),
+		);
+		this.#worker.onmessage = (e: MessageEvent<FromFilmstripWorker>) =>
+			this.#onMessage(e.data);
+	}
+
+	static async create(
+		url: string,
+		tileHeightPx: number,
+		onChange: () => void,
+	): Promise<WebCodecsTileProvider> {
+		const res = await fetch(url);
+		if (!res.ok) throw new Error(`fetch failed: HTTP ${res.status}`);
+		const buffer = await res.arrayBuffer();
+		const worker = new Worker(
+			new URL("./filmstrip-worker.ts", import.meta.url),
+			{ type: "module" },
+		);
+		try {
+			await new Promise<void>((resolve, reject) => {
+				worker.onmessage = (e: MessageEvent<FromFilmstripWorker>) => {
+					const m = e.data;
+					if (m.type === "ready") resolve();
+					else if (m.type === "error") reject(new Error(m.message));
+				};
+				worker.onerror = (e) =>
+					reject(new Error(e.message || "filmstrip worker error"));
+				const init: ToFilmstripWorker = { type: "init", buffer, tileHeightPx };
+				worker.postMessage(init, [buffer]);
+			});
+		} catch (err) {
+			worker.terminate();
+			throw err;
+		}
+		return new WebCodecsTileProvider(worker, onChange);
+	}
+
+	get(tile: FilmstripTile): string | undefined {
+		return this.#cache.get(tile.cacheKey);
+	}
+
+	request(tiles: FilmstripTile[]): void {
+		if (this.#disposed) return;
+		for (const t of tiles) {
+			if (
+				this.#cache.has(t.cacheKey) ||
+				this.#inflight.has(t.cacheKey) ||
+				this.#pending.has(t.cacheKey)
+			) {
+				continue;
+			}
+			this.#pending.set(t.cacheKey, t.sampleOriginalSec);
+		}
+		this.#scheduleFlush();
+	}
+
+	previewAt(originalSec: number): string | undefined {
+		if (this.#disposed) return undefined;
+		// Own cache namespace so hover frames don't collide with filmstrip tiles.
+		const cacheKey = `hover:${Math.round(originalSec / HOVER_QUANTUM)}`;
+		const cached = this.#cache.get(cacheKey);
+		if (cached) return cached;
+		if (!this.#inflight.has(cacheKey) && !this.#pending.has(cacheKey)) {
+			this.#pending.set(cacheKey, Math.max(0, originalSec));
+			this.#scheduleFlush();
+		}
+		return undefined;
+	}
+
+	#scheduleFlush(): void {
+		if (this.#pending.size > 0 && !this.#flushScheduled) {
+			this.#flushScheduled = true;
+			requestAnimationFrame(() => this.#flush());
+		}
+	}
+
+	#flush(): void {
+		this.#flushScheduled = false;
+		if (this.#disposed || this.#pending.size === 0) return;
+		const requests: Array<{ id: number; originalSec: number }> = [];
+		for (const [cacheKey, originalSec] of this.#pending) {
+			const id = this.#nextId++;
+			this.#idToKey.set(id, cacheKey);
+			this.#inflight.add(cacheKey);
+			requests.push({ id, originalSec });
+		}
+		this.#pending.clear();
+		const msg: ToFilmstripWorker = { type: "decode", requests };
+		this.#worker.postMessage(msg);
+	}
+
+	#onMessage(msg: FromFilmstripWorker): void {
+		if (msg.type === "error") {
+			console.error("filmstrip worker:", msg.message);
+			return;
+		}
+		if (msg.type !== "tile") return;
+		const cacheKey = this.#idToKey.get(msg.id);
+		this.#idToKey.delete(msg.id);
+		if (cacheKey === undefined) return;
+		this.#inflight.delete(cacheKey);
+		if (this.#disposed) return;
+		this.#cache.set(cacheKey, URL.createObjectURL(msg.blob));
+		this.#onChange();
+	}
+
+	dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		try {
+			const msg: ToFilmstripWorker = { type: "dispose" };
+			this.#worker.postMessage(msg);
+		} catch {
+			/* worker already gone */
+		}
+		this.#worker.terminate();
+		this.#cache.clear(); // revokes every object URL
+		this.#inflight.clear();
+		this.#idToKey.clear();
+		this.#pending.clear();
+	}
+}
+
+export interface TileProviderInput {
+	/** Tauri asset URL of the source video. */
+	url: string;
+	/** Source size (bytes) from the probe; selects whole-file vs progressive. */
+	sizeBytes: number | undefined;
+	/** Device-pixel tile height to decode thumbnails at. */
+	tileHeightPx: number;
+	/** Called when a new tile lands, so the clip bar can repaint. */
+	onChange: () => void;
+}
+
+/**
+ * Build the WebCodecs tile provider for whole-file inputs in a capable WebView.
+ * Returns null for huge/progressive files or on decoder failure — the caller
+ * falls back to the stretched Rust strip. Never throws.
+ */
+export async function createTileProvider(
+	input: TileProviderInput,
+): Promise<TileProvider | null> {
+	const canDecode =
+		chooseIngestion(input.sizeBytes) === "whole" &&
+		typeof Worker !== "undefined" &&
+		typeof VideoFrame !== "undefined";
+	if (!canDecode) return null;
+	try {
+		return await WebCodecsTileProvider.create(
+			input.url,
+			input.tileHeightPx,
+			input.onChange,
+		);
+	} catch (err) {
+		console.warn("Filmstrip decoder unavailable, using strip fallback", err);
+		return null;
+	}
+}

--- a/apps/desktop/src/lib/timeline/filmstrip-worker.ts
+++ b/apps/desktop/src/lib/timeline/filmstrip-worker.ts
@@ -1,0 +1,237 @@
+/// <reference lib="webworker" />
+/**
+ * Filmstrip decode worker — random-access thumbnail extraction, off the main
+ * thread. Separate from the preview decoder (webcodecs-worker.ts) because the
+ * access pattern is the opposite: sparse seeks that decode one frame and stop,
+ * not sequential decode-ahead. Sharing the preview's cache would make the two
+ * fight; here each thumbnail is decoded, downscaled, and the frame released.
+ *
+ * Decode requests are drained from a FIFO queue one batch at a time — the single
+ * decoder can't be driven concurrently. Within a batch, requests are grouped by
+ * GOP keyframe so one keyframe decode serves every tile in it, then matching
+ * frames are drawn onto a small OffscreenCanvas and emitted as JPEG blobs.
+ * Whole-file ingestion only; the provider routes huge/progressive files to the
+ * Rust strip fallback instead. The provider only enqueues on-screen tiles, so
+ * the queue stays bounded by what virtualization asks for.
+ */
+
+import {
+	buildKeyframes,
+	buildPresOrder,
+	type ChunkMeta,
+	keyframeAtOrBefore,
+	sampleAtOrBefore,
+} from "../playback/frame-index";
+import { demuxWholeFile } from "../playback/mp4-demux";
+import type { FromFilmstripWorker, ToFilmstripWorker } from "./filmstrip-protocol";
+
+const ctx = self as unknown as DedicatedWorkerGlobalScope;
+
+let chunks: ChunkMeta[] = [];
+let keyframes: number[] = [];
+let presOrder: number[] = [];
+let decoder: VideoDecoder | null = null;
+let config: VideoDecoderConfig | null = null;
+let canvas: OffscreenCanvas | null = null;
+let canvasCtx: OffscreenCanvasRenderingContext2D | null = null;
+let thumbW = 2;
+let thumbH = 2;
+let disposed = false;
+
+/** Pending tile requests; drained one batch at a time by `drain`. */
+let queue: Array<{ id: number; originalSec: number }> = [];
+let draining = false;
+/** Frames decoded for the GOP currently in flight (the output callback fills it). */
+let gopFrames: VideoFrame[] = [];
+
+function post(msg: FromFilmstripWorker, transfer: Transferable[] = []): void {
+	ctx.postMessage(msg, transfer);
+}
+
+function makeDecoder(): VideoDecoder {
+	return new VideoDecoder({
+		output: (frame) => {
+			if (disposed) {
+				frame.close();
+				return;
+			}
+			gopFrames.push(frame);
+		},
+		error: (e) => post({ type: "error", message: String(e) }),
+	});
+}
+
+async function init(buffer: ArrayBuffer, tileHeightPx: number): Promise<void> {
+	try {
+		const res = await demuxWholeFile(buffer);
+		chunks = res.chunks;
+		keyframes = buildKeyframes(chunks);
+		presOrder = buildPresOrder(chunks);
+		config = res.config;
+		const aspect = res.height > 0 ? res.width / res.height : 16 / 9;
+		thumbH = Math.max(2, Math.round(tileHeightPx));
+		thumbW = Math.max(2, Math.round(thumbH * aspect));
+		canvas = new OffscreenCanvas(thumbW, thumbH);
+		canvasCtx = canvas.getContext("2d");
+		decoder = makeDecoder();
+		decoder.configure(config);
+		post({
+			type: "ready",
+			width: res.width,
+			height: res.height,
+			durationSec: res.durationSec,
+			fps: res.fps,
+		});
+	} catch (err) {
+		post({
+			type: "error",
+			message: err instanceof Error ? err.message : String(err),
+		});
+	}
+}
+
+interface TileItem {
+	id: number;
+	sample: number;
+	targetTs: number;
+	kf: number;
+}
+
+function enqueue(requests: Array<{ id: number; originalSec: number }>): void {
+	queue.push(...requests);
+	if (!draining) void drain();
+}
+
+/** Process queued requests one batch at a time until the queue empties. */
+async function drain(): Promise<void> {
+	draining = true;
+	while (queue.length > 0 && !disposed) {
+		const batch = queue;
+		queue = [];
+		await decodeBatch(batch);
+	}
+	draining = false;
+}
+
+async function decodeBatch(
+	requests: Array<{ id: number; originalSec: number }>,
+): Promise<void> {
+	if (disposed || !decoder || !config || chunks.length === 0) return;
+
+	const items: TileItem[] = requests.map((r) => {
+		const tUs = Math.max(0, Math.round(r.originalSec * 1e6));
+		const sample = sampleAtOrBefore(chunks, presOrder, tUs);
+		return {
+			id: r.id,
+			sample,
+			targetTs: chunks[sample].ctsUs,
+			kf: keyframeAtOrBefore(keyframes, sample),
+		};
+	});
+
+	const byGop = new Map<number, TileItem[]>();
+	for (const it of items) {
+		const list = byGop.get(it.kf);
+		if (list) list.push(it);
+		else byGop.set(it.kf, [it]);
+	}
+
+	// Ascending so the decoder feeds forward through the file.
+	for (const kf of [...byGop.keys()].sort((a, b) => a - b)) {
+		if (disposed) return;
+		await decodeGop(kf, byGop.get(kf) as TileItem[]);
+	}
+}
+
+async function decodeGop(kf: number, reqs: TileItem[]): Promise<void> {
+	if (!decoder || !config) return;
+	const feedEnd = Math.min(
+		Math.max(...reqs.map((r) => r.sample)),
+		chunks.length - 1,
+	);
+
+	gopFrames = [];
+	decoder.reset();
+	decoder.configure(config);
+	for (let i = kf; i <= feedEnd; i++) {
+		const c = chunks[i];
+		decoder.decode(
+			new EncodedVideoChunk({
+				type: c.key ? "key" : "delta",
+				timestamp: c.ctsUs,
+				duration: c.durUs,
+				data: c.data as Uint8Array,
+			}),
+		);
+	}
+	await decoder.flush();
+
+	const frames = gopFrames;
+	gopFrames = [];
+	if (disposed) {
+		for (const f of frames) f.close();
+		return;
+	}
+
+	for (const req of reqs) {
+		const frame = pickFrame(frames, req.targetTs);
+		if (frame && canvasCtx && canvas) {
+			canvasCtx.drawImage(frame, 0, 0, thumbW, thumbH);
+			const blob = await canvas.convertToBlob({
+				type: "image/jpeg",
+				quality: 0.72,
+			});
+			if (disposed) break;
+			post({ type: "tile", id: req.id, blob });
+		}
+	}
+	for (const f of frames) f.close();
+}
+
+/** The decoded frame at-or-before `targetTs` (closest), or null if none. */
+function pickFrame(frames: VideoFrame[], targetTs: number): VideoFrame | null {
+	let best: VideoFrame | null = null;
+	let bestTs = -Infinity;
+	for (const f of frames) {
+		if (f.timestamp <= targetTs && f.timestamp > bestTs) {
+			bestTs = f.timestamp;
+			best = f;
+		}
+	}
+	// Before the first frame's cts (rare rounding) — fall back to the earliest.
+	if (!best && frames.length > 0) {
+		best = frames.reduce((a, b) => (a.timestamp <= b.timestamp ? a : b));
+	}
+	return best;
+}
+
+function dispose(): void {
+	if (disposed) return;
+	disposed = true;
+	queue = [];
+	for (const f of gopFrames) f.close();
+	gopFrames = [];
+	try {
+		if (decoder && decoder.state !== "closed") decoder.close();
+	} catch {
+		/* already closing */
+	}
+	decoder = null;
+	chunks = [];
+	ctx.close();
+}
+
+ctx.onmessage = (e: MessageEvent<ToFilmstripWorker>) => {
+	const msg = e.data;
+	switch (msg.type) {
+		case "init":
+			void init(msg.buffer, msg.tileHeightPx);
+			break;
+		case "decode":
+			enqueue(msg.requests);
+			break;
+		case "dispose":
+			dispose();
+			break;
+	}
+};

--- a/apps/desktop/src/lib/timeline/filmstrip-worker.ts
+++ b/apps/desktop/src/lib/timeline/filmstrip-worker.ts
@@ -24,6 +24,7 @@ import {
 } from "../playback/frame-index";
 import { demuxWholeFile } from "../playback/mp4-demux";
 import type { FromFilmstripWorker, ToFilmstripWorker } from "./filmstrip-protocol";
+import { planStoryboard, storyboardSampleSec } from "./storyboard";
 
 const ctx = self as unknown as DedicatedWorkerGlobalScope;
 
@@ -36,10 +37,14 @@ let canvas: OffscreenCanvas | null = null;
 let canvasCtx: OffscreenCanvasRenderingContext2D | null = null;
 let thumbW = 2;
 let thumbH = 2;
+let videoDurationSec = 0;
 let disposed = false;
 
 /** Pending tile requests; drained one batch at a time by `drain`. */
 let queue: Array<{ id: number; originalSec: number }> = [];
+/** Set when the storyboard sprite has been requested; built once the tile
+ *  queue is idle so on-screen filmstrip tiles aren't starved by it. */
+let storyboardPending = false;
 let draining = false;
 /** Frames decoded for the GOP currently in flight (the output callback fills it). */
 let gopFrames: VideoFrame[] = [];
@@ -71,6 +76,7 @@ async function init(buffer: ArrayBuffer, tileHeightPx: number): Promise<void> {
 		const aspect = res.height > 0 ? res.width / res.height : 16 / 9;
 		thumbH = Math.max(2, Math.round(tileHeightPx));
 		thumbW = Math.max(2, Math.round(thumbH * aspect));
+		videoDurationSec = res.durationSec;
 		canvas = new OffscreenCanvas(thumbW, thumbH);
 		canvasCtx = canvas.getContext("2d");
 		decoder = makeDecoder();
@@ -102,15 +108,40 @@ function enqueue(requests: Array<{ id: number; originalSec: number }>): void {
 	if (!draining) void drain();
 }
 
-/** Process queued requests one batch at a time until the queue empties. */
+function requestStoryboard(): void {
+	storyboardPending = true;
+	if (!draining) void drain();
+}
+
+/** Process queued requests one batch at a time until the queue empties, then
+ *  build the storyboard if asked. Both share the single decoder, so they must
+ *  run serially; on-screen tiles take priority over the storyboard. Each op is
+ *  isolated in try/catch and `draining` resets in `finally`, so one decode
+ *  failure can't wedge the loop and stall every later thumbnail/preview. */
 async function drain(): Promise<void> {
 	draining = true;
-	while (queue.length > 0 && !disposed) {
-		const batch = queue;
-		queue = [];
-		await decodeBatch(batch);
+	try {
+		while ((queue.length > 0 || storyboardPending) && !disposed) {
+			if (queue.length > 0) {
+				const batch = queue;
+				queue = [];
+				try {
+					await decodeBatch(batch);
+				} catch (err) {
+					post({ type: "error", message: `tile decode: ${String(err)}` });
+				}
+			} else if (storyboardPending) {
+				storyboardPending = false;
+				try {
+					await buildStoryboard();
+				} catch (err) {
+					post({ type: "error", message: `storyboard: ${String(err)}` });
+				}
+			}
+		}
+	} finally {
+		draining = false;
 	}
-	draining = false;
 }
 
 async function decodeBatch(
@@ -188,6 +219,108 @@ async function decodeGop(kf: number, reqs: TileItem[]): Promise<void> {
 	for (const f of frames) f.close();
 }
 
+/**
+ * Build the storyboard sprite: decode `count` frames evenly spaced across the
+ * duration and pack them into one `cols`×`rows` canvas, GOP-grouped like the
+ * tile path so a keyframe decode serves every cell in its GOP. Emitted as a
+ * single JPEG so hover-scrub crops a cell instead of decoding per position.
+ */
+async function buildStoryboard(): Promise<void> {
+	if (disposed || !decoder || !config || chunks.length === 0) return;
+	const duration = videoDurationSec;
+	if (duration <= 0) return;
+
+	// Grid sizing shared with the hover preview (storyboard.ts), so both agree.
+	const { count, cols, rows } = planStoryboard(duration);
+	const cellW = thumbW;
+	const cellH = thumbH;
+	const sheet = new OffscreenCanvas(cols * cellW, rows * cellH);
+	const sheetCtx = sheet.getContext("2d");
+	if (!sheetCtx) return;
+
+	// One cell per evenly-spaced sample time; group by GOP like decodeBatch.
+	const items = Array.from({ length: count }, (_, cell) => {
+		const tUs = Math.max(
+			0,
+			Math.round(storyboardSampleSec(cell, count, duration) * 1e6),
+		);
+		const sample = sampleAtOrBefore(chunks, presOrder, tUs);
+		return {
+			cell,
+			sample,
+			targetTs: chunks[sample].ctsUs,
+			kf: keyframeAtOrBefore(keyframes, sample),
+		};
+	});
+	const byGop = new Map<number, typeof items>();
+	for (const it of items) {
+		const list = byGop.get(it.kf);
+		if (list) list.push(it);
+		else byGop.set(it.kf, [it]);
+	}
+
+	for (const kf of [...byGop.keys()].sort((a, b) => a - b)) {
+		if (disposed) return;
+		// On-screen tiles / hover-scrub frames jump ahead between GOPs, so the
+		// preview stays responsive while the (slower) full storyboard builds.
+		while (queue.length > 0 && !disposed) {
+			const batch = queue;
+			queue = [];
+			await decodeBatch(batch);
+		}
+		if (disposed) return;
+		const reqs = byGop.get(kf) as typeof items;
+		const feedEnd = Math.min(
+			Math.max(...reqs.map((r) => r.sample)),
+			chunks.length - 1,
+		);
+		gopFrames = [];
+		decoder.reset();
+		decoder.configure(config);
+		for (let i = kf; i <= feedEnd; i++) {
+			const c = chunks[i];
+			decoder.decode(
+				new EncodedVideoChunk({
+					type: c.key ? "key" : "delta",
+					timestamp: c.ctsUs,
+					duration: c.durUs,
+					data: c.data as Uint8Array,
+				}),
+			);
+		}
+		await decoder.flush();
+		const frames = gopFrames;
+		gopFrames = [];
+		if (disposed) {
+			for (const f of frames) f.close();
+			return;
+		}
+		for (const req of reqs) {
+			const frame = pickFrame(frames, req.targetTs);
+			if (frame) {
+				const col = req.cell % cols;
+				const row = Math.floor(req.cell / cols);
+				sheetCtx.drawImage(frame, col * cellW, row * cellH, cellW, cellH);
+			}
+		}
+		for (const f of frames) f.close();
+	}
+
+	if (disposed) return;
+	const blob = await sheet.convertToBlob({ type: "image/jpeg", quality: 0.72 });
+	if (disposed) return;
+	post({
+		type: "storyboard",
+		blob,
+		cols,
+		rows,
+		cellW,
+		cellH,
+		count,
+		durationSec: duration,
+	});
+}
+
 /** The decoded frame at-or-before `targetTs` (closest), or null if none. */
 function pickFrame(frames: VideoFrame[], targetTs: number): VideoFrame | null {
 	let best: VideoFrame | null = null;
@@ -229,6 +362,9 @@ ctx.onmessage = (e: MessageEvent<ToFilmstripWorker>) => {
 			break;
 		case "decode":
 			enqueue(msg.requests);
+			break;
+		case "storyboard":
+			requestStoryboard();
 			break;
 		case "dispose":
 			dispose();

--- a/apps/desktop/src/lib/timeline/filmstrip.test.ts
+++ b/apps/desktop/src/lib/timeline/filmstrip.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+	type FilmstripBlock,
+	LruCache,
+	planFilmstrip,
+} from "./filmstrip";
+
+function block(
+	key: number,
+	leftPx: number,
+	widthPx: number,
+	originalStart: number,
+	originalEnd: number,
+): FilmstripBlock {
+	return { key, leftPx, widthPx, originalStart, originalEnd };
+}
+
+const WIDE_VIEW = { leftPx: 0, widthPx: 100000 };
+
+describe("planFilmstrip density", () => {
+	it("scales tile count with block width / target", () => {
+		const tiles = planFilmstrip(
+			[block(0, 0, 1000, 0, 10)],
+			WIDE_VIEW,
+			{ tileWidthPx: 100, tileHeightPx: 48 },
+		);
+		expect(tiles).toHaveLength(10);
+	});
+
+	it("rounds the count up so the block is fully covered", () => {
+		const tiles = planFilmstrip(
+			[block(0, 0, 950, 0, 10)],
+			WIDE_VIEW,
+			{ tileWidthPx: 100, tileHeightPx: 48 },
+		);
+		expect(tiles).toHaveLength(10);
+		// Tiles evenly divide the block (no remainder sliver).
+		const total = tiles.reduce((s, t) => s + t.widthPx, 0);
+		expect(total).toBeCloseTo(950);
+	});
+
+	it("always emits at least one tile for a thin block", () => {
+		const tiles = planFilmstrip(
+			[block(0, 0, 12, 0, 0.5)],
+			WIDE_VIEW,
+			{ tileWidthPx: 100, tileHeightPx: 48 },
+		);
+		expect(tiles).toHaveLength(1);
+	});
+});
+
+describe("planFilmstrip virtualization", () => {
+	const blocks = [block(0, 0, 4000, 0, 40)];
+
+	it("emits only tiles intersecting the viewport", () => {
+		const tiles = planFilmstrip(
+			blocks,
+			{ leftPx: 1000, widthPx: 200 },
+			{ tileWidthPx: 100, tileHeightPx: 48 },
+		);
+		// Window [1000,1200] over 100px tiles → the 2 covered tiles plus the two
+		// boundary-touchers, never all 40.
+		expect(tiles.length).toBeLessThanOrEqual(4);
+		for (const t of tiles) {
+			expect(t.offsetPx + t.widthPx).toBeGreaterThanOrEqual(1000);
+			expect(t.offsetPx).toBeLessThanOrEqual(1200);
+		}
+	});
+
+	it("widens the window by overscan", () => {
+		const tight = planFilmstrip(
+			blocks,
+			{ leftPx: 1000, widthPx: 200 },
+			{ tileWidthPx: 100, tileHeightPx: 48 },
+		);
+		const padded = planFilmstrip(
+			blocks,
+			{ leftPx: 1000, widthPx: 200 },
+			{ tileWidthPx: 100, tileHeightPx: 48, overscanPx: 300 },
+		);
+		expect(padded.length).toBeGreaterThan(tight.length);
+	});
+
+	it("drops blocks entirely outside the viewport", () => {
+		const tiles = planFilmstrip(
+			[block(0, 0, 500, 0, 5), block(1, 5000, 500, 50, 55)],
+			{ leftPx: 0, widthPx: 600 },
+			{ tileWidthPx: 100, tileHeightPx: 48 },
+		);
+		expect(tiles.every((t) => t.blockKey === 0)).toBe(true);
+	});
+});
+
+describe("planFilmstrip sample time", () => {
+	it("interpolates the sample across the block's original range", () => {
+		const tiles = planFilmstrip(
+			[block(0, 0, 400, 10, 14)],
+			WIDE_VIEW,
+			{ tileWidthPx: 100, tileHeightPx: 48 },
+		);
+		// 4 tiles, centers at 12.5/37.5/62.5/87.5% of [10,14].
+		expect(tiles.map((t) => t.sampleOriginalSec)).toEqual([10.5, 11.5, 12.5, 13.5]);
+	});
+
+	it("is speed-agnostic: sample depends on original span, not output width", () => {
+		// Same original range [0,4], but a 2x segment is half as wide on output.
+		const slow = planFilmstrip(
+			[block(0, 0, 400, 0, 4)],
+			WIDE_VIEW,
+			{ tileWidthPx: 100, tileHeightPx: 48 },
+		);
+		const fast = planFilmstrip(
+			[block(0, 0, 200, 0, 4)],
+			WIDE_VIEW,
+			{ tileWidthPx: 100, tileHeightPx: 48 },
+		);
+		// Fewer tiles when faster, but each still samples within [0,4].
+		expect(fast.length).toBeLessThan(slow.length);
+		for (const t of fast) {
+			expect(t.sampleOriginalSec).toBeGreaterThanOrEqual(0);
+			expect(t.sampleOriginalSec).toBeLessThanOrEqual(4);
+		}
+	});
+
+	it("buckets the cache key by tile height and quantized time", () => {
+		const [tile] = planFilmstrip(
+			[block(0, 0, 100, 2, 2.02)],
+			WIDE_VIEW,
+			{ tileWidthPx: 100, tileHeightPx: 48 },
+		);
+		// center = 2.01s → bucket 201 at 10ms quantum.
+		expect(tile.cacheKey).toBe("48:201");
+	});
+});
+
+describe("LruCache", () => {
+	it("evicts the least-recently-used entry past max", () => {
+		const evicted: string[] = [];
+		const lru = new LruCache<string>(2, (v) => evicted.push(v));
+		lru.set("a", "A");
+		lru.set("b", "B");
+		lru.set("c", "C"); // evicts "a"
+		expect(lru.has("a")).toBe(false);
+		expect(evicted).toEqual(["A"]);
+	});
+
+	it("a read refreshes recency so the entry survives eviction", () => {
+		const evicted: string[] = [];
+		const lru = new LruCache<string>(2, (v) => evicted.push(v));
+		lru.set("a", "A");
+		lru.set("b", "B");
+		lru.get("a"); // "a" now newest
+		lru.set("c", "C"); // evicts "b", not "a"
+		expect(lru.has("a")).toBe(true);
+		expect(lru.has("b")).toBe(false);
+		expect(evicted).toEqual(["B"]);
+	});
+
+	it("re-setting an existing key updates value without growing size", () => {
+		const lru = new LruCache<string>(2);
+		lru.set("a", "A");
+		lru.set("a", "A2");
+		expect(lru.size).toBe(1);
+		expect(lru.get("a")).toBe("A2");
+	});
+
+	it("clear evicts everything", () => {
+		const evicted: string[] = [];
+		const lru = new LruCache<string>(4, (v) => evicted.push(v));
+		lru.set("a", "A");
+		lru.set("b", "B");
+		lru.clear();
+		expect(lru.size).toBe(0);
+		expect(evicted.sort()).toEqual(["A", "B"]);
+	});
+});

--- a/apps/desktop/src/lib/timeline/filmstrip.ts
+++ b/apps/desktop/src/lib/timeline/filmstrip.ts
@@ -1,0 +1,166 @@
+/**
+ * Filmstrip layout: density-based, virtualized thumbnail tiling for the clip bar.
+ *
+ * Replaces the old fixed 8–12 stretched strip. Tiles are laid per kept segment
+ * block on the OUTPUT axis (each block is cut-free internally), and the count
+ * scales with the block's pixel width — so a long clip gets more, sharper tiles
+ * instead of a dozen blurry stretched ones, and zooming in adds tiles rather
+ * than magnifying the same images.
+ *
+ * A tile's sample time is interpolated across the block's ORIGINAL range, so it
+ * stays correct under per-segment speed for free: speeding a segment narrows its
+ * output width (fewer tiles) without touching its original span. Only tiles that
+ * intersect the viewport (plus overscan) are emitted — the decoder never works on
+ * off-screen frames. See ./time-map.ts for the axis the block widths come from.
+ */
+
+/** A kept segment block placed on the output axis. */
+export interface FilmstripBlock {
+	/** Stable identity (the segment's original start). */
+	key: number;
+	/** Block start on the output axis, px. */
+	leftPx: number;
+	/** Block width on the output axis, px (already reflects speed). */
+	widthPx: number;
+	/** Block start on the original-recording timeline, seconds. */
+	originalStart: number;
+	/** Block end on the original-recording timeline, seconds. */
+	originalEnd: number;
+}
+
+export interface FilmstripViewport {
+	/** Horizontal scroll offset of the timeline content, px. */
+	leftPx: number;
+	/** Visible width, px. */
+	widthPx: number;
+}
+
+export interface FilmstripOptions {
+	/** Target tile width, px; tiles per block = ceil(blockWidth / this). */
+	tileWidthPx: number;
+	/** Tile height, px — part of the cache key, since sharpness depends on it. */
+	tileHeightPx: number;
+	/** Extra px decoded beyond each viewport edge. Default 0. */
+	overscanPx?: number;
+}
+
+export interface FilmstripTile {
+	/** Owning block's key, for rendering inside the per-block container. */
+	blockKey: number;
+	/** Offset within the block, px (block containers are overflow-hidden). */
+	offsetPx: number;
+	/** Tile width, px. */
+	widthPx: number;
+	/** Original-recording time to decode for this tile, seconds. */
+	sampleOriginalSec: number;
+	/** Stable LRU key: tile height + quantized sample time. */
+	cacheKey: string;
+}
+
+/** Cache-key time bucket (seconds): coarse enough to reuse tiles across small
+ *  zoom/scroll changes, fine enough that adjacent tiles stay distinct. */
+const TIME_QUANTUM = 0.01;
+
+function intersects(
+	leftPx: number,
+	rightPx: number,
+	viewLeft: number,
+	viewRight: number,
+): boolean {
+	return rightPx >= viewLeft && leftPx <= viewRight;
+}
+
+/**
+ * Plan the visible tiles across the given blocks. Off-screen blocks and tiles
+ * are dropped (virtualization); each surviving tile carries the original time to
+ * decode and a stable cache key.
+ */
+export function planFilmstrip(
+	blocks: FilmstripBlock[],
+	viewport: FilmstripViewport,
+	opts: FilmstripOptions,
+): FilmstripTile[] {
+	const overscan = opts.overscanPx ?? 0;
+	const tileTarget = Math.max(8, opts.tileWidthPx);
+	const viewLeft = viewport.leftPx - overscan;
+	const viewRight = viewport.leftPx + viewport.widthPx + overscan;
+
+	const tiles: FilmstripTile[] = [];
+	for (const block of blocks) {
+		if (block.widthPx <= 0) continue;
+		if (!intersects(block.leftPx, block.leftPx + block.widthPx, viewLeft, viewRight)) {
+			continue;
+		}
+		const count = Math.max(1, Math.ceil(block.widthPx / tileTarget));
+		const tileW = block.widthPx / count;
+		const origSpan = block.originalEnd - block.originalStart;
+		for (let i = 0; i < count; i++) {
+			const tileLeftAbs = block.leftPx + i * tileW;
+			if (!intersects(tileLeftAbs, tileLeftAbs + tileW, viewLeft, viewRight)) {
+				continue;
+			}
+			const centerFrac = (i + 0.5) / count;
+			const sampleOriginalSec = block.originalStart + centerFrac * origSpan;
+			const bucket = Math.round(sampleOriginalSec / TIME_QUANTUM);
+			tiles.push({
+				blockKey: block.key,
+				offsetPx: i * tileW,
+				widthPx: tileW,
+				sampleOriginalSec,
+				cacheKey: `${opts.tileHeightPx}:${bucket}`,
+			});
+		}
+	}
+	return tiles;
+}
+
+/**
+ * Bounded LRU keyed by string. Reads refresh recency; inserts past `max` evict
+ * the least-recently-used entry and call `onEvict` — the hook that closes an
+ * ImageBitmap so decoded tiles don't leak GPU memory.
+ */
+export class LruCache<V> {
+	#max: number;
+	#map = new Map<string, V>();
+	#onEvict?: (value: V) => void;
+
+	constructor(max: number, onEvict?: (value: V) => void) {
+		this.#max = Math.max(1, max);
+		this.#onEvict = onEvict;
+	}
+
+	get size(): number {
+		return this.#map.size;
+	}
+
+	has(key: string): boolean {
+		return this.#map.has(key);
+	}
+
+	get(key: string): V | undefined {
+		const value = this.#map.get(key);
+		if (value === undefined) return undefined;
+		// Refresh recency: re-insert moves the key to the newest position.
+		this.#map.delete(key);
+		this.#map.set(key, value);
+		return value;
+	}
+
+	set(key: string, value: V): void {
+		if (this.#map.has(key)) this.#map.delete(key);
+		this.#map.set(key, value);
+		while (this.#map.size > this.#max) {
+			const oldest = this.#map.keys().next().value as string;
+			const evicted = this.#map.get(oldest) as V;
+			this.#map.delete(oldest);
+			this.#onEvict?.(evicted);
+		}
+	}
+
+	clear(): void {
+		if (this.#onEvict) {
+			for (const value of this.#map.values()) this.#onEvict(value);
+		}
+		this.#map.clear();
+	}
+}

--- a/apps/desktop/src/lib/timeline/segment-speed.test.ts
+++ b/apps/desktop/src/lib/timeline/segment-speed.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildSpeedOf,
+	clampSpeed,
+	MAX_SEGMENT_SPEED,
+	MIN_SEGMENT_SPEED,
+	pruneSegmentSpeeds,
+	type SegmentSpeed,
+	segmentSpeedAt,
+	setSegmentSpeed,
+} from "./segment-speed";
+import { deriveSegments, type Segment } from "./segments";
+import { timeMapFromSegments } from "./time-map";
+import speedParity from "./__fixtures__/speed-parity.json";
+
+function seg(start: number, end: number, index: number): Segment {
+	return { start, end, index };
+}
+
+describe("clampSpeed", () => {
+	it("keeps in-range values", () => {
+		expect(clampSpeed(2)).toBe(2);
+	});
+	it("clamps to the supported bounds", () => {
+		expect(clampSpeed(99)).toBe(MAX_SEGMENT_SPEED);
+		expect(clampSpeed(0.01)).toBe(MIN_SEGMENT_SPEED);
+	});
+	it("resets a non-positive or non-finite value to 1", () => {
+		expect(clampSpeed(0)).toBe(1);
+		expect(clampSpeed(-3)).toBe(1);
+		expect(clampSpeed(Number.NaN)).toBe(1);
+	});
+});
+
+describe("segmentSpeedAt", () => {
+	const overrides: SegmentSpeed[] = [{ start: 4, speed: 2 }];
+	it("returns the matching speed within tolerance", () => {
+		expect(segmentSpeedAt(overrides, 4)).toBe(2);
+		expect(segmentSpeedAt(overrides, 4.00005)).toBe(2);
+	});
+	it("returns 1 for an unmatched anchor", () => {
+		expect(segmentSpeedAt(overrides, 5)).toBe(1);
+		expect(segmentSpeedAt([], 4)).toBe(1);
+	});
+});
+
+describe("setSegmentSpeed", () => {
+	it("inserts a new override, sorted by start", () => {
+		const out = setSegmentSpeed([{ start: 6, speed: 2 }], 2, 0.5);
+		expect(out).toEqual([
+			{ start: 2, speed: 0.5 },
+			{ start: 6, speed: 2 },
+		]);
+	});
+	it("replaces an existing anchor in place", () => {
+		const out = setSegmentSpeed([{ start: 2, speed: 2 }], 2, 3);
+		expect(out).toEqual([{ start: 2, speed: 3 }]);
+	});
+	it("removes the entry when set back to 1 (stays sparse)", () => {
+		expect(setSegmentSpeed([{ start: 2, speed: 2 }], 2, 1)).toEqual([]);
+	});
+	it("clamps the stored value", () => {
+		expect(setSegmentSpeed([], 2, 99)).toEqual([
+			{ start: 2, speed: MAX_SEGMENT_SPEED },
+		]);
+	});
+	it("does not mutate the input", () => {
+		const input: SegmentSpeed[] = [{ start: 2, speed: 2 }];
+		setSegmentSpeed(input, 2, 3);
+		expect(input).toEqual([{ start: 2, speed: 2 }]);
+	});
+});
+
+describe("pruneSegmentSpeeds", () => {
+	it("keeps anchors that still match a segment start", () => {
+		const segs = [seg(2, 4, 0), seg(4, 8, 1)];
+		const overrides: SegmentSpeed[] = [
+			{ start: 2, speed: 2 },
+			{ start: 9, speed: 0.5 },
+		];
+		expect(pruneSegmentSpeeds(overrides, segs)).toEqual([{ start: 2, speed: 2 }]);
+	});
+	it("returns empty for empty input", () => {
+		expect(pruneSegmentSpeeds([], [seg(0, 1, 0)])).toEqual([]);
+	});
+});
+
+describe("speed parity (shared fixtures with Rust export)", () => {
+	// Loaded VERBATIM by the Rust export test too
+	// (editor.rs::warped_duration_matches_shared_parity_fixtures). The frontend
+	// playback time-map's output duration must equal the export's warped duration
+	// for every case, or the two speed models have drifted. trimStart is 0.
+	for (const c of speedParity.cases) {
+		it(`warped duration: ${c.name}`, () => {
+			const segments = deriveSegments({
+				trimStart: 0,
+				trimEnd: c.trimEnd,
+				cuts: c.cuts.map(([start, end], i) => ({
+					id: `fx-${i}`,
+					start,
+					end,
+					source: "manual" as const,
+				})),
+				splitPoints: c.splitPoints,
+			});
+			const overrides = c.segmentSpeeds.map(([start, speed]) => ({ start, speed }));
+			const map = timeMapFromSegments(segments, buildSpeedOf(segments, overrides));
+			expect(map.outputDuration).toBeCloseTo(c.expectedOutputDuration, 6);
+		});
+	}
+});
+
+describe("buildSpeedOf", () => {
+	const segs = [seg(2, 4, 0), seg(4, 8, 1)];
+	const overrides: SegmentSpeed[] = [{ start: 4, speed: 2 }];
+	it("maps a segment index to its anchored speed", () => {
+		const speedOf = buildSpeedOf(segs, overrides);
+		expect(speedOf(0)).toBe(1);
+		expect(speedOf(1)).toBe(2);
+	});
+	it("returns 1 for an out-of-range index", () => {
+		expect(buildSpeedOf(segs, overrides)(9)).toBe(1);
+	});
+});

--- a/apps/desktop/src/lib/timeline/segment-speed.test.ts
+++ b/apps/desktop/src/lib/timeline/segment-speed.test.ts
@@ -7,6 +7,7 @@ import {
 	pruneSegmentSpeeds,
 	type SegmentSpeed,
 	segmentSpeedAt,
+	segmentSpeedAtTime,
 	setSegmentSpeed,
 } from "./segment-speed";
 import { deriveSegments, type Segment } from "./segments";
@@ -41,6 +42,27 @@ describe("segmentSpeedAt", () => {
 	it("returns 1 for an unmatched anchor", () => {
 		expect(segmentSpeedAt(overrides, 5)).toBe(1);
 		expect(segmentSpeedAt([], 4)).toBe(1);
+	});
+});
+
+describe("segmentSpeedAtTime", () => {
+	// Two kept segments [0,4] and [4,10]; only the second is sped up.
+	const segments = [seg(0, 4, 0), seg(4, 10, 1)];
+	const overrides: SegmentSpeed[] = [{ start: 4, speed: 2 }];
+
+	it("returns the speed of the segment containing the time", () => {
+		expect(segmentSpeedAtTime(segments, overrides, 1)).toBe(1);
+		expect(segmentSpeedAtTime(segments, overrides, 7)).toBe(2);
+	});
+	it("forward-biases a seam onto the following segment", () => {
+		expect(segmentSpeedAtTime(segments, overrides, 4)).toBe(2);
+	});
+	it("holds the last segment's speed at/after the final frame", () => {
+		expect(segmentSpeedAtTime(segments, overrides, 10)).toBe(2);
+		expect(segmentSpeedAtTime(segments, overrides, 99)).toBe(2);
+	});
+	it("defaults to 1 with no segments", () => {
+		expect(segmentSpeedAtTime([], overrides, 3)).toBe(1);
 	});
 });
 

--- a/apps/desktop/src/lib/timeline/segment-speed.ts
+++ b/apps/desktop/src/lib/timeline/segment-speed.ts
@@ -1,0 +1,81 @@
+/**
+ * Per-segment speed overrides — the data model behind Cap-style "edit this cut
+ * differently". A kept segment can play at a speed other than 1×; an override is
+ * anchored to the segment's ORIGINAL start time, which is stable under cuts and
+ * ripple-deletes (they don't move original times). A trim or split that orphans
+ * an anchor drops it, the same forgiving rule deriveSegments uses for stray
+ * splits. The time-map (./time-map.ts) turns these into the warped output axis.
+ */
+
+import type { Segment } from "./segments";
+
+export const MIN_SEGMENT_SPEED = 0.25;
+export const MAX_SEGMENT_SPEED = 4;
+/** Tolerance for matching an anchor to a segment start. Matches segments.ts. */
+const EPS = 1e-4;
+
+/** A speed pinned to the segment starting at `start` (original seconds). */
+export interface SegmentSpeed {
+	start: number;
+	speed: number;
+}
+
+/** Clamp to the supported range; a non-positive or non-finite value resets to 1. */
+export function clampSpeed(speed: number): number {
+	if (!Number.isFinite(speed) || speed <= 0) return 1;
+	return Math.min(MAX_SEGMENT_SPEED, Math.max(MIN_SEGMENT_SPEED, speed));
+}
+
+/** Speed for the segment starting at `start`, or 1 when unset. */
+export function segmentSpeedAt(
+	overrides: ReadonlyArray<SegmentSpeed>,
+	start: number,
+): number {
+	for (const o of overrides) {
+		if (Math.abs(o.start - start) <= EPS) return o.speed;
+	}
+	return 1;
+}
+
+/**
+ * Upsert a segment's speed, returning a new sorted array. Setting it back to ~1
+ * removes the entry so the override list stays sparse (and serializes to
+ * nothing). The value is clamped to the supported range.
+ */
+export function setSegmentSpeed(
+	overrides: ReadonlyArray<SegmentSpeed>,
+	start: number,
+	speed: number,
+): SegmentSpeed[] {
+	const clamped = clampSpeed(speed);
+	const rest = overrides
+		.filter((o) => Math.abs(o.start - start) > EPS)
+		.map((o) => ({ ...o }));
+	if (Math.abs(clamped - 1) <= EPS) {
+		return rest.sort((a, b) => a.start - b.start);
+	}
+	return [...rest, { start, speed: clamped }].sort((a, b) => a.start - b.start);
+}
+
+/** Drop overrides whose anchor no longer matches a current segment start. */
+export function pruneSegmentSpeeds(
+	overrides: ReadonlyArray<SegmentSpeed>,
+	segments: ReadonlyArray<Segment>,
+): SegmentSpeed[] {
+	if (overrides.length === 0) return [];
+	return overrides
+		.filter((o) => segments.some((s) => Math.abs(s.start - o.start) <= EPS))
+		.map((o) => ({ ...o }))
+		.sort((a, b) => a.start - b.start);
+}
+
+/** A speed lookup by segment index, for `timeMapFromSegments`. */
+export function buildSpeedOf(
+	segments: ReadonlyArray<Segment>,
+	overrides: ReadonlyArray<SegmentSpeed>,
+): (segmentIndex: number) => number {
+	return (segmentIndex) => {
+		const seg = segments[segmentIndex];
+		return seg ? segmentSpeedAt(overrides, seg.start) : 1;
+	};
+}

--- a/apps/desktop/src/lib/timeline/segment-speed.ts
+++ b/apps/desktop/src/lib/timeline/segment-speed.ts
@@ -38,6 +38,26 @@ export function segmentSpeedAt(
 }
 
 /**
+ * Speed of the segment that CONTAINS original time `t`, or 1 when none matches.
+ * Forward-biased at a seam (t on a boundary resolves to the following segment),
+ * and held at the final segment's speed once `t` reaches the last kept frame.
+ * The legacy `<video>` preview reads this to set `playbackRate` per segment.
+ */
+export function segmentSpeedAtTime(
+	segments: ReadonlyArray<Segment>,
+	overrides: ReadonlyArray<SegmentSpeed>,
+	t: number,
+): number {
+	for (const s of segments) {
+		if (t >= s.start - EPS && t < s.end - EPS) {
+			return segmentSpeedAt(overrides, s.start);
+		}
+	}
+	const last = segments[segments.length - 1];
+	return last ? segmentSpeedAt(overrides, last.start) : 1;
+}
+
+/**
  * Upsert a segment's speed, returning a new sorted array. Setting it back to ~1
  * removes the entry so the override list stays sparse (and serializes to
  * nothing). The value is clamped to the supported range.

--- a/apps/desktop/src/lib/timeline/storyboard.test.ts
+++ b/apps/desktop/src/lib/timeline/storyboard.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+	planStoryboard,
+	storyboardCellIndex,
+	storyboardCrop,
+	storyboardSampleSec,
+	type StoryboardMeta,
+} from "./storyboard";
+
+describe("planStoryboard", () => {
+	it("floors short clips at the minimum cell count", () => {
+		expect(planStoryboard(3)).toEqual({ count: 40, cols: 10, rows: 4 });
+		expect(planStoryboard(0)).toEqual({ count: 40, cols: 10, rows: 4 });
+	});
+	it("scales ~1 cell/sec in the mid range", () => {
+		expect(planStoryboard(60)).toEqual({ count: 60, cols: 10, rows: 6 });
+		expect(planStoryboard(95)).toEqual({ count: 95, cols: 10, rows: 10 });
+	});
+	it("caps very long clips at the maximum", () => {
+		expect(planStoryboard(10_000)).toEqual({ count: 200, cols: 10, rows: 20 });
+	});
+	it("rounds the cell count up for fractional durations", () => {
+		expect(planStoryboard(60.2).count).toBe(61);
+	});
+	it("rows always cover every cell", () => {
+		for (const d of [3, 41, 60, 137, 200, 9999]) {
+			const { count, cols, rows } = planStoryboard(d);
+			expect(rows * cols).toBeGreaterThanOrEqual(count);
+			expect((rows - 1) * cols).toBeLessThan(count);
+		}
+	});
+});
+
+describe("storyboardSampleSec", () => {
+	it("samples the centre of each cell", () => {
+		// 40 cells over 40s → cell 0 centres at 0.5s, cell 39 at 39.5s.
+		expect(storyboardSampleSec(0, 40, 40)).toBeCloseTo(0.5);
+		expect(storyboardSampleSec(39, 40, 40)).toBeCloseTo(39.5);
+	});
+	it("is monotonic and inside the clip", () => {
+		const count = 50;
+		let prev = -1;
+		for (let c = 0; c < count; c++) {
+			const t = storyboardSampleSec(c, count, 30);
+			expect(t).toBeGreaterThan(prev);
+			expect(t).toBeGreaterThan(0);
+			expect(t).toBeLessThan(30);
+			prev = t;
+		}
+	});
+	it("guards a zero count", () => {
+		expect(storyboardSampleSec(0, 0, 30)).toBe(0);
+	});
+});
+
+describe("storyboardCellIndex", () => {
+	it("maps a time to the covering cell", () => {
+		// 40 cells over 40s → 1s per cell.
+		expect(storyboardCellIndex(0, 40, 40)).toBe(0);
+		expect(storyboardCellIndex(0.9, 40, 40)).toBe(0);
+		expect(storyboardCellIndex(1, 40, 40)).toBe(1);
+		expect(storyboardCellIndex(24.3, 40, 40)).toBe(24);
+	});
+	it("clamps past the ends", () => {
+		expect(storyboardCellIndex(-5, 40, 40)).toBe(0);
+		expect(storyboardCellIndex(40, 40, 40)).toBe(39);
+		expect(storyboardCellIndex(999, 40, 40)).toBe(39);
+	});
+	it("guards non-positive count or duration", () => {
+		expect(storyboardCellIndex(5, 0, 40)).toBe(0);
+		expect(storyboardCellIndex(5, 40, 0)).toBe(0);
+	});
+});
+
+describe("storyboardCrop", () => {
+	const meta: StoryboardMeta = {
+		cols: 10,
+		rows: 4,
+		cellW: 80,
+		cellH: 48,
+		count: 40,
+		durationSec: 40,
+	};
+
+	it("scales a cell to the display height, preserving aspect", () => {
+		const crop = storyboardCrop(meta, 0, 64);
+		// dispW = 80/48 * 64
+		expect(crop.dispW).toBeCloseTo((80 / 48) * 64);
+		expect(crop.bgW).toBeCloseTo(10 * crop.dispW);
+		expect(crop.bgH).toBe(4 * 64);
+	});
+
+	it("offsets to the cell covering the time (row-major)", () => {
+		// 24s → cell 24 → col 4, row 2.
+		const crop = storyboardCrop(meta, 24, 64);
+		expect(crop.offX).toBeCloseTo(4 * crop.dispW);
+		expect(crop.offY).toBe(2 * 64);
+	});
+
+	it("keeps the crop inside the sheet at the last cell", () => {
+		const crop = storyboardCrop(meta, meta.durationSec, 64);
+		expect(crop.offX + crop.dispW).toBeLessThanOrEqual(crop.bgW + 1e-6);
+		expect(crop.offY + 64).toBeLessThanOrEqual(crop.bgH + 1e-6);
+	});
+
+	it("falls back to a square cell when cellH is missing", () => {
+		const crop = storyboardCrop({ ...meta, cellH: 0 }, 0, 64);
+		expect(crop.dispW).toBe(64);
+	});
+});

--- a/apps/desktop/src/lib/timeline/storyboard.ts
+++ b/apps/desktop/src/lib/timeline/storyboard.ts
@@ -1,0 +1,88 @@
+/**
+ * Pure geometry for the YouTube-style hover storyboard sprite — the grid sizing
+ * (how many cells, the column/row layout) and the time↔cell↔crop mapping. Shared
+ * by the decode worker (filmstrip-worker.ts), which packs frames into the sheet,
+ * and the hover preview (Timeline.svelte), which crops one cell as a CSS
+ * background. Kept here so both sides agree and the math stays unit-tested.
+ */
+
+/** Cells per second of source, before clamping. ~1/sec reads well and keeps the
+ *  decode bounded (it's really bounded by GOP count, not cell count). */
+const MIN_CELLS = 40;
+const MAX_CELLS = 200;
+const MAX_COLS = 10;
+
+/** Grid sizing derived from the clip duration. */
+export interface StoryboardPlan {
+	count: number;
+	cols: number;
+	rows: number;
+}
+
+export function planStoryboard(durationSec: number): StoryboardPlan {
+	const count = Math.min(
+		MAX_CELLS,
+		Math.max(MIN_CELLS, Math.ceil(Math.max(0, durationSec))),
+	);
+	const cols = Math.min(MAX_COLS, count);
+	const rows = Math.ceil(count / cols);
+	return { count, cols, rows };
+}
+
+/** Original-time sampled by cell `cell` — its centre, so the frame represents
+ *  the middle of the cell's slice rather than its leading edge. */
+export function storyboardSampleSec(
+	cell: number,
+	count: number,
+	durationSec: number,
+): number {
+	if (count <= 0) return 0;
+	return ((cell + 0.5) / count) * durationSec;
+}
+
+/** Cell index covering `originalSec`, clamped to [0, count-1]. */
+export function storyboardCellIndex(
+	originalSec: number,
+	count: number,
+	durationSec: number,
+): number {
+	if (count <= 0 || durationSec <= 0) return 0;
+	const i = Math.floor((originalSec / durationSec) * count);
+	return Math.min(count - 1, Math.max(0, i));
+}
+
+/** The built sprite's grid + cell pixel size (no URL — that's the caller's). */
+export interface StoryboardMeta {
+	cols: number;
+	rows: number;
+	cellW: number;
+	cellH: number;
+	count: number;
+	durationSec: number;
+}
+
+/** CSS background geometry to crop the cell covering `originalSec`, scaled so a
+ *  cell renders `displayH` tall (aspect preserved). */
+export interface StoryboardCrop {
+	dispW: number;
+	bgW: number;
+	bgH: number;
+	offX: number;
+	offY: number;
+}
+
+export function storyboardCrop(
+	meta: StoryboardMeta,
+	originalSec: number,
+	displayH: number,
+): StoryboardCrop {
+	const i = storyboardCellIndex(originalSec, meta.count, meta.durationSec);
+	const dispW = meta.cellH > 0 ? (meta.cellW / meta.cellH) * displayH : displayH;
+	return {
+		dispW,
+		bgW: meta.cols * dispW,
+		bgH: meta.rows * displayH,
+		offX: (i % meta.cols) * dispW,
+		offY: Math.floor(i / meta.cols) * displayH,
+	};
+}

--- a/apps/desktop/src/lib/timeline/time-map.test.ts
+++ b/apps/desktop/src/lib/timeline/time-map.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import {
+	originalToOutput as cutOriginalToOutput,
+	normalizeCuts,
+	type TimelineCut,
+} from "./cuts";
+import { deriveSegments } from "./segments";
+import {
+	buildTimeMap,
+	displayTimeMap,
+	originalToOutput,
+	outputToOriginal,
+	spanAtOriginal,
+	timeMapFromSegments,
+} from "./time-map";
+import parityFixtures from "./__fixtures__/cut-parity.json";
+
+function cut(start: number, end: number, id = `${start}-${end}`): TimelineCut {
+	return { id, start, end, source: "manual" };
+}
+
+function span(origStart: number, origEnd: number, speed = 1) {
+	return { origStart, origEnd, speed };
+}
+
+describe("buildTimeMap", () => {
+	it("lays kept spans end-to-end on the output axis", () => {
+		const map = buildTimeMap([span(0, 2), span(5, 6)]);
+		expect(map.spans.map((s) => [s.outStart, s.outEnd])).toEqual([
+			[0, 2],
+			[2, 3],
+		]);
+		expect(map.outputDuration).toBeCloseTo(3);
+	});
+
+	it("sorts spans by original start", () => {
+		const map = buildTimeMap([span(5, 6), span(0, 2)]);
+		expect(map.spans.map((s) => s.origStart)).toEqual([0, 5]);
+	});
+
+	it("drops zero-length spans", () => {
+		expect(buildTimeMap([span(2, 2)]).spans).toHaveLength(0);
+	});
+
+	it("a 2x span occupies half the output width", () => {
+		const map = buildTimeMap([span(0, 4, 2)]);
+		expect(map.outputDuration).toBeCloseTo(2);
+	});
+
+	it("falls back to 1x for a non-positive or non-finite speed", () => {
+		expect(buildTimeMap([span(0, 4, 0)]).outputDuration).toBeCloseTo(4);
+		expect(
+			buildTimeMap([span(0, 4, Number.POSITIVE_INFINITY)]).outputDuration,
+		).toBeCloseTo(4);
+	});
+});
+
+describe("originalToOutput / outputToOriginal (general map)", () => {
+	const map = buildTimeMap([span(0, 4, 2), span(6, 10, 1)]); // out: [0,2] then [2,6]
+
+	it("applies per-span slope", () => {
+		expect(originalToOutput(map, 2)).toBeCloseTo(1); // half-way through 2x span
+		expect(originalToOutput(map, 8)).toBeCloseTo(4); // half-way through 1x span
+	});
+
+	it("collapses a removed-gap time onto the next seam", () => {
+		// The [4,6] gap has no output image; both edges map to the seam at out=2.
+		expect(originalToOutput(map, 5)).toBeCloseTo(2);
+	});
+
+	it("round-trips kept times", () => {
+		for (const t of [0, 1, 3, 6, 7, 9, 10]) {
+			expect(outputToOriginal(map, originalToOutput(map, t))).toBeCloseTo(t);
+		}
+	});
+
+	it("right-biases an exact internal seam", () => {
+		// out=2 is both the 2x span's end and the 1x span's start → next span wins.
+		expect(outputToOriginal(map, 2)).toBeCloseTo(6);
+	});
+
+	it("clamps output outside the kept range", () => {
+		expect(outputToOriginal(map, -1)).toBeCloseTo(0);
+		expect(outputToOriginal(map, 99)).toBeCloseTo(10);
+	});
+
+	it("is monotonic non-decreasing in original time", () => {
+		let prev = -Infinity;
+		for (let t = 0; t <= 10; t += 0.1) {
+			const o = originalToOutput(map, t);
+			expect(o).toBeGreaterThanOrEqual(prev - 1e-9);
+			prev = o;
+		}
+	});
+});
+
+describe("spanAtOriginal", () => {
+	const map = buildTimeMap([span(0, 4, 2), span(6, 10)]);
+	it("finds the covering span", () => {
+		expect(spanAtOriginal(map, 1)?.origStart).toBe(0);
+		expect(spanAtOriginal(map, 7)?.origStart).toBe(6);
+	});
+	it("returns null inside a removed gap", () => {
+		expect(spanAtOriginal(map, 5)).toBeNull();
+	});
+});
+
+describe("speed=1 reduces exactly to the cut translation map", () => {
+	// Same shared fixtures the Rust export and cuts.test.ts assert against: at
+	// speed 1 the general map's output duration must equal the kept duration, and
+	// its mapping must match cuts.originalToOutput up to the trim-start offset.
+	for (const c of parityFixtures.cases) {
+		it(`matches fixture: ${c.name}`, () => {
+			const cuts = c.cuts.map(([s, e], i) => cut(s, e, `fx-${i}`));
+			const segments = deriveSegments({
+				trimStart: c.trimStart,
+				trimEnd: c.trimEnd,
+				cuts,
+				splitPoints: [],
+			});
+			const map = timeMapFromSegments(segments);
+
+			expect(map.outputDuration).toBeCloseTo(c.expectedKeptDuration, 6);
+
+			// The general map's output axis starts at trimStart; the cut map's starts
+			// at original 0. They must agree once that constant offset is removed.
+			const offset = cutOriginalToOutput(cuts, c.trimStart);
+			const normalized = normalizeCuts(cuts);
+			for (const seg of segments) {
+				for (const t of [seg.start, (seg.start + seg.end) / 2, seg.end]) {
+					expect(originalToOutput(map, t)).toBeCloseTo(
+						cutOriginalToOutput(normalized, t) - offset,
+						6,
+					);
+				}
+			}
+		});
+	}
+});
+
+describe("displayTimeMap (trim-drag axis) reduces to the full-duration cut map at 1x", () => {
+	// While trimming the timeline swaps onto this full-recording axis; at 1x it
+	// must match the cut translation map over [0, duration] so the layout matches.
+	const DURATION = 12;
+	for (const c of parityFixtures.cases) {
+		if (c.trimEnd > DURATION) continue;
+		it(`matches fixture: ${c.name}`, () => {
+			const cuts = c.cuts.map(([s, e], i) => cut(s, e, `fx-${i}`));
+			const segments = deriveSegments({
+				trimStart: c.trimStart,
+				trimEnd: c.trimEnd,
+				cuts,
+				splitPoints: [],
+			});
+			const map = displayTimeMap({
+				trimStart: c.trimStart,
+				trimEnd: c.trimEnd,
+				durationSec: DURATION,
+				segments,
+				cuts,
+			});
+			expect(map.outputDuration).toBeCloseTo(
+				cutOriginalToOutput(cuts, DURATION),
+				6,
+			);
+			for (let t = 0; t <= DURATION; t += 0.37) {
+				expect(originalToOutput(map, t)).toBeCloseTo(
+					cutOriginalToOutput(cuts, t),
+					6,
+				);
+			}
+		});
+	}
+});
+
+describe("timeMapFromSegments warps a sped-up segment (kept axis)", () => {
+	it("narrows a 2x segment and shortens the output", () => {
+		const segments = deriveSegments({
+			trimStart: 0,
+			trimEnd: 10,
+			cuts: [],
+			splitPoints: [4],
+		});
+		// Kept axis: output 0 == first segment start; [0,4]@1x=4 then [4,10]@2x=3.
+		const map = timeMapFromSegments(segments, (i) => (i === 1 ? 2 : 1));
+		expect(map.outputDuration).toBeCloseTo(7);
+		expect(originalToOutput(map, 4)).toBeCloseTo(4);
+		expect(originalToOutput(map, 10)).toBeCloseTo(7);
+	});
+});

--- a/apps/desktop/src/lib/timeline/time-map.ts
+++ b/apps/desktop/src/lib/timeline/time-map.ts
@@ -1,0 +1,171 @@
+/**
+ * General piecewise-linear time map: original-recording time ↔ output time.
+ *
+ * Generalizes the cut model (./cuts.ts) so a kept span can play at a speed other
+ * than 1×. Each kept span maps original→output with slope `1/speed`; removed
+ * (trimmed or cut) original time has no output image and collapses to the seam.
+ * With every span at speed 1 this reduces exactly to the cut translation map —
+ * proven in ./time-map.test.ts against the shared cut-parity fixtures.
+ *
+ * This is the substrate per-segment speed sits on: build the map from the kept
+ * segments (./segments.ts) plus a speed per segment, then route playhead,
+ * filmstrip, and export through the same arithmetic so they can't drift.
+ */
+
+import { normalizeCuts, type TimelineCut } from "./cuts";
+import type { Segment } from "./segments";
+
+/** Tolerance for treating two times as the same boundary. Matches cuts.ts. */
+const EPS = 1e-4;
+
+/** A kept original range to play at `speed`. */
+export interface TimeSpan {
+	/** Kept original range start (seconds). */
+	origStart: number;
+	/** Kept original range end (seconds). */
+	origEnd: number;
+	/** Playback speed (>0). 2 = twice as fast = half the output width. */
+	speed: number;
+}
+
+/** A kept span placed on both axes. */
+export interface MappedSpan extends TimeSpan {
+	/** Output range start (seconds). */
+	outStart: number;
+	/** Output range end (seconds). */
+	outEnd: number;
+}
+
+export interface TimeMap {
+	/** Kept spans in original order, each annotated with its output range. */
+	spans: MappedSpan[];
+	/** Total output duration (seconds). */
+	outputDuration: number;
+}
+
+/** Speed lookup keyed by segment index; defaults to 1× for any missing entry. */
+export type SpeedOf = (segmentIndex: number) => number;
+
+/**
+ * Build a time map from kept spans. Spans are sorted by original start and laid
+ * end-to-end on the output axis; a non-positive or non-finite speed falls back
+ * to 1 so a bad override can never produce a zero-width or NaN output range.
+ */
+export function buildTimeMap(spans: TimeSpan[]): TimeMap {
+	const ordered = spans
+		.filter((s) => s.origEnd - s.origStart > EPS)
+		.sort((a, b) => a.origStart - b.origStart);
+
+	const mapped: MappedSpan[] = [];
+	let out = 0;
+	for (const s of ordered) {
+		const speed = s.speed > 0 && Number.isFinite(s.speed) ? s.speed : 1;
+		const outStart = out;
+		out += (s.origEnd - s.origStart) / speed;
+		mapped.push({ ...s, speed, outStart, outEnd: out });
+	}
+	return { spans: mapped, outputDuration: out };
+}
+
+/** Build a time map from kept segments, applying a per-segment speed. */
+export function timeMapFromSegments(
+	segments: Segment[],
+	speedOf: SpeedOf = () => 1,
+): TimeMap {
+	return buildTimeMap(
+		segments.map((seg) => ({
+			origStart: seg.start,
+			origEnd: seg.end,
+			speed: speedOf(seg.index),
+		})),
+	);
+}
+
+/** Kept sub-intervals of [lo, hi] with the cuts removed. */
+function keptIntervals(
+	lo: number,
+	hi: number,
+	normalized: TimelineCut[],
+): Array<{ start: number; end: number }> {
+	if (hi - lo <= EPS) return [];
+	const out: Array<{ start: number; end: number }> = [];
+	let cursor = lo;
+	for (const c of normalized) {
+		if (c.end <= lo || c.start >= hi) continue;
+		const cutStart = Math.max(c.start, lo);
+		if (cutStart - cursor > EPS) out.push({ start: cursor, end: cutStart });
+		cursor = Math.max(cursor, Math.min(c.end, hi));
+	}
+	if (hi - cursor > EPS) out.push({ start: cursor, end: hi });
+	return out;
+}
+
+/**
+ * The FULL-recording axis used transiently WHILE TRIMMING: the whole [0,
+ * durationSec] with the trimmed head/tail shown at 1× (so the handles can move
+ * across the entire source and reveal what's trimmed), kept segments warped by
+ * speed, and cuts collapsed. Resting state uses the kept-only map
+ * (`timeMapFromSegments`); this un-collapses so a trim drag isn't degenerate at
+ * the clip's left edge. At all-1× it's the cut translation map over [0,duration].
+ */
+export function displayTimeMap(args: {
+	trimStart: number;
+	trimEnd: number;
+	durationSec: number;
+	segments: Segment[];
+	cuts: TimelineCut[];
+	speedOf?: SpeedOf;
+}): TimeMap {
+	const { trimStart, trimEnd, durationSec, segments, cuts } = args;
+	const speedOf = args.speedOf ?? (() => 1);
+	const normalized = normalizeCuts(cuts);
+	const spans: TimeSpan[] = [];
+	for (const k of keptIntervals(0, trimStart, normalized)) {
+		spans.push({ origStart: k.start, origEnd: k.end, speed: 1 });
+	}
+	for (const seg of segments) {
+		spans.push({ origStart: seg.start, origEnd: seg.end, speed: speedOf(seg.index) });
+	}
+	for (const k of keptIntervals(trimEnd, durationSec, normalized)) {
+		spans.push({ origStart: k.start, origEnd: k.end, speed: 1 });
+	}
+	return buildTimeMap(spans);
+}
+
+/**
+ * Map an original-timeline time to output time. A time in a removed gap (or
+ * before the first span) collapses onto the next kept span's output start — the
+ * seam — matching cuts.ts, where a time inside a cut maps to the cut's start.
+ */
+export function originalToOutput(map: TimeMap, t: number): number {
+	for (const s of map.spans) {
+		if (t < s.origStart) return s.outStart;
+		if (t <= s.origEnd) return s.outStart + (t - s.origStart) / s.speed;
+	}
+	return map.outputDuration;
+}
+
+/**
+ * Map an output time back to original time. Output is clamped to the kept range;
+ * on an exact internal seam the right-hand span wins (NLE convention, matching
+ * segmentAt), so seeking onto a seam lands at the start of the next kept span.
+ */
+export function outputToOriginal(map: TimeMap, t: number): number {
+	const spans = map.spans;
+	if (spans.length === 0) return 0;
+	for (const s of spans) {
+		if (t <= s.outStart + EPS) return s.origStart;
+		if (t < s.outEnd - EPS) return s.origStart + (t - s.outStart) * s.speed;
+	}
+	return spans[spans.length - 1].origEnd;
+}
+
+/** The kept span covering original time `t`, or null if `t` is removed. */
+export function spanAtOriginal(map: TimeMap, t: number): MappedSpan | null {
+	for (const s of map.spans) {
+		if (t >= s.origStart - EPS && t < s.origEnd - EPS) return s;
+	}
+	const last = map.spans[map.spans.length - 1];
+	if (last && Math.abs(t - last.origEnd) <= EPS) return last;
+	return null;
+}

--- a/apps/desktop/src/routes/editor/[file]/+page.svelte
+++ b/apps/desktop/src/routes/editor/[file]/+page.svelte
@@ -38,8 +38,11 @@
   } from "$lib/stores/editor-store.svelte";
   import { experimentalStore } from "$lib/stores/experimental.svelte";
   import { AudioTimelineEngine } from "$lib/playback/audio-engine";
-  import { keptRegions } from "$lib/playback/audio-schedule";
-  import { originalToOutput, outputToOriginal } from "$lib/timeline/cuts";
+  import { originalToOutput, outputToOriginal } from "$lib/timeline/time-map";
+  import {
+    createTileProvider,
+    type TileProvider,
+  } from "$lib/timeline/filmstrip-source";
   import { gdrive } from "$lib/stores/gdrive.svelte";
   import {
     ArrowLeft,
@@ -147,6 +150,14 @@
   let error = $state("");
   let loadedPath = $state("");
   let thumbnailToken = 0;
+
+  // Density-based filmstrip: a WebCodecs tile provider (or null, when the clip
+  // bar falls back to the stretched Rust strip). `filmstripVersion` bumps as
+  // decoded tiles land so the bar repaints. Clip-bar height (h-12) in CSS px.
+  const FILMSTRIP_TILE_HEIGHT = 48;
+  let tileProvider = $state<TileProvider | null>(null);
+  let filmstripVersion = $state(0);
+  let tileProviderToken = 0;
 
   // Legacy-format gate: a v1 `.recast` must be migrated before the editor
   // touches it. `migrationDone` distinguishes a confirmed update (→ reload)
@@ -290,14 +301,21 @@
   }
   onDestroy(stopAudioClockSync);
   onDestroy(() => audioEngine?.dispose());
+  onDestroy(disposeTileProvider);
 
-  // Kept audio regions (trim minus cuts) and current OUTPUT time — what the
-  // Web Audio engine schedules against.
+  // Kept audio regions and current OUTPUT time — what the Web Audio engine
+  // schedules against. Regions are the kept SEGMENTS (trim − cuts, split-bounded)
+  // each carrying its clip speed, so audio speeds up/down with the segment.
+  // Output time is the warped axis (store.timeMap), matching the picture clock.
   function audioRegions() {
-    return keptRegions(store.inPoint, store.outPoint, store.effectiveCuts);
+    return store.segments.map((s) => ({
+      start: s.start,
+      end: s.end,
+      speed: store.segmentSpeedAt(s.start),
+    }));
   }
   function outputNow() {
-    return originalToOutput(store.effectiveCuts, store.currentTime);
+    return originalToOutput(store.timeMap, store.currentTime);
   }
   // Lazily build the engine on first WebCodecs playback. Tried once; on failure
   // it's marked failed and the <audio> elements take over.
@@ -376,17 +394,16 @@
   let lastRegionsKey = "";
   $effect(() => {
     const t = store.currentTime;
-    const cuts = store.effectiveCuts;
     const eng = audioEngine;
     if (!eng || !webcodecsActive || !store.isPlaying) {
       engineSyncOut = -1;
       lastRegionsKey = "";
       return;
     }
-    const out = originalToOutput(cuts, t);
-    const regions = keptRegions(store.inPoint, store.outPoint, cuts);
+    const out = originalToOutput(store.timeMap, t);
+    const regions = audioRegions();
     const regionsKey = regions
-      .map((r) => `${r.start.toFixed(3)}-${r.end.toFixed(3)}`)
+      .map((r) => `${r.start.toFixed(3)}-${r.end.toFixed(3)}@${r.speed.toFixed(3)}`)
       .join(",");
     const jumped =
       engineSyncOut >= 0 && Math.abs(out - engineSyncOut) > ENGINE_RESEEK_JUMP;
@@ -421,14 +438,14 @@
   // kept frame, never inside a removed range. `store.currentTime` stays original.
   function frameStepSeek(direction: 1 | -1) {
     if (!store.metadata) return;
-    const cuts = store.effectiveCuts;
+    const map = store.timeMap;
     const frameDur = 1 / (store.metadata.fps || 30);
-    const outDur = originalToOutput(cuts, store.metadata.duration);
+    const outDur = originalToOutput(map, store.metadata.duration);
     const nextOut = Math.max(
       0,
-      Math.min(originalToOutput(cuts, store.currentTime) + frameDur * direction, outDur),
+      Math.min(originalToOutput(map, store.currentTime) + frameDur * direction, outDur),
     );
-    const orig = outputToOriginal(cuts, nextOut);
+    const orig = outputToOriginal(map, nextOut);
     if (videoEl) videoEl.currentTime = orig;
     store.currentTime = orig;
   }
@@ -445,6 +462,32 @@
     if (store.trimEnd <= 0 && store.metadata.duration > 0) {
       store.loadRenderState({ trimEnd: store.metadata.duration });
     }
+  }
+
+  function disposeTileProvider() {
+    tileProvider?.dispose();
+    tileProvider = null;
+  }
+
+  // Build the WebCodecs filmstrip provider for the opened media. Tokened so a
+  // rapid reopen disposes a provider that resolves after we moved on.
+  async function setupTileProvider(url: string) {
+    const token = ++tileProviderToken;
+    disposeTileProvider();
+    const dpr = browser ? window.devicePixelRatio || 1 : 1;
+    const provider = await createTileProvider({
+      url,
+      sizeBytes: store.metadata?.sizeBytes,
+      tileHeightPx: Math.round(FILMSTRIP_TILE_HEIGHT * dpr),
+      onChange: () => {
+        filmstripVersion++;
+      },
+    });
+    if (token !== tileProviderToken) {
+      provider?.dispose();
+      return;
+    }
+    tileProvider = provider;
   }
 
   async function loadThumbnailStrip(path: string) {
@@ -530,6 +573,7 @@
     store.metadata = null;
     store.reset();
     store.thumbnailStrip = [];
+    disposeTileProvider();
 
     try {
       const document = await loadEditorDocument(data.filePath);
@@ -553,6 +597,7 @@
       });
       void loadThumbnailStrip(document.projectPath);
       videoSrc = convertFileSrc(document.mediaPath);
+      void setupTileProvider(videoSrc);
       cursorPath = document.cursorPath ?? null;
       store.cursorPath = cursorPath;
       // Raw on-disk media paths for Rust-side analysis (silence detection).
@@ -1445,7 +1490,7 @@
             class="shrink-0 overflow-hidden"
             transition:slide={{ axis: "y", duration: 240, easing: cubicOut }}
           >
-            <Timeline {store} {videoEl} />
+            <Timeline {store} {videoEl} {tileProvider} {filmstripVersion} />
           </div>
         {/if}
       </div>

--- a/apps/desktop/src/routes/editor/[file]/+page.svelte
+++ b/apps/desktop/src/routes/editor/[file]/+page.svelte
@@ -522,6 +522,9 @@
     }
   }
 
+  // Latch so the lazy scheduler fires once per loaded clip (reset on load).
+  let waveformRequested = false;
+
   // Decode the audio peak envelope for the timeline waveform. Best-effort async.
   async function loadWaveform() {
     // Skip sub-5s clips: too narrow to read, and the FFmpeg pass isn't worth it.
@@ -616,9 +619,9 @@
       store.audioPath = document.audioPath ?? null;
       store.microphonePath = document.microphonePath ?? null;
       store.waveform = [];
-      // Only the experimental cut lane uses the waveform; skip the ffmpeg pass
-      // when off (the $effect below back-fills if the flag flips on).
-      if (experimentalStore.silenceDetection) void loadWaveform();
+      // Lazy: the idle-scheduled effect below extracts the waveform once the
+      // editor is interactive, so the ffmpeg pass never competes with load.
+      waveformRequested = false;
       systemAudioSrc = document.audioPath
         ? convertFileSrc(document.audioPath)
         : "";
@@ -1315,12 +1318,19 @@
     videoEl.muted = true;
   });
 
-  // Back-fill the waveform if the experimental flag flips on after load.
+  // Extract the waveform lazily: defer to browser idle (best-effort) so the
+  // ffmpeg pass runs after the editor is interactive, never on the load path.
+  // The latch keeps the reactive re-runs from scheduling it more than once.
   $effect(() => {
-    if (!experimentalStore.silenceDetection) return;
-    if (store.waveform.length > 0) return;
+    if (store.waveform.length > 0 || waveformRequested) return;
     if (!store.audioPath && !store.microphonePath) return;
-    void loadWaveform();
+    waveformRequested = true;
+    const run = () => void loadWaveform();
+    if (typeof requestIdleCallback === "function") {
+      requestIdleCallback(run, { timeout: 3000 });
+    } else {
+      setTimeout(run, 1000);
+    }
   });
 
   $effect(() => {

--- a/apps/desktop/src/routes/editor/[file]/+page.svelte
+++ b/apps/desktop/src/routes/editor/[file]/+page.svelte
@@ -413,6 +413,17 @@
     if (jumped || editsChanged) eng.reschedule(regions, out);
   });
 
+  // Legacy/fallback path: the <audio> elements are slaved to the <video> clock,
+  // so they must share its per-segment clip speed or audio plays at 1× while the
+  // picture speeds up. preservesPitch stays on (default), matching the export's
+  // pitch-preserving atempo. On the WebCodecs path these elements are paused
+  // (the Web Audio engine carries speed via the schedule), so this is a no-op.
+  $effect(() => {
+    const segSpeed = store.segmentSpeedAtTime(store.currentTime);
+    if (systemAudioEl) systemAudioEl.playbackRate = segSpeed;
+    if (micAudioEl) micAudioEl.playbackRate = segSpeed;
+  });
+
   // Apply volume/mute from the store's audio settings to both audio elements.
   $effect(() => {
     const settings = store.audioSettings;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,6 +44,10 @@
       "svelte": "./src/components/ui/command/index.ts",
       "default": "./src/components/ui/command/index.ts"
     },
+    "./context-menu": {
+      "svelte": "./src/components/ui/context-menu/index.ts",
+      "default": "./src/components/ui/context-menu/index.ts"
+    },
     "./cutout": {
       "svelte": "./src/components/ui/cutout/index.ts",
       "default": "./src/components/ui/cutout/index.ts"

--- a/packages/ui/src/components/ui/context-menu/context-menu-checkbox-group.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-checkbox-group.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		value = $bindable([]),
+		...restProps
+	}: ContextMenuPrimitive.CheckboxGroupProps = $props();
+</script>
+
+<ContextMenuPrimitive.CheckboxGroup
+	bind:ref
+	bind:value
+	data-slot="context-menu-checkbox-group"
+	{...restProps}
+/>

--- a/packages/ui/src/components/ui/context-menu/context-menu-checkbox-item.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-checkbox-item.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+	import { IconMinus } from '@tabler/icons-svelte';
+	import { IconCheck } from '@tabler/icons-svelte';
+	import { cn, type WithoutChildrenOrChild } from "@recast/ui/utils";
+	import type { Snippet } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		checked = $bindable(false),
+		indeterminate = $bindable(false),
+		class: className,
+		children: childrenProp,
+		...restProps
+	}: WithoutChildrenOrChild<ContextMenuPrimitive.CheckboxItemProps> & {
+		children?: Snippet;
+	} = $props();
+</script>
+
+<ContextMenuPrimitive.CheckboxItem
+	bind:ref
+	bind:checked
+	bind:indeterminate
+	data-slot="context-menu-checkbox-item"
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
+	)}
+	{...restProps}
+>
+	{#snippet children({ checked, indeterminate })}
+		<span
+			class="absolute right-2 flex items-center justify-center pointer-events-none"
+			data-slot="context-menu-checkbox-item-indicator"
+		>
+			{#if indeterminate}
+				<IconMinus  />
+			{:else if checked}
+				<IconCheck  />
+			{/if}
+		</span>
+		{@render childrenProp?.()}
+	{/snippet}
+</ContextMenuPrimitive.CheckboxItem>

--- a/packages/ui/src/components/ui/context-menu/context-menu-content.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-content.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { CRAFT_OVERLAY_ANIMATION, cn, type WithoutChildrenOrChild } from "@recast/ui/utils";
+	import ContextMenuPortal from "./context-menu-portal.svelte";
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+	import type { ComponentProps } from "svelte";
+	import {
+		contextMenuContentSizeVariants,
+		setContextMenuSize,
+		type ContextMenuSize,
+	} from "./context";
+
+	let {
+		ref = $bindable(null),
+		size = "default",
+		portalProps,
+		class: className,
+		preventScroll = false,
+		...restProps
+	}: ContextMenuPrimitive.ContentProps & {
+		size?: ContextMenuSize;
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof ContextMenuPortal>>;
+	} = $props();
+
+	// Propagate size to descendant Item / CheckboxItem / RadioItem / SubTrigger.
+	$effect(() => {
+		setContextMenuSize(size);
+	});
+</script>
+
+<ContextMenuPortal {...portalProps}>
+	<ContextMenuPrimitive.Content
+		bind:ref
+		data-slot="context-menu-content"
+		data-size={size}
+		{preventScroll}
+		class={cn(
+			CRAFT_OVERLAY_ANIMATION,
+			// Unfold from the corner nearest the pointer (macOS-menu feel)
+			// instead of scaling from the centre.
+			"origin-(--bits-floating-transform-origin)",
+			"ring-foreground/10 text-popover-foreground rounded-lg shadow-md ring-1 z-50 overflow-x-hidden overflow-y-auto outline-none data-[state=closed]:overflow-hidden relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!",
+			contextMenuContentSizeVariants({ size }),
+			className
+		)}
+		{...restProps}
+	/>
+</ContextMenuPortal>

--- a/packages/ui/src/components/ui/context-menu/context-menu-group-heading.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-group-heading.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+	import { cn } from "@recast/ui/utils";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		...restProps
+	}: ComponentProps<typeof ContextMenuPrimitive.GroupHeading> & {
+		inset?: boolean;
+	} = $props();
+</script>
+
+<ContextMenuPrimitive.GroupHeading
+	bind:ref
+	data-slot="context-menu-group-heading"
+	data-inset={inset}
+	class={cn("px-2 py-1.5 text-sm font-semibold data-[inset]:ps-8", className)}
+	{...restProps}
+/>

--- a/packages/ui/src/components/ui/context-menu/context-menu-group.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-group.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: ContextMenuPrimitive.GroupProps = $props();
+</script>
+
+<ContextMenuPrimitive.Group bind:ref data-slot="context-menu-group" {...restProps} />

--- a/packages/ui/src/components/ui/context-menu/context-menu-item.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-item.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { cn } from "@recast/ui/utils";
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+	import {
+		contextMenuItemSizeVariants,
+		getContextMenuSize,
+		type ContextMenuSize,
+	} from "./context";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		size,
+		variant = "default",
+		...restProps
+	}: ContextMenuPrimitive.ItemProps & {
+		inset?: boolean;
+		size?: ContextMenuSize;
+		variant?: "default" | "destructive";
+	} = $props();
+
+	// Inherit from <Content size="…"> unless overridden per-item.
+	const resolvedSize = $derived(size ?? getContextMenuSize());
+</script>
+
+<ContextMenuPrimitive.Item
+	bind:ref
+	data-slot="context-menu-item"
+	data-inset={inset}
+	data-variant={variant}
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground rounded-md data-inset:pl-7 group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		contextMenuItemSizeVariants({ size: resolvedSize }),
+		className
+	)}
+	{...restProps}
+/>

--- a/packages/ui/src/components/ui/context-menu/context-menu-label.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-label.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "@recast/ui/utils";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		inset?: boolean;
+	} = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="context-menu-label"
+	data-inset={inset}
+	class={cn("text-muted-foreground px-1.5 py-1 text-xs font-medium data-inset:pl-7 data-[inset]:pl-8", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/components/ui/context-menu/context-menu-portal.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+
+	let { ...restProps }: ContextMenuPrimitive.PortalProps = $props();
+</script>
+
+<ContextMenuPrimitive.Portal {...restProps} />

--- a/packages/ui/src/components/ui/context-menu/context-menu-radio-group.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-radio-group.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		...restProps
+	}: ContextMenuPrimitive.RadioGroupProps = $props();
+</script>
+
+<ContextMenuPrimitive.RadioGroup
+	bind:ref
+	bind:value
+	data-slot="context-menu-radio-group"
+	{...restProps}
+/>

--- a/packages/ui/src/components/ui/context-menu/context-menu-radio-item.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-radio-item.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+	import { IconCheck } from '@tabler/icons-svelte';
+	import { cn, type WithoutChild } from "@recast/ui/utils";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children: childrenProp,
+		...restProps
+	}: WithoutChild<ContextMenuPrimitive.RadioItemProps> = $props();
+</script>
+
+<ContextMenuPrimitive.RadioItem
+	bind:ref
+	data-slot="context-menu-radio-item"
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
+	)}
+	{...restProps}
+>
+	{#snippet children({ checked })}
+		<span
+			class="absolute right-2 flex items-center justify-center pointer-events-none"
+			data-slot="context-menu-radio-item-indicator"
+		>
+			{#if checked}
+				<IconCheck  />
+			{/if}
+		</span>
+		{@render childrenProp?.({ checked })}
+	{/snippet}
+</ContextMenuPrimitive.RadioItem>

--- a/packages/ui/src/components/ui/context-menu/context-menu-separator.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-separator.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+	import { cn } from "@recast/ui/utils";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: ContextMenuPrimitive.SeparatorProps = $props();
+</script>
+
+<ContextMenuPrimitive.Separator
+	bind:ref
+	data-slot="context-menu-separator"
+	class={cn("bg-border -mx-1 my-1 h-px", className)}
+	{...restProps}
+/>

--- a/packages/ui/src/components/ui/context-menu/context-menu-shortcut.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-shortcut.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "@recast/ui/utils";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();
+</script>
+
+<span
+	bind:this={ref}
+	data-slot="context-menu-shortcut"
+	class={cn("text-muted-foreground group-focus/context-menu-item:text-accent-foreground ml-auto text-xs tracking-widest", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</span>

--- a/packages/ui/src/components/ui/context-menu/context-menu-sub-content.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-sub-content.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+	import { CRAFT_OVERLAY_ANIMATION, cn, type WithoutChildrenOrChild } from "@recast/ui/utils";
+	import ContextMenuPortal from "./context-menu-portal.svelte";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		portalProps,
+		...restProps
+	}: ContextMenuPrimitive.SubContentProps & {
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof ContextMenuPortal>>;
+	} = $props();
+</script>
+
+<!-- Portal the submenu to <body>, same as the root Content. Without this the
+     SubContent renders *inside* the scrollable Content (which carries
+     `overflow-x-hidden overflow-y-auto` for long menus), so a submenu opening
+     to the side gets clipped. Floating-ui anchors it off the SubTrigger
+     regardless of DOM location, so portaling is safe and fixes the clipping. -->
+<ContextMenuPortal {...portalProps}>
+	<ContextMenuPrimitive.SubContent
+		bind:ref
+		data-slot="context-menu-sub-content"
+		class={cn(CRAFT_OVERLAY_ANIMATION, "origin-(--bits-floating-transform-origin) ring-foreground/10 text-popover-foreground min-w-[96px] rounded-lg p-1 shadow-lg ring-1 w-auto relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!", className)}
+		{...restProps}
+	/>
+</ContextMenuPortal>

--- a/packages/ui/src/components/ui/context-menu/context-menu-sub-trigger.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-sub-trigger.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+	import { IconChevronRight } from '@tabler/icons-svelte';
+	import { cn } from "@recast/ui/utils";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		children,
+		...restProps
+	}: ContextMenuPrimitive.SubTriggerProps & {
+		inset?: boolean;
+	} = $props();
+</script>
+
+<ContextMenuPrimitive.SubTrigger
+	bind:ref
+	data-slot="context-menu-sub-trigger"
+	data-inset={inset}
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 flex cursor-default items-center outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+	<IconChevronRight class="ml-auto" />
+</ContextMenuPrimitive.SubTrigger>

--- a/packages/ui/src/components/ui/context-menu/context-menu-sub.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-sub.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+
+	let { open = $bindable(false), ...restProps }: ContextMenuPrimitive.SubProps = $props();
+</script>
+
+<ContextMenuPrimitive.Sub bind:open {...restProps} />

--- a/packages/ui/src/components/ui/context-menu/context-menu-trigger.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: ContextMenuPrimitive.TriggerProps = $props();
+</script>
+
+<ContextMenuPrimitive.Trigger bind:ref data-slot="context-menu-trigger" {...restProps} />

--- a/packages/ui/src/components/ui/context-menu/context-menu.svelte
+++ b/packages/ui/src/components/ui/context-menu/context-menu.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+
+	let { open = $bindable(false), ...restProps }: ContextMenuPrimitive.RootProps = $props();
+</script>
+
+<ContextMenuPrimitive.Root bind:open {...restProps} />

--- a/packages/ui/src/components/ui/context-menu/context.ts
+++ b/packages/ui/src/components/ui/context-menu/context.ts
@@ -1,0 +1,44 @@
+import { getContext, setContext } from "svelte";
+import { tv, type VariantProps } from "tailwind-variants";
+
+const SIZE_KEY = Symbol.for("recast-ui.context-menu.size");
+
+export type ContextMenuSize = "sm" | "default" | "lg";
+
+export function setContextMenuSize(size: ContextMenuSize) {
+	setContext<ContextMenuSize>(SIZE_KEY, size);
+}
+
+export function getContextMenuSize(): ContextMenuSize {
+	return getContext<ContextMenuSize>(SIZE_KEY) ?? "default";
+}
+
+/** Padding / min-width applied to <Content>. */
+export const contextMenuContentSizeVariants = tv({
+	base: "",
+	variants: {
+		size: {
+			sm: "min-w-28 p-0.5 text-[11px]",
+			default: "min-w-32 p-1",
+			lg: "min-w-40 p-1.5 text-[14px]",
+		},
+	},
+	defaultVariants: { size: "default" },
+});
+
+/** Row sizing applied to <Item>, <CheckboxItem>, <RadioItem>, <SubTrigger>. */
+export const contextMenuItemSizeVariants = tv({
+	base: "",
+	variants: {
+		size: {
+			sm: "h-7 gap-1.5 px-2 text-[11px] [&_svg:not([class*='size-'])]:size-3",
+			default: "gap-1.5 px-1.5 py-1 text-sm [&_svg:not([class*='size-'])]:size-4",
+			lg: "gap-2 px-2 py-1.5 text-[14px] [&_svg:not([class*='size-'])]:size-4",
+		},
+	},
+	defaultVariants: { size: "default" },
+});
+
+export type ContextMenuContentSizeVariant = VariantProps<
+	typeof contextMenuContentSizeVariants
+>["size"];

--- a/packages/ui/src/components/ui/context-menu/index.ts
+++ b/packages/ui/src/components/ui/context-menu/index.ts
@@ -1,0 +1,60 @@
+import Root from "./context-menu.svelte";
+import Sub from "./context-menu-sub.svelte";
+import CheckboxGroup from "./context-menu-checkbox-group.svelte";
+import CheckboxItem from "./context-menu-checkbox-item.svelte";
+import Content from "./context-menu-content.svelte";
+import Group from "./context-menu-group.svelte";
+import Item from "./context-menu-item.svelte";
+import Label from "./context-menu-label.svelte";
+import RadioGroup from "./context-menu-radio-group.svelte";
+import RadioItem from "./context-menu-radio-item.svelte";
+import Separator from "./context-menu-separator.svelte";
+import Shortcut from "./context-menu-shortcut.svelte";
+import Trigger from "./context-menu-trigger.svelte";
+import SubContent from "./context-menu-sub-content.svelte";
+import SubTrigger from "./context-menu-sub-trigger.svelte";
+import GroupHeading from "./context-menu-group-heading.svelte";
+import Portal from "./context-menu-portal.svelte";
+
+export type { ContextMenuSize } from "./context";
+export {
+	contextMenuContentSizeVariants,
+	contextMenuItemSizeVariants,
+} from "./context";
+
+export {
+	CheckboxGroup,
+	CheckboxItem,
+	Content,
+	Portal,
+	Root as ContextMenu,
+	CheckboxGroup as ContextMenuCheckboxGroup,
+	CheckboxItem as ContextMenuCheckboxItem,
+	Content as ContextMenuContent,
+	Portal as ContextMenuPortal,
+	Group as ContextMenuGroup,
+	Item as ContextMenuItem,
+	Label as ContextMenuLabel,
+	RadioGroup as ContextMenuRadioGroup,
+	RadioItem as ContextMenuRadioItem,
+	Separator as ContextMenuSeparator,
+	Shortcut as ContextMenuShortcut,
+	Sub as ContextMenuSub,
+	SubContent as ContextMenuSubContent,
+	SubTrigger as ContextMenuSubTrigger,
+	Trigger as ContextMenuTrigger,
+	GroupHeading as ContextMenuGroupHeading,
+	Group,
+	GroupHeading,
+	Item,
+	Label,
+	RadioGroup,
+	RadioItem,
+	Root,
+	Separator,
+	Shortcut,
+	Sub,
+	SubContent,
+	SubTrigger,
+	Trigger,
+};


### PR DESCRIPTION


Rework the editor timeline toward a Screen Studio/Cap-grade experience,
built on a general piecewise-linear time-map.

Foundations
- time-map.ts: general original<->output map with per-segment speed; reduces
  to the cut translation map at 1x (parity-pinned to the shared fixtures).
- Density-based, virtualized WebCodecs filmstrip (replaces the 8-12 stretched
  thumbnails): random-access decode worker + tile provider with an object-URL
  LRU; shared whole-file demux extracted from the preview worker.

Per-segment speed ("edit this cut differently")
- segment-speed.ts: speed overrides anchored to a segment's original start.
- Warps timeline geometry, preview playback (clock maps through the time-map),
  audio (Web Audio plays each segment at its rate), overlays, and export
  (FFmpeg setpts warp + per-segment atempo). TS<->Rust parity fixture.

Timeline UX
- Trim collapses Cap-style (clip fills the track); trim-drag ghost-reveal
  un-collapses to the full recording so the handle follows the cursor and
  trimmed content can be restored, with a snap guide.
- Clip sidebar panel (speed/split/delete) auto-opens on selection.
- Hover-scrub frame preview; toolbar regrouped Edit/Insert/View; preview rate
  demoted (distinct from per-clip speed).
- Fix clip selection swallowed by the scrubber's pointer capture.