### PR TITLE
Feature/silence detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,13 @@ See [`.changeset/README.md`](.changeset/README.md) for the full flow.
 
 ## [Unreleased]
 
+## [0.2.9] — 2026-06-29
+
 ### Added
 - Update older recordings to the current project format in bulk from the library, or one at a time from a recording's menu. Recordings that still use the old format are marked so you can see which need updating.
 
 ### Changed
+- Silence detection is far more accurate. It now uses on-device voice detection to find genuinely silent, speech-free stretches and suggest them for removal, instead of judging by volume alone, which often mistook breathing, typing, and background hum for speech. Suggestions appear instantly when a recording opens, and now show up for camera-only recordings, not just screen recordings. Nothing is removed automatically, the quiet parts are only suggested for you to accept or skip.
 - Recordings now save in a new project format that keeps each part of your edit (background, zoom, annotations, audio) in its own section, so project files are more robust and easier to inspect. Older recordings are updated to the new format when you open them, and a copy of the original is kept alongside it first.
 - The editor stays responsive on long recordings. Adjusting cursor smoothing no longer freezes the preview, undo and redo are quicker, and autosave no longer causes a brief stutter.
 

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -402,6 +402,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,7 +741,7 @@ version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
- "smallvec",
+ "smallvec 1.15.1",
  "target-lexicon 0.12.16",
 ]
 
@@ -745,7 +751,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368"
 dependencies = [
- "smallvec",
+ "smallvec 1.15.1",
  "target-lexicon 0.13.3",
 ]
 
@@ -989,7 +995,7 @@ dependencies = [
  "phf 0.10.1",
  "proc-macro2",
  "quote",
- "smallvec",
+ "smallvec 1.15.1",
  "syn 1.0.109",
 ]
 
@@ -1067,6 +1073,16 @@ checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
  "dbus",
  "openssl",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1446,7 +1462,7 @@ dependencies = [
  "lebe",
  "miniz_oxide",
  "rayon-core",
- "smallvec",
+ "smallvec 1.15.1",
  "zune-inflate",
 ]
 
@@ -1610,12 +1626,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1683,6 +1715,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1921,7 +1954,7 @@ dependencies = [
  "libc",
  "once_cell",
  "pin-project-lite",
- "smallvec",
+ "smallvec 1.15.1",
  "thiserror 1.0.69",
 ]
 
@@ -1977,7 +2010,7 @@ dependencies = [
  "libc",
  "memchr",
  "once_cell",
- "smallvec",
+ "smallvec 1.15.1",
  "thiserror 1.0.69",
 ]
 
@@ -2217,7 +2250,7 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "pin-utils",
- "smallvec",
+ "smallvec 1.15.1",
  "tokio",
  "want",
 ]
@@ -2331,7 +2364,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec",
+ "smallvec 1.15.1",
  "zerovec",
 ]
 
@@ -2395,7 +2428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
- "smallvec",
+ "smallvec 1.15.1",
  "utf8_iter",
 ]
 
@@ -2938,6 +2971,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3042,6 +3085,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,6 +3202,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -3636,6 +3720,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ort"
+version = "2.0.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa7e49bd669d32d7bc2a15ec540a527e7764aec722a45467814005725bcd721"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "smallvec 2.0.0-alpha.10",
+ "tracing",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2aba9f5c7c479925205799216e7e5d07cc1d4fa76ea8058c60a9a30f6a4e890"
+dependencies = [
+ "flate2",
+ "pkg-config",
+ "sha2",
+ "tar",
+ "ureq",
+]
+
+[[package]]
 name = "os_info"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3715,7 +3824,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec",
+ "smallvec 1.15.1",
  "windows-link 0.2.1",
 ]
 
@@ -3736,6 +3845,15 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3878,6 +3996,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3985,6 +4123,21 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -4431,6 +4584,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4501,6 +4660,7 @@ dependencies = [
  "tokio",
  "trash",
  "urlencoding",
+ "voice_activity_detector",
  "webkit2gtk",
  "windows 0.58.0",
  "x11rb",
@@ -5017,7 +5177,7 @@ dependencies = [
  "phf_codegen 0.8.0",
  "precomputed-hash",
  "servo_arc",
- "smallvec",
+ "smallvec 1.15.1",
 ]
 
 [[package]]
@@ -5273,6 +5433,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smallvec"
+version = "2.0.0-alpha.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b"
+
+[[package]]
 name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5280,6 +5446,17 @@ checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -6369,6 +6546,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-builder"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6463,6 +6660,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "der",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6504,6 +6731,12 @@ name = "utf8-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -6557,6 +6790,21 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "voice_activity_detector"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50407ebe9f37f46ee5d9a7a4228324f400439de9c62861273ab34bcfbdaf08b6"
+dependencies = [
+ "futures",
+ "ndarray",
+ "ort",
+ "ort-sys",
+ "pin-project",
+ "thiserror 2.0.18",
+ "typed-builder",
+]
 
 [[package]]
 name = "vswhom"
@@ -6756,7 +7004,7 @@ dependencies = [
  "downcast-rs",
  "rustix",
  "scoped-tls",
- "smallvec",
+ "smallvec 1.15.1",
  "wayland-sys",
 ]
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -70,6 +70,13 @@ urlencoding = "2"
 # Cryptographic-quality randomness for PKCE code verifier + state token.
 # The `getrandom` backend on each OS feeds /dev/urandom or BCryptGenRandom.
 rand = "0.8"
+# Silero VAD (MIT model, bundled inside the crate) for silence detection —
+# replaces the old RMS-envelope gate, which mistakes room tone / breathing
+# for speech. Pulls `ort`; its default `download-binaries` fetches and
+# static-links a prebuilt ONNX Runtime at build time, so there's no loose
+# native lib to ship. `ort` is pinned to a pre-release by this crate, so it
+# stays pinned here too — a float would break the build on the next rc.
+voice_activity_detector = "0.2.1"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.58.0", features = [

--- a/apps/desktop/src-tauri/src/silence.rs
+++ b/apps/desktop/src-tauri/src/silence.rs
@@ -1,21 +1,24 @@
 //! Silence detection for the editor timeline.
 //!
-//! A range counts as silence when **both** of the following hold for at least
-//! `min_segment` seconds:
+//! Candidates come from a Silero voice-activity model — per-frame speech
+//! probability — not an energy threshold. Room tone, breathing and keyboard
+//! noise all sit well above the noise floor an RMS gate keys on, so the old
+//! envelope approach both leaked false silences and swallowed quiet speech.
+//! A range is a candidate when the model reports non-speech (with hysteresis,
+//! so a single dipping frame doesn't split a run) for at least
+//! `min_audio_silence` seconds.
 //!
-//!   1. The audio envelope is *flat and minimal* — frames sit within
-//!      `flatness_db` of the recording's own estimated noise floor. This is
-//!      explicitly relative, not an absolute dB threshold: a quiet hum in a
-//!      noisy room reads as "background" because the floor itself adapts.
-//!   2. The mouse cursor is *idle* — the cursor track shows no meaningful
-//!      movement over the same range.
-//!
-//! Background-noise suppression is intentionally out of scope here. So is
-//! pixel-level screen-motion detection (blinking carets and ticking clocks
-//! made `freezedetect` too noisy to be useful as a hard gate).
+//! The cursor track is a *confidence* signal, not a gate. An idle cursor over
+//! the range raises the score; a moving cursor no longer vetoes it, so
+//! webcam / talking-head recordings with no meaningful cursor still get
+//! suggestions. Nothing is cut automatically — these are suggestions only.
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::path::Path;
 use std::process::{Command, Stdio};
+
+use voice_activity_detector::VoiceActivityDetector;
 
 use serde::{Deserialize, Serialize};
 
@@ -26,12 +29,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SilenceOptions {
-    /// Frames must sit within this many dB of the recording's noise floor
-    /// to count as background. Smaller = stricter (only very flat
-    /// stretches register); larger = more aggressive.
-    #[serde(default = "d_flatness_db")]
-    pub flatness_db: f64,
-    /// Minimum continuous flat-audio run for a candidate (seconds).
+    /// Speech-probability threshold in [0,1]: a frame is speech once the model
+    /// scores at or above it. Higher = more aggressive (more gets called
+    /// silence). Hysteresis derives a lower release threshold from this.
+    #[serde(default = "d_threshold")]
+    pub threshold: f32,
+    /// Minimum continuous non-speech run for a candidate (seconds).
     #[serde(default = "d_min_audio_silence")]
     pub min_audio_silence: f64,
     /// Minimum length of a returned silence segment (seconds).
@@ -39,8 +42,8 @@ pub struct SilenceOptions {
     pub min_segment: f64,
 }
 
-fn d_flatness_db() -> f64 {
-    5.0
+fn d_threshold() -> f32 {
+    0.5
 }
 fn d_min_audio_silence() -> f64 {
     0.6
@@ -52,7 +55,7 @@ fn d_min_segment() -> f64 {
 impl Default for SilenceOptions {
     fn default() -> Self {
         Self {
-            flatness_db: d_flatness_db(),
+            threshold: d_threshold(),
             min_audio_silence: d_min_audio_silence(),
             min_segment: d_min_segment(),
         }
@@ -60,7 +63,7 @@ impl Default for SilenceOptions {
 }
 
 /// A detected silence range, in original-recording seconds.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SilenceSegment {
     pub start: f64,
@@ -77,22 +80,19 @@ pub struct SilenceSegment {
 
 type Interval = (f64, f64);
 
-// 8 kHz mono is plenty for envelope detection — speech and dynamics live well
-// below half that.
-const RATE: u32 = 8000;
-const FRAME_MS: f64 = 50.0;
+// Silero v5 runs at 16 kHz with a fixed 512-sample window (32 ms/frame).
+const RATE: u32 = 16_000;
+const CHUNK: usize = 512;
+/// How far below `threshold` the score must fall to *end* a speech run. The
+/// gap is the hysteresis band: it stops a single quiet frame mid-word from
+/// fracturing speech into spurious micro-silences.
+const RELEASE_MARGIN: f32 = 0.15;
 /// Cursor counts as idle once it stays within this radius for this long.
 const CURSOR_IDLE_MIN_US: u64 = 300_000;
 const CURSOR_IDLE_RADIUS_PX: f64 = 8.0;
-/// Where the noise floor sits in the frame-energy distribution. The 5th
-/// percentile is conservative: it remains inside the genuine background
-/// even on a recording that is mostly speech (the 20th percentile crept
-/// up into quiet-syllable territory and made `audio_flat` swallow speech).
-const PERCENTILE_FLOOR: f64 = 0.05;
-/// Hard ceiling — a frame above this is never "silent" regardless of how
-/// close it sits to the estimated floor. Guards against pathological
-/// percentile bias on very noisy recordings.
-const ABS_QUIET_DBFS: f64 = -28.0;
+/// A candidate whose duration is at least this fraction covered by cursor-idle
+/// time is reported as cursor-confirmed (drives the `cursor_idle` flag).
+const CURSOR_CONFIRM_FRAC: f64 = 0.5;
 
 //  Command
 
@@ -131,6 +131,20 @@ fn detect_blocking(
         return Err("no audio track available to analyse".into());
     }
 
+    // Detection is a pure function of the input files + options, but each run
+    // is a full FFmpeg decode plus per-frame model inference. Serve it from the
+    // file-identity disk cache so the editor opens instantly on reopen — and so
+    // the precompute kicked off at recording-stop is what the editor reads.
+    // The cursor track is a source too: re-recording it changes the scores.
+    let mut sources: Vec<&Path> = inputs.iter().map(|p| Path::new(*p)).collect();
+    if let Some(c) = cursor_path.filter(|c| Path::new(c).exists()) {
+        sources.push(Path::new(c));
+    }
+    let key = opts_key(&opts);
+    if let Some(cached) = crate::cache::get::<Vec<SilenceSegment>>("silence", &sources, key) {
+        return Ok(cached);
+    }
+
     // Decode the mixed audio to mono s16le at our analysis rate.
     let mut args: Vec<String> = vec!["-hide_banner".into(), "-nostats".into()];
     for p in &inputs {
@@ -155,30 +169,30 @@ fn detect_blocking(
         .chunks_exact(2)
         .map(|c| i16::from_le_bytes([c[0], c[1]]))
         .collect();
-    if samples.len() < 2 {
+    if samples.len() < CHUNK {
         return Ok(Vec::new());
     }
     let total = samples.len() as f64 / RATE as f64;
 
-    // Per-frame RMS in dBFS.
-    let frame_size = (RATE as f64 * FRAME_MS / 1000.0).round() as usize;
-    let frame_dur = FRAME_MS / 1000.0;
-    let frame_db: Vec<f64> = samples.chunks(frame_size).map(frame_rms_db).collect();
+    // Per-frame speech probability. Silero is stateful across frames (an LSTM),
+    // so they must be scored in order; `predict` carries that state and
+    // zero-fills the short trailing frame.
+    let mut vad = VoiceActivityDetector::builder()
+        .sample_rate(RATE)
+        .chunk_size(CHUNK)
+        .build()
+        .map_err(|e| format!("init Silero VAD: {e}"))?;
+    let probs: Vec<f32> = samples
+        .chunks(CHUNK)
+        .map(|c| vad.predict(c.iter().copied()))
+        .collect();
+    let frame_dur = CHUNK as f64 / RATE as f64;
 
-    // Audio-flat runs: stretches whose envelope stays within `flatness_db`
-    // of the recording's own noise floor *and* below an absolute quiet
-    // ceiling. We deliberately do NOT merge_close these — bridging a short
-    // gap would silently swallow a speech burst between two flat runs.
-    let audio_flat = flat_intervals(
-        &frame_db,
-        frame_dur,
-        opts.min_audio_silence,
-        opts.flatness_db,
-    );
+    // Non-speech runs as frame-index ranges, gated by minimum duration.
+    let runs = silence_runs(&probs, frame_dur, opts.threshold, opts.min_audio_silence);
 
-    // Cursor-idle intervals. A missing track is treated as "idle everywhere"
-    // so the feature still works without cursor data, but the segment's
-    // `cursor_idle` flag and score reflect the unverified state.
+    // Cursor-idle intervals — a confidence signal, not a gate. A missing track
+    // just means no cursor confirmation is available; candidates still stand.
     let (cursor_idle, has_cursor) = match cursor_path {
         Some(p) if Path::new(p).exists() => {
             let bytes =
@@ -201,125 +215,105 @@ fn detect_blocking(
                 .collect();
             (ivs, true)
         }
-        _ => (vec![(0.0, total)], false),
+        _ => (Vec::new(), false),
     };
 
-    // Both constraints must hold — the user's spec, intentionally strict.
-    // No `merge_close` here either: a gap between two intersected ranges
-    // means at least one of {audio quiet, cursor still} *failed* in that
-    // gap, and bridging would mark a region as silent that isn't.
-    let mut candidates = intersect(&audio_flat, &cursor_idle);
-    candidates.retain(|iv| iv.1 - iv.0 >= opts.min_segment);
+    let mic_present = microphone_path
+        .map(|p| Path::new(p).exists())
+        .unwrap_or(false);
+    let system_present = audio_path.map(|p| Path::new(p).exists()).unwrap_or(false);
 
-    Ok(candidates
-        .into_iter()
-        .map(|seg| SilenceSegment {
-            start: round3(seg.0),
-            end: round3(seg.1),
-            confidence: score(seg, has_cursor),
-            mic_silent: microphone_path
-                .map(|p| Path::new(p).exists())
-                .unwrap_or(false),
-            system_silent: audio_path.map(|p| Path::new(p).exists()).unwrap_or(false),
-            cursor_idle: has_cursor,
-        })
-        .collect())
+    let mut out = Vec::new();
+    for (s, e) in runs {
+        let start = s as f64 * frame_dur;
+        let end = (e as f64 * frame_dur).min(total);
+        if end - start < opts.min_segment {
+            continue;
+        }
+        let mean_speech = mean(&probs[s..e]);
+        let idle_frac = if has_cursor {
+            overlap_fraction((start, end), &cursor_idle)
+        } else {
+            0.0
+        };
+        out.push(SilenceSegment {
+            start: round3(start),
+            end: round3(end),
+            confidence: score(end - start, mean_speech, idle_frac, has_cursor),
+            mic_silent: mic_present,
+            system_silent: system_present,
+            cursor_idle: has_cursor && idle_frac >= CURSOR_CONFIRM_FRAC,
+        });
+    }
+    crate::cache::put("silence", &sources, key, &out);
+    Ok(out)
+}
+
+/// Fold the detection options into a cache discriminator so a different
+/// sensitivity doesn't collide with a previously cached result.
+fn opts_key(opts: &SilenceOptions) -> u64 {
+    let mut h = DefaultHasher::new();
+    opts.threshold.to_bits().hash(&mut h);
+    opts.min_audio_silence.to_bits().hash(&mut h);
+    opts.min_segment.to_bits().hash(&mut h);
+    h.finish()
 }
 
 //  Audio analysis
 
-fn frame_rms_db(chunk: &[i16]) -> f64 {
-    if chunk.is_empty() {
-        return -120.0;
-    }
-    let sum_sq: f64 = chunk
-        .iter()
-        .map(|s| {
-            let v = *s as f64;
-            v * v
-        })
-        .sum();
-    let rms = (sum_sq / chunk.len() as f64).sqrt();
-    if rms > 1e-6 {
-        20.0 * (rms / 32768.0).log10()
-    } else {
-        -120.0
-    }
-}
-
-/// Find runs of frames whose energy sits within `tol_db` of the recording's
-/// estimated noise floor *and* below an absolute quiet ceiling. Returns
-/// intervals in seconds.
+/// Walk per-frame speech probabilities and return the non-speech runs as
+/// half-open frame-index ranges `[start, end)`, keeping only those at least
+/// `min_dur` seconds long.
 ///
-/// The dual gate matters on recordings that are mostly speech: the
-/// percentile-based floor drifts upward into quiet-syllable territory there,
-/// and a relative-only check would happily mark speech as silence. The hard
-/// `ABS_QUIET_DBFS` ceiling rejects any frame that simply isn't quiet.
-fn flat_intervals(frame_db: &[f64], frame_dur: f64, min_dur: f64, tol_db: f64) -> Vec<Interval> {
-    if frame_db.is_empty() {
-        return Vec::new();
-    }
-    let mut finite: Vec<f64> = frame_db.iter().copied().filter(|v| v.is_finite()).collect();
-    if finite.is_empty() {
-        return Vec::new();
-    }
-    finite.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    let idx = ((finite.len() as f64) * PERCENTILE_FLOOR).floor() as usize;
-    let floor = finite[idx.min(finite.len() - 1)];
-    let cap = floor + tol_db;
-
-    // Per-frame bg decision: close to the noise floor AND below the absolute
-    // quiet ceiling. Both must hold.
-    let raw_mask: Vec<bool> = frame_db
-        .iter()
-        .map(|v| *v <= cap && *v <= ABS_QUIET_DBFS)
-        .collect();
-
-    // 3-frame majority smoothing — kills single-frame jitter (an isolated
-    // envelope spike inside a silent stretch, or a one-frame bg fleck inside
-    // speech) without bridging a real burst, which is always longer than the
-    // 100 ms smoothing window.
-    let mask: Vec<bool> = (0..raw_mask.len())
-        .map(|i| {
-            let a = if i > 0 { raw_mask[i - 1] } else { false };
-            let b = raw_mask[i];
-            let c = if i + 1 < raw_mask.len() {
-                raw_mask[i + 1]
-            } else {
-                false
-            };
-            (a as u8 + b as u8 + c as u8) >= 2
-        })
-        .collect();
+/// A two-threshold state machine provides hysteresis: a frame opens a speech
+/// run at `threshold` and only closes it once the score falls below
+/// `threshold - RELEASE_MARGIN`. Without the gap, one quiet frame inside a
+/// word would carve a real utterance into spurious micro-silences.
+fn silence_runs(probs: &[f32], frame_dur: f64, threshold: f32, min_dur: f64) -> Vec<(usize, usize)> {
+    let release = (threshold - RELEASE_MARGIN).max(0.0);
+    let min_frames = (min_dur / frame_dur).ceil() as usize;
 
     let mut out = Vec::new();
-    let mut run_start: Option<usize> = None;
-    let n = mask.len();
-    for i in 0..n {
-        match (mask[i], run_start) {
-            (true, None) => run_start = Some(i),
-            (false, Some(s)) => {
-                let st = s as f64 * frame_dur;
-                let en = i as f64 * frame_dur;
-                if en - st >= min_dur {
-                    out.push((st, en));
-                }
-                run_start = None;
+    let mut speaking = false;
+    let mut run_start = 0usize;
+    for (i, &p) in probs.iter().enumerate() {
+        if speaking {
+            if p < release {
+                speaking = false;
+                run_start = i;
             }
-            _ => {}
+        } else if p >= threshold {
+            if i - run_start >= min_frames {
+                out.push((run_start, i));
+            }
+            speaking = true;
         }
     }
-    if let Some(s) = run_start {
-        let st = s as f64 * frame_dur;
-        let en = n as f64 * frame_dur;
-        if en - st >= min_dur {
-            out.push((st, en));
-        }
+    if !speaking && probs.len() - run_start >= min_frames {
+        out.push((run_start, probs.len()));
     }
     out
 }
 
+fn mean(xs: &[f32]) -> f32 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    xs.iter().sum::<f32>() / xs.len() as f32
+}
+
 //  Interval algebra
+
+/// Fraction of `seg`'s duration covered by the (sorted, disjoint) `cover`
+/// intervals, in [0,1].
+fn overlap_fraction(seg: Interval, cover: &[Interval]) -> f64 {
+    let span = seg.1 - seg.0;
+    if span <= 0.0 {
+        return 0.0;
+    }
+    let covered: f64 = intersect(&[seg], cover).iter().map(|iv| iv.1 - iv.0).sum();
+    (covered / span).clamp(0.0, 1.0)
+}
 
 /// Intersect two sorted, non-overlapping interval lists.
 fn intersect(a: &[Interval], b: &[Interval]) -> Vec<Interval> {
@@ -342,16 +336,16 @@ fn intersect(a: &[Interval], b: &[Interval]) -> Vec<Interval> {
 
 //  Confidence
 
-fn score(seg: Interval, has_cursor: bool) -> f32 {
-    let len = seg.1 - seg.0;
+/// Blend three signals into a 0..1 score:
+///   - how confidently non-speech the audio is (`1 - mean_speech`),
+///   - how long the run is (saturating at 4 s),
+///   - cursor confirmation (only when a track was present), proportional to
+///     how much of the run the cursor sat idle through.
+fn score(len: f64, mean_speech: f32, idle_frac: f64, has_cursor: bool) -> f32 {
+    let audio_conf = (1.0 - mean_speech).clamp(0.0, 1.0) as f64;
     let len_score = (len / 4.0).min(1.0);
-    let mut c = 0.45 + 0.40 * len_score;
-    // Verified-idle cursor is a real second-source confirmation; an
-    // unverified cursor (track missing) gets none.
-    if has_cursor {
-        c += 0.15;
-    }
-    c.clamp(0.0, 1.0) as f32
+    let cursor_bonus = if has_cursor { 0.15 * idle_frac } else { 0.0 };
+    (0.55 * audio_conf + 0.30 * len_score + cursor_bonus).clamp(0.0, 1.0) as f32
 }
 
 fn round3(v: f64) -> f64 {
@@ -475,16 +469,35 @@ fn waveform_blocking(
 
 #[cfg(test)]
 mod tests {
-    use super::{frame_rms_db, intersect, round3, score};
+    use super::{intersect, overlap_fraction, round3, score, silence_runs};
+
+    // frame_dur 1.0 makes frame index == seconds, so min_dur reads directly.
+    const DUR: f64 = 1.0;
 
     #[test]
-    fn frame_rms_db_handles_silence_and_levels() {
-        // No samples and digital silence both read as the floor.
-        assert_eq!(frame_rms_db(&[]), -120.0);
-        assert_eq!(frame_rms_db(&[0, 0, 0, 0]), -120.0);
-        // Full-scale sits at ~0 dBFS, half-amplitude at ~ -6 dBFS.
-        assert!((frame_rms_db(&[i16::MAX; 64]) - 0.0).abs() < 0.01);
-        assert!((frame_rms_db(&[16384i16; 64]) - (-6.02)).abs() < 0.05);
+    fn silence_runs_finds_leading_internal_and_trailing_gaps() {
+        let probs = [0.1, 0.1, 0.9, 0.9, 0.1, 0.1, 0.1, 0.9];
+        assert_eq!(silence_runs(&probs, DUR, 0.5, 2.0), vec![(0, 2), (4, 7)]);
+    }
+
+    #[test]
+    fn silence_runs_hysteresis_does_not_split_speech_on_a_single_dip() {
+        // 0.4 sits in the [release, threshold) band, so the speech run holds
+        // through it instead of fracturing into two silences.
+        let probs = [0.9, 0.9, 0.4, 0.9, 0.9];
+        assert!(silence_runs(&probs, DUR, 0.5, 2.0).is_empty());
+    }
+
+    #[test]
+    fn silence_runs_drops_runs_below_min_duration() {
+        // A single-frame gap (< 2 s) is discarded; the trailing 3-frame gap
+        // is kept and runs to the end.
+        assert!(silence_runs(&[0.1, 0.9, 0.9], DUR, 0.5, 2.0).is_empty());
+        assert_eq!(
+            silence_runs(&[0.9, 0.9, 0.1, 0.1, 0.1], DUR, 0.5, 2.0),
+            vec![(2, 5)]
+        );
+        assert_eq!(silence_runs(&[0.1; 5], DUR, 0.5, 2.0), vec![(0, 5)]);
     }
 
     #[test]
@@ -499,16 +512,23 @@ mod tests {
     }
 
     #[test]
-    fn score_scales_with_length_and_cursor_confirmation() {
-        // A 4 s segment saturates the length term (0.45 + 0.40).
-        assert!((score((0.0, 4.0), false) - 0.85_f32).abs() < 1e-4);
-        // Cursor confirmation adds 0.15 and clamps at 1.0.
-        assert!((score((0.0, 4.0), true) - 1.0_f32).abs() < 1e-4);
-        // A 2 s segment → half the length term.
-        assert!((score((0.0, 2.0), false) - 0.65_f32).abs() < 1e-4);
-        // Always within [0, 1].
-        let long = score((0.0, 100.0), true);
-        assert!((0.0..=1.0).contains(&long));
+    fn overlap_fraction_measures_covered_share() {
+        assert!((overlap_fraction((0.0, 10.0), &[(2.0, 4.0), (6.0, 7.0)]) - 0.3).abs() < 1e-9);
+        assert_eq!(overlap_fraction((0.0, 10.0), &[]), 0.0);
+        assert_eq!(overlap_fraction((5.0, 5.0), &[(0.0, 10.0)]), 0.0);
+    }
+
+    #[test]
+    fn score_blends_audio_length_and_cursor() {
+        // Deeply silent (mean 0), 4 s saturates length: 0.55 + 0.30.
+        assert!((score(4.0, 0.0, 0.0, false) - 0.85).abs() < 1e-6);
+        // Full cursor-idle confirmation adds 0.15 → clamps at 1.0.
+        assert!((score(4.0, 0.0, 1.0, true) - 1.0).abs() < 1e-6);
+        // High mean speech probability collapses the audio term.
+        assert!((score(4.0, 1.0, 0.0, false) - 0.30).abs() < 1e-6);
+        // Shorter run → half the length term, no cursor track.
+        assert!((score(2.0, 0.0, 0.0, false) - 0.70).abs() < 1e-6);
+        assert!((0.0..=1.0).contains(&score(100.0, 0.0, 1.0, true)));
     }
 
     #[test]
@@ -516,5 +536,19 @@ mod tests {
         assert_eq!(round3(1.234_56), 1.235);
         assert_eq!(round3(0.0), 0.0);
         assert_eq!(round3(2.0 / 3.0), 0.667);
+    }
+
+    // Integration guard: the bundled Silero model loads through ort and scores
+    // a frame, and digital silence reads as non-speech.
+    #[test]
+    fn silero_model_loads_and_scores_silence_low() {
+        let mut vad = super::VoiceActivityDetector::builder()
+            .sample_rate(super::RATE)
+            .chunk_size(super::CHUNK)
+            .build()
+            .expect("build Silero VAD");
+        let p = vad.predict(vec![0i16; super::CHUNK]);
+        assert!((0.0..=1.0).contains(&p), "probability in range, got {p}");
+        assert!(p < 0.5, "digital silence should read as non-speech, got {p}");
     }
 }

--- a/apps/desktop/src-tauri/src/silence.rs
+++ b/apps/desktop/src-tauri/src/silence.rs
@@ -269,7 +269,12 @@ fn opts_key(opts: &SilenceOptions) -> u64 {
 /// run at `threshold` and only closes it once the score falls below
 /// `threshold - RELEASE_MARGIN`. Without the gap, one quiet frame inside a
 /// word would carve a real utterance into spurious micro-silences.
-fn silence_runs(probs: &[f32], frame_dur: f64, threshold: f32, min_dur: f64) -> Vec<(usize, usize)> {
+fn silence_runs(
+    probs: &[f32],
+    frame_dur: f64,
+    threshold: f32,
+    min_dur: f64,
+) -> Vec<(usize, usize)> {
     let release = (threshold - RELEASE_MARGIN).max(0.0);
     let min_frames = (min_dur / frame_dur).ceil() as usize;
 
@@ -549,6 +554,9 @@ mod tests {
             .expect("build Silero VAD");
         let p = vad.predict(vec![0i16; super::CHUNK]);
         assert!((0.0..=1.0).contains(&p), "probability in range, got {p}");
-        assert!(p < 0.5, "digital silence should read as non-speech, got {p}");
+        assert!(
+            p < 0.5,
+            "digital silence should read as non-speech, got {p}"
+        );
     }
 }

--- a/apps/desktop/src/components/editor/Timeline.svelte
+++ b/apps/desktop/src/components/editor/Timeline.svelte
@@ -4,7 +4,7 @@
     ZoomRegion,
   } from "$lib/stores/editor-store.svelte";
   import { experimentalStore } from "$lib/stores/experimental.svelte";
-  import { Eye, EyeOff, Film, Pencil, Scissors, Target } from "@lucide/svelte";
+  import { Film, Pencil, Scissors, Target } from "@lucide/svelte";
   import { onMount } from "svelte";
   import TimelineAnnotationLane from "./_components/timeline/TimelineAnnotationLane.svelte";
   import TimelineClipBar from "./_components/timeline/TimelineClipBar.svelte";
@@ -69,6 +69,7 @@
     clipContent: ClipContent;
     zoom: boolean;
     markup: boolean;
+    silence: boolean;
   } {
     if (typeof localStorage !== "undefined") {
       try {
@@ -79,18 +80,25 @@
             clipContent: v.clipContent === "waveform" ? "waveform" : "thumbnails",
             zoom: v.zoom !== false,
             markup: v.markup !== false,
+            silence: v.silence !== false,
           };
         }
       } catch {
         /* fall through to defaults */
       }
     }
-    return { clipContent: "thumbnails", zoom: true, markup: true };
+    return { clipContent: "thumbnails", zoom: true, markup: true, silence: true };
   }
   const _view = loadView();
   let clipContent = $state<ClipContent>(_view.clipContent);
   let showZoomLane = $state(_view.zoom);
   let showMarkupLane = $state(_view.markup);
+  let showSilenceLane = $state(_view.silence);
+  // The Silence lane only exists when the experimental flag is on; this gates
+  // both the rail header and the lane so the two never disagree.
+  const silenceLaneVisible = $derived(
+    experimentalStore.silenceDetection && showSilenceLane,
+  );
   $effect(() => {
     if (typeof localStorage === "undefined") return;
     try {
@@ -100,6 +108,7 @@
           clipContent,
           zoom: showZoomLane,
           markup: showMarkupLane,
+          silence: showSilenceLane,
         }),
       );
     } catch {
@@ -783,23 +792,6 @@
   </span>
 {/snippet}
 
-{#snippet railEye(visible: boolean, toggle: () => void, title: string)}
-  <button
-    type="button"
-    onclick={toggle}
-    {title}
-    aria-label={title}
-    aria-pressed={!visible}
-    class="flex size-4 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-  >
-    {#if visible}
-      <Eye class="size-2.5" />
-    {:else}
-      <EyeOff class="size-2.5" />
-    {/if}
-  </button>
-{/snippet}
-
 <div
   class="shrink-0 select-none border-t border-border/60 bg-card/30 px-2 pt-1.5 pb-2"
 >
@@ -817,6 +809,7 @@
     clipContent={clipContent}
     {showZoomLane}
     {showMarkupLane}
+    {showSilenceLane}
     onSetTrim={setTrimPoint}
     onSplit={splitAtPlayhead}
     onToggleRazor={toggleRazor}
@@ -830,6 +823,7 @@
     onSetClipContent={(c) => (clipContent = c)}
     onToggleZoomLane={() => (showZoomLane = !showZoomLane)}
     onToggleMarkupLane={() => (showMarkupLane = !showMarkupLane)}
+    onToggleSilenceLane={() => (showSilenceLane = !showSilenceLane)}
   />
 
   <!-- Rail lives OUTSIDE the scroller so lane names never overlap a card at t≈0.
@@ -857,17 +851,9 @@
             {@render railLabel(Pencil, "Markup", "bg-warning/15 text-warning")}
           </div>
         {/if}
-        {#if experimentalStore.silenceDetection}
-          <!-- Cuts -->
-          <div class="mt-1.5 flex min-h-9 items-center justify-between gap-1">
+        {#if silenceLaneVisible}
+          <div class="mt-1.5 flex min-h-9 items-center justify-center">
             {@render railLabel(Scissors, "Silence", "bg-destructive/15 text-destructive")}
-            {@render railEye(
-              store.cutsEnabled,
-              () => (store.cutsEnabled = !store.cutsEnabled),
-              store.cutsEnabled
-                ? "Disable silence cuts (cuts stay; playback & export ignore them)"
-                : "Enable silence cuts",
-            )}
           </div>
         {/if}
       </div>
@@ -940,7 +926,7 @@
           />
         {/if}
 
-        {#if experimentalStore.silenceDetection}
+        {#if silenceLaneVisible}
           <TimelineCutLane {store} {pixelsPerSecond} {duration} />
         {/if}
       </div>

--- a/apps/desktop/src/components/editor/_components/timeline/TimelineToolbar.svelte
+++ b/apps/desktop/src/components/editor/_components/timeline/TimelineToolbar.svelte
@@ -50,12 +50,14 @@
     clipContent: "thumbnails" | "waveform";
     showZoomLane: boolean;
     showMarkupLane: boolean;
+    showSilenceLane: boolean;
     onSetTrim: (kind: "in" | "out") => void;
     onSplit: () => void;
     onToggleRazor: () => void;
     onSetClipContent: (content: "thumbnails" | "waveform") => void;
     onToggleZoomLane: () => void;
     onToggleMarkupLane: () => void;
+    onToggleSilenceLane: () => void;
     onAddFocusRegion: () => void;
     onResetTrim: () => void;
     onZoomTimeline: (dir: number) => void;
@@ -79,12 +81,14 @@
     clipContent,
     showZoomLane,
     showMarkupLane,
+    showSilenceLane,
     onSetTrim,
     onSplit,
     onToggleRazor,
     onSetClipContent,
     onToggleZoomLane,
     onToggleMarkupLane,
+    onToggleSilenceLane,
     onAddFocusRegion,
     onResetTrim,
     onZoomTimeline,
@@ -383,6 +387,15 @@
           <Pencil class="size-3" />
           Markup
         </DropdownMenu.CheckboxItem>
+        {#if experimentalStore.silenceDetection}
+          <DropdownMenu.CheckboxItem
+            checked={showSilenceLane}
+            onCheckedChange={onToggleSilenceLane}
+          >
+            <Scissors class="size-3" />
+            Silence
+          </DropdownMenu.CheckboxItem>
+        {/if}
 
         <DropdownMenu.Separator />
 
@@ -402,6 +415,15 @@
           <Pencil class="size-3" />
           Markup
         </DropdownMenu.CheckboxItem>
+        {#if experimentalStore.silenceDetection}
+          <DropdownMenu.CheckboxItem
+            checked={store.cutsEnabled}
+            onCheckedChange={() => (store.cutsEnabled = !store.cutsEnabled)}
+          >
+            <Scissors class="size-3" />
+            Silence cuts
+          </DropdownMenu.CheckboxItem>
+        {/if}
       </DropdownMenu.Content>
     </DropdownMenu.Root>
 

--- a/apps/desktop/src/components/editor/silence-review.logic.ts
+++ b/apps/desktop/src/components/editor/silence-review.logic.ts
@@ -18,16 +18,17 @@ export const CUT_PADDING = 0.12;
 export const BULK_MIN_CONFIDENCE = 0.5;
 
 /** "Balanced" uses the Rust-side defaults; the others trade recall vs false
- *  positives. */
+ *  positives. A lower `threshold` is stricter (a frame counts as speech more
+ *  readily, so less is called silence); a higher one is more aggressive. */
 export const SENSITIVITY_PRESETS: Record<Sensitivity, SilenceDetectOptions> = {
 	relaxed: {
-		flatnessDb: 3,
+		threshold: 0.35,
 		minAudioSilence: 1,
 		minSegment: 1.5,
 	},
 	balanced: {},
 	aggressive: {
-		flatnessDb: 8,
+		threshold: 0.6,
 		minAudioSilence: 0.4,
 		minSegment: 0.6,
 	},

--- a/apps/desktop/src/constants/changelog.ts
+++ b/apps/desktop/src/constants/changelog.ts
@@ -37,6 +37,16 @@ export const KIND_META: Record<
 // RELEASES:START — auto-generated, do not edit by hand
 export const RELEASES: readonly ChangelogRelease[] = [
 	{
+		version: '0.2.9',
+		date: '2026-06-29',
+		changes: [
+			{ kind: 'added', summary: 'Update older recordings to the current project format in bulk from the library, or one at a time from a recording\'s menu. Recordings that still use the old format are marked so you can see which need updating.' },
+			{ kind: 'changed', summary: 'Silence detection is far more accurate. It now uses on-device voice detection to find genuinely silent, speech-free stretches and suggest them for removal, instead of judging by volume alone, which often mistook breathing, typing, and background hum for speech. Suggestions appear instantly when a recording opens, and now show up for camera-only recordings, not just screen recordings. Nothing is removed automatically, the quiet parts are only suggested for you to accept or skip.' },
+			{ kind: 'changed', summary: 'Recordings now save in a new project format that keeps each part of your edit (background, zoom, annotations, audio) in its own section, so project files are more robust and easier to inspect. Older recordings are updated to the new format when you open them, and a copy of the original is kept alongside it first.' },
+			{ kind: 'changed', summary: 'The editor stays responsive on long recordings. Adjusting cursor smoothing no longer freezes the preview, undo and redo are quicker, and autosave no longer causes a brief stutter.' },
+		],
+	},
+	{
 		version: '0.2.8',
 		date: '2026-06-28',
 		highlights: [

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -547,13 +547,12 @@ export function suggestZoomRegions(cursorPath: string): Promise<ZoomSuggestion[]
 /** Tunable thresholds for `detectSilence`; omit any field to use the default. */
 export interface SilenceDetectOptions {
 	/**
-	 * Frames must sit within this many dB of the recording's own noise floor
-	 * to count as background. The floor is estimated per-recording, so this
-	 * is relative to whatever level "background" sits at — a noisy room and a
-	 * dead-quiet one both detect sensibly.
+	 * Speech-probability threshold in [0,1]: a frame counts as speech once the
+	 * voice-activity model scores at or above it, so everything below is
+	 * silence. Higher = more aggressive (more gets called silence).
 	 */
-	flatnessDb?: number;
-	/** Minimum continuous flat-audio run (seconds). */
+	threshold?: number;
+	/** Minimum continuous non-speech run (seconds). */
 	minAudioSilence?: number;
 	/** Minimum length of a returned silence segment (seconds). */
 	minSegment?: number;
@@ -572,9 +571,9 @@ export interface SilenceSegment {
 }
 
 /**
- * Analyse a recording for silence — ranges where the audio envelope is flat
- * near its own noise floor AND the cursor isn't moving. Both constraints
- * must hold. Implementation lives in `silence.rs` (Rust).
+ * Analyse a recording for silence — ranges a Silero voice-activity model
+ * scores as non-speech. An idle cursor over the range raises confidence but is
+ * no longer required. Implementation lives in `silence.rs` (Rust).
  */
 export function detectSilence(
 	audioPath?: string | null,

--- a/apps/desktop/src/routes/editor/[file]/+page.svelte
+++ b/apps/desktop/src/routes/editor/[file]/+page.svelte
@@ -19,6 +19,7 @@
     cancelExport,
     clearAutosave,
     createExportId,
+    detectSilence,
     extractWaveform,
     generateThumbnails,
     loadEditorDocument,
@@ -541,6 +542,24 @@
     } catch (err) {
       console.warn("Waveform extraction failed", err);
       store.waveform = [];
+    }
+    // Warm the silence-detection cache off the back of the waveform pass (one
+    // FFmpeg decode at a time, never on the load path). The result is discarded
+    // here — `detectSilence` writes it to the file-identity cache the review
+    // popover reads, so opening that popover is instant. Default options match
+    // the popover's "balanced" sensitivity.
+    void warmSilenceCache();
+  }
+
+  async function warmSilenceCache() {
+    try {
+      await detectSilence(
+        store.audioPath,
+        store.microphonePath,
+        store.cursorPath,
+      );
+    } catch (err) {
+      console.warn("Silence precompute failed", err);
     }
   }
 


### PR DESCRIPTION
The envelope/RMS gate mistook room tone, breathing and keyboard noise
for speech, so it both leaked false silences and swallowed quiet speech.
Swap it for a Silero voice-activity model (MIT, bundled) run through ort.

- silence.rs: decode at 16kHz/512-window; silence_runs() derives non-speech
  runs with two-threshold hysteresis + min-duration, replacing flat_intervals
  and frame_rms_db
- cursor demoted from a hard AND-gate to a confidence weight via
  overlap_fraction(), so webcam/talking-head clips get suggestions too
- detect_silence disk-caches results by file identity + options; the editor
  warms that cache after the waveform pass so the review popover opens instantly
- SilenceOptions.flatnessDb -> threshold (speech probability); presets retuned
  (relaxed 0.35 / balanced default / aggressive 0.6)
- SilenceSegment shape unchanged, so the review UI and cut model are untouched

ort downloads + static-links the ONNX Runtime at build; no loose native lib
and no runtime model download. Tests cover the run derivation, overlap and
scoring, plus a live model-load guard.