### PR TITLE
fix(build): keep Intel-Mac support — pure-Rust silence, gate captions off ort

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -105,10 +105,15 @@ jobs:
             os: macos-latest
             rust_target: aarch64-apple-darwin
             tauri_args: --target aarch64-apple-darwin
+          # macos-x64 (Intel) builds WITHOUT captions (`--no-default-features`):
+          # ort rc.12 has no x86_64-apple-darwin ONNX Runtime prebuilt (Microsoft
+          # dropped Intel-Mac at 1.24). Silence detection runs on pure-Rust tract,
+          # so the rest of the app builds fine; the UI warns captions are
+          # unavailable on Intel Mac.
           - name: macos-x64
             os: macos-latest
             rust_target: x86_64-apple-darwin
-            tauri_args: --target x86_64-apple-darwin
+            tauri_args: --target x86_64-apple-darwin --no-default-features
           - name: linux-x64
             os: ubuntu-24.04
             rust_target: x86_64-unknown-linux-gnu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,25 @@ See [`.changeset/README.md`](.changeset/README.md) for the full flow.
 
 ## [Unreleased]
 
+## [0.2.10] — 2026-07-01
+
+### Highlights
+- Animated captions: highlight the word being spoken, pop words in one at a time, or reveal short phrases.
+- Captions sit around the padded video frame and export with their real fonts.
+
+### Added
+- Animated captions. Captions can now animate in time with speech: highlight the word being spoken karaoke-style, pop each word in one at a time, or fade in short phrases. A set of modern presets (Clean, Pill, Bold, Spotlight, Wave, Punch, Hype) ships with matching fonts, colors, and animation, and the theme picker previews each one. Controls for how words are grouped, the active-word highlight, the entrance effect, and position all live in the Captions tab.
+- The Captions tab now tells you when a recording has no audio to transcribe, instead of letting you try and fail.
+
+### Changed
+- Captions are positioned against the whole video frame. When you add padding, top and bottom captions sit in the margin instead of overlapping the footage, and the preview matches the exported video. The position control moved next to alignment and now nudges captions in either direction over a wider range.
+- Refreshed the built-in caption styles with modern fonts and colors.
+- On-device captions need Apple Silicon, Windows, or Linux. On Intel Macs the Captions tab explains this and the rest of the editor works normally.
+
+### Fixed
+- Caption fonts now render in exported video, not just the preview.
+- Exporting a recording that has cuts or speed changes no longer holds the last frame for several seconds or produces a file longer than the edit.
+
 ## [0.2.9] — 2026-06-29
 
 ### Added

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -20,6 +20,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +120,18 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "anymap2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
+
+[[package]]
+name = "anymap3"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5dfbc6d8d2675589ccbe4d0fd61df2419075625f8c1a62325e718e2b0049f9"
 
 [[package]]
 name = "apple-cf"
@@ -425,6 +449,21 @@ dependencies = [
  "shlex",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit_field"
@@ -1132,6 +1171,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1338,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
+
+[[package]]
 name = "doom-fish-utils"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,6 +1441,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "dyn-hash"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15401da73a9ed8c80e3b2d4dc05fe10e7b72d7243b9f614e516a44fa99986e88"
 
 [[package]]
 name = "either"
@@ -1543,16 +1605,6 @@ dependencies = [
  "rayon-core",
  "smallvec",
  "zune-inflate",
-]
-
-[[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
 ]
 
 [[package]]
@@ -2187,6 +2239,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -2196,7 +2249,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -2573,12 +2635,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
-name = "indenter"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2665,6 +2721,24 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2822,6 +2896,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,6 +3006,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,6 +3082,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "liquid"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9338405fdbc0bce9b01695b2a2ef6b20eca5363f385d47bce48ddf8323cc25"
+dependencies = [
+ "doc-comment",
+ "liquid-core",
+ "liquid-derive",
+ "liquid-lib",
+ "serde",
+]
+
+[[package]]
+name = "liquid-core"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feb8fed70857010ed9016ed2ce5a7f34e7cc51d5d7255c9c9dc2e3243e490b42"
+dependencies = [
+ "anymap2",
+ "itertools 0.13.0",
+ "kstring",
+ "liquid-derive",
+ "num-traits",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "liquid-derive"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b51f1d220e3fa869e24cfd75915efe3164bd09bb11b3165db3f37f57bf673e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "liquid-lib"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee1794b5605e9f8864a8a4f41aa97976b42512cc81093f8c885d29fb94c6c556"
+dependencies = [
+ "itertools 0.13.0",
+ "liquid-core",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "time",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,6 +3198,12 @@ dependencies = [
  "core-foundation 0.9.4",
  "core-foundation-sys",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
@@ -3216,6 +3369,21 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "ndarray"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
@@ -3371,6 +3539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3838,7 +4007,7 @@ version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
- "ndarray",
+ "ndarray 0.17.2",
  "ort-sys",
  "smallvec",
  "tracing",
@@ -3972,6 +4141,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "phf"
@@ -4369,6 +4581,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4611,6 +4846,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4739,6 +4984,7 @@ dependencies = [
  "image",
  "keyring",
  "log",
+ "ort",
  "parking_lot",
  "pipewire",
  "rand 0.8.5",
@@ -4759,10 +5005,10 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tokio",
+ "tract-onnx",
  "transcribe-rs",
  "trash",
  "urlencoding",
- "vad-rs",
  "webkit2gtk",
  "windows 0.58.0",
  "x11rb",
@@ -4973,12 +5219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ringbuffer"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
-
-[[package]]
 name = "rkyv"
 version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5158,6 +5398,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scan_fmt"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b53b0a5db882a8e2fdaae0a43f7b39e7e9082389e978398bdf223a55b581248"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -5630,10 +5879,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "string-interner"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f9fdfdd31a0ff38b59deb401be81b73913d76c9cc5b1aed4e1330a223420b9"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "serde",
+]
 
 [[package]]
 name = "string_cache"
@@ -6631,6 +6897,143 @@ dependencies = [
 ]
 
 [[package]]
+name = "tract-core"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b5347639690871b124593a8c8903f1f369531498b8abaebd18eb5c58163971"
+dependencies = [
+ "anyhow",
+ "anymap3",
+ "bit-set",
+ "derive-new",
+ "downcast-rs",
+ "dyn-clone",
+ "lazy_static",
+ "log",
+ "maplit",
+ "ndarray 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "rustfft",
+ "smallvec",
+ "tract-data",
+ "tract-linalg",
+]
+
+[[package]]
+name = "tract-data"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a3f476a1804e05708e9bc5e2d29dcab82bad531e357d3d14d7da80fbba0b6d"
+dependencies = [
+ "anyhow",
+ "downcast-rs",
+ "dyn-clone",
+ "dyn-hash",
+ "half",
+ "itertools 0.12.1",
+ "lazy_static",
+ "maplit",
+ "ndarray 0.16.1",
+ "nom 7.1.3",
+ "num-integer",
+ "num-traits",
+ "parking_lot",
+ "scan_fmt",
+ "smallvec",
+ "string-interner",
+]
+
+[[package]]
+name = "tract-hir"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dca047ba1151fe3446fb0194d4b6ddb9ae8f361337c47a267870c53605fbafb"
+dependencies = [
+ "derive-new",
+ "log",
+ "tract-core",
+]
+
+[[package]]
+name = "tract-linalg"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8e0703eb53ef1bbf77050ff261675818dd5f0d6c27044c6e48ede9b845f9e0"
+dependencies = [
+ "byteorder",
+ "cc",
+ "derive-new",
+ "downcast-rs",
+ "dyn-clone",
+ "dyn-hash",
+ "half",
+ "lazy_static",
+ "liquid",
+ "liquid-core",
+ "liquid-derive",
+ "log",
+ "num-traits",
+ "paste",
+ "rayon",
+ "scan_fmt",
+ "smallvec",
+ "time",
+ "tract-data",
+ "unicode-normalization",
+ "walkdir",
+]
+
+[[package]]
+name = "tract-nnef"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cb88a4367ec2c695610223cf886f01fc1deb5c9a82c7a74b1a5d32dc0b1466"
+dependencies = [
+ "byteorder",
+ "flate2",
+ "log",
+ "nom 7.1.3",
+ "tar",
+ "tract-core",
+ "walkdir",
+]
+
+[[package]]
+name = "tract-onnx"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5830aa672b2aa4dc98a97a36e5988eaf77b3ecee65e2601619588d2ca557008"
+dependencies = [
+ "bytes",
+ "derive-new",
+ "log",
+ "memmap2",
+ "num-integer",
+ "prost",
+ "smallvec",
+ "tract-hir",
+ "tract-nnef",
+ "tract-onnx-opl",
+]
+
+[[package]]
+name = "tract-onnx-opl"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121d3d224c806ba3d941f4bb50943ad33b59d1da5ae704d0e4e76d2808221f96"
+dependencies = [
+ "getrandom 0.2.17",
+ "log",
+ "rand 0.8.5",
+ "rand_distr",
+ "rustfft",
+ "tract-nnef",
+]
+
+[[package]]
 name = "transcribe-rs"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6641,7 +7044,7 @@ dependencies = [
  "env_logger",
  "hound",
  "log",
- "ndarray",
+ "ndarray 0.17.2",
  "once_cell",
  "ort",
  "regex",
@@ -6720,6 +7123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "uds_windows"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6776,6 +7185,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -6907,17 +7325,6 @@ dependencies = [
  "aligned-vec",
  "num-traits",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "vad-rs"
-version = "0.1.6"
-source = "git+https://github.com/cjpais/vad-rs#2a412ed858695b9251f3f5a1a20d95b59fa7c498"
-dependencies = [
- "eyre",
- "ndarray",
- "ort",
- "ringbuffer",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -70,13 +70,19 @@ urlencoding = "2"
 # Cryptographic-quality randomness for PKCE code verifier + state token.
 # The `getrandom` backend on each OS feeds /dev/urandom or BCryptGenRandom.
 rand = "0.8"
-# Silero VAD via `vad-rs` for silence detection. Pins `ort = 2.0.0-rc.12`, the
-# SAME version transcribe-rs (captions) uses — so the two share one ONNX
-# Runtime (ort's `download-binaries` fetches a prebuilt lib; no libclang/CMake).
-# Replaces `voice_activity_detector` (which pinned ort rc.10 and couldn't
-# coexist with Parakeet). Unlike that crate, vad-rs does NOT embed the model, so
-# `silero_vad.onnx` is downloaded on first use (see silence.rs).
-vad-rs = { git = "https://github.com/cjpais/vad-rs", default-features = false }
+# Silence detection runs Silero VAD on `tract` — PURE RUST, no native ONNX
+# Runtime. This keeps the always-on silence path OS-agnostic (builds on every
+# target, incl. x86_64-apple-darwin where `ort` has no prebuilt). Replaces the
+# old `vad-rs` (which pulled `ort`). `silero_vad.onnx` is downloaded on first use
+# (see silence.rs); tract runs its Conv+LSTM graph natively.
+tract-onnx = "0.21"
+# `ort` (ONNX Runtime, native) is needed ONLY by the captions engine, so it's
+# optional and gated behind `captions`. `download-binaries` fetches the prebuilt
+# runtime. NOTE: ort rc.12 ships NO x86_64-apple-darwin prebuilt (Microsoft
+# dropped Intel-Mac at ONNX Runtime 1.24), so the Intel-Mac CI job builds with
+# `--no-default-features` (captions off → no ort); the app warns that captions
+# aren't available there. Pin must match transcribe-rs (rc.12); no libclang/CMake.
+ort = { version = "=2.0.0-rc.12", default-features = false, features = ["download-binaries"], optional = true }
 # Offline transcription — Parakeet via ONNX (ort rc.12, prebuilt runtime, NO
 # libclang/CMake). Optional, behind `captions`. whisper.cpp (the `whisper-cpp`
 # feature) is intentionally OFF — it would add the LLVM+CMake toolchain; revisit
@@ -164,10 +170,11 @@ device_query = "2.1"
 screencapturekit = { version = "6.0", default-features = false, features = ["macos_13_0"], optional = true }
 
 [features]
-# Captions on by default: the Parakeet/ONNX engine builds with no extra
-# toolchain (ort ships a prebuilt runtime; vad-rs already pulls ort), so the
-# normal `pnpm tauri dev` / `tauri build` includes transcription. Only the
-# whisper.cpp side (not enabled) would need LLVM+CMake.
+# Captions on by default: the Parakeet/ONNX engine builds with no extra toolchain
+# (ort ships a prebuilt runtime via download-binaries). Silence detection is NOT
+# gated — it runs on pure-Rust `tract`, so the app (minus captions) builds on
+# every target. The Intel-Mac CI job builds `--no-default-features` (no `ort`,
+# which has no x86_64-apple-darwin prebuilt); captions are then unavailable there.
 default = ["captions"]
 # Offline captions / transcription engine. Will gate the `transcribe-rs`
 # (Parakeet) + `whisper-rs` deps. BLOCKED for now: `transcribe-rs` pins
@@ -176,10 +183,11 @@ default = ["captions"]
 # DECIDED: align everything on rc.12. No VAD release > 0.2.1 exists, so this
 # needs a `[patch.crates-io]` fork of `voice_activity_detector` re-pinned to
 # rc.12, landed together with the engine deps so one `cargo build` verifies
-# both. The download/audio/command plumbing compiles without the feature;
-# flipping it on currently just changes the engine seam's error message.
-# See docs/captions-transcription-plan.md §7.
-captions = ["dep:transcribe-rs"]
+# Offline captions engine (Parakeet/ONNX via transcribe-rs). Pulls the native
+# `ort` runtime — hence excluded from the Intel-Mac build. The transcription
+# module's non-engine plumbing (model list, download, device caps) compiles
+# without the feature; the engine seam returns a "not available" error.
+captions = ["dep:transcribe-rs", "dep:ort"]
 # Enables the native ScreenCaptureKit audio loopback path on macOS.
 # See `audio/platform/macos_sckit.rs` for the runtime smoke-test
 # checklist before flipping this on for a release build.

--- a/apps/desktop/src-tauri/src/silence.rs
+++ b/apps/desktop/src-tauri/src/silence.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use tauri::AppHandle;
-use vad_rs::Vad;
+use tract_onnx::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
@@ -81,9 +81,86 @@ pub struct SilenceSegment {
 
 type Interval = (f64, f64);
 
-// Silero v5 runs at 16 kHz with a fixed 512-sample window (32 ms/frame).
+// Silero runs at 16 kHz with a fixed 512-sample window (32 ms/frame).
 const RATE: u32 = 16_000;
 const CHUNK: usize = 512;
+/// Silero's LSTM hidden/cell state size — two tensors of shape [2, 1, 64].
+const STATE: [usize; 3] = [2, 1, 64];
+
+/// Silero VAD on **tract** (pure Rust — no native ONNX Runtime, so the always-on
+/// silence path builds on every target incl. x86_64-apple-darwin). Mirrors the
+/// model I/O the app has always fed it: `input`/`sr`/`h`/`c` → `output`/`hn`/`cn`,
+/// carrying the two LSTM state tensors between windows.
+struct SileroVad {
+    plan: TypedSimplePlan<TypedModel>,
+    h: Tensor,
+    c: Tensor,
+    sr: Tensor,
+}
+
+impl SileroVad {
+    fn new(path: &Path) -> Result<Self, String> {
+        let map = |e: TractError, what: &str| format!("Silero {what}: {e}");
+        let plan = tract_onnx::onnx()
+            .model_for_path(path)
+            .map_err(|e| map(e, "load"))?
+            // Pin input/output order + shapes so tract can optimize the graph.
+            .with_input_names(["input", "sr", "h", "c"])
+            .map_err(|e| map(e, "input names"))?
+            .with_output_names(["output", "hn", "cn"])
+            .map_err(|e| map(e, "output names"))?
+            .with_input_fact(0, f32::fact([1, CHUNK]).into())
+            .map_err(|e| map(e, "input fact"))?
+            .with_input_fact(1, i64::fact([1]).into())
+            .map_err(|e| map(e, "sr fact"))?
+            .with_input_fact(2, f32::fact(STATE).into())
+            .map_err(|e| map(e, "h fact"))?
+            .with_input_fact(3, f32::fact(STATE).into())
+            .map_err(|e| map(e, "c fact"))?
+            .into_optimized()
+            .map_err(|e| map(e, "optimize"))?
+            .into_runnable()
+            .map_err(|e| map(e, "runnable"))?;
+        Ok(Self {
+            plan,
+            h: Tensor::zero::<f32>(&STATE).map_err(|e| map(e, "state"))?,
+            c: Tensor::zero::<f32>(&STATE).map_err(|e| map(e, "state"))?,
+            sr: tensor1(&[RATE as i64]),
+        })
+    }
+
+    /// Clear the LSTM state so the next window starts a fresh sequence.
+    fn reset(&mut self) -> Result<(), String> {
+        self.h = Tensor::zero::<f32>(&STATE).map_err(|e| format!("Silero reset: {e}"))?;
+        self.c = Tensor::zero::<f32>(&STATE).map_err(|e| format!("Silero reset: {e}"))?;
+        Ok(())
+    }
+
+    /// Speech probability for one 512-sample window; advances the LSTM state.
+    fn compute(&mut self, window: &[f32]) -> Result<f32, String> {
+        let input = Tensor::from_shape(&[1, window.len()], window)
+            .map_err(|e| format!("Silero window: {e}"))?;
+        let out = self
+            .plan
+            .run(tvec!(
+                input.into(),
+                self.sr.clone().into(),
+                self.h.clone().into(),
+                self.c.clone().into(),
+            ))
+            .map_err(|e| format!("Silero run: {e}"))?;
+        let prob = out[0]
+            .to_array_view::<f32>()
+            .map_err(|e| format!("Silero output: {e}"))?
+            .iter()
+            .copied()
+            .next()
+            .unwrap_or(0.0);
+        self.h = out[1].clone().into_tensor();
+        self.c = out[2].clone().into_tensor();
+        Ok(prob)
+    }
+}
 /// How far below `threshold` the score must fall to *end* a speech run. The
 /// gap is the hysteresis band: it stops a single quiet frame mid-word from
 /// fracturing speech into spurious micro-silences.
@@ -203,20 +280,16 @@ fn detect_blocking(
 
     // Per-frame speech probability. Silero is a stateful LSTM, so frames are
     // scored in order; `reset` clears that state, and the short trailing frame
-    // is zero-padded to a full window. vad-rs takes f32 in [-1, 1].
-    let mut vad =
-        Vad::new(silero_path, RATE as usize).map_err(|e| format!("init Silero VAD: {e}"))?;
-    vad.reset();
+    // is zero-padded to a full window. Samples are f32 in [-1, 1].
+    let mut vad = SileroVad::new(silero_path)?;
+    vad.reset()?;
     let mut probs: Vec<f32> = Vec::with_capacity(samples.len() / CHUNK + 1);
     let mut window = [0f32; CHUNK];
     for chunk in samples.chunks(CHUNK) {
         for (i, slot) in window.iter_mut().enumerate() {
             *slot = chunk.get(i).map(|s| *s as f32 / 32768.0).unwrap_or(0.0);
         }
-        let result = vad
-            .compute(&window)
-            .map_err(|e| format!("Silero VAD compute: {e}"))?;
-        probs.push(result.prob);
+        probs.push(vad.compute(&window)?);
     }
     let frame_dur = CHUNK as f64 / RATE as f64;
 
@@ -575,22 +648,22 @@ mod tests {
         assert_eq!(round3(2.0 / 3.0), 0.667);
     }
 
-    // Integration guard: the Silero model loads through vad-rs and scores a
+    // Integration guard: the Silero model loads through tract and scores a
     // frame, and digital silence reads as non-speech. The model isn't bundled
     // — it's fetched to disk at runtime — so point this at a local copy via
-    // RECAST_SILERO_PATH; the test skips when that isn't set.
+    // RECAST_SILERO_PATH; the test skips when that isn't set. This also verifies
+    // tract can optimize + run the model's Conv/LSTM graph (the migration off ort).
     #[test]
     fn silero_model_loads_and_scores_silence_low() {
         let Ok(model) = std::env::var("RECAST_SILERO_PATH") else {
             eprintln!("skipping: set RECAST_SILERO_PATH to the silero_vad.onnx file");
             return;
         };
-        let mut vad = vad_rs::Vad::new(&model, super::RATE as usize).expect("init Silero VAD");
-        vad.reset();
+        let mut vad = super::SileroVad::new(std::path::Path::new(&model)).expect("init Silero VAD");
+        vad.reset().expect("reset");
         let p = vad
             .compute(&[0f32; super::CHUNK])
-            .expect("Silero VAD compute")
-            .prob;
+            .expect("Silero VAD compute");
         assert!((0.0..=1.0).contains(&p), "probability in range, got {p}");
         assert!(
             p < 0.5,

--- a/apps/desktop/src-tauri/src/transcription/capabilities.rs
+++ b/apps/desktop/src-tauri/src/transcription/capabilities.rs
@@ -26,6 +26,10 @@ pub struct DeviceCapabilities {
     pub arch: String,
     pub total_ram_bytes: Option<u64>,
     pub gpu: GpuInfo,
+    /// Whether the on-device caption engine is compiled into this build. False on
+    /// the Intel-Mac build (no `ort`/ONNX Runtime for x86_64-apple-darwin), where
+    /// the UI shows a "captions unavailable" notice instead of the generator.
+    pub captions_available: bool,
 }
 
 pub fn detect() -> DeviceCapabilities {
@@ -34,6 +38,7 @@ pub fn detect() -> DeviceCapabilities {
         arch: std::env::consts::ARCH.to_string(),
         total_ram_bytes: total_ram(),
         gpu: detect_gpu(),
+        captions_available: cfg!(feature = "captions"),
     }
 }
 

--- a/apps/desktop/src/components/editor/properity-panel/CaptionsPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/CaptionsPanel.svelte
@@ -347,7 +347,21 @@
       {/if}
     {/snippet}
 
-    {#if !hasAudio}
+    {#if caps && !caps.captionsAvailable}
+      <!-- On-device captions aren't in this build (Intel Mac — no ONNX Runtime
+           for x86_64-apple-darwin). The rest of the editor works normally. -->
+      <div
+        class="flex flex-col items-center gap-1.5 rounded-lg border border-dashed border-border/60 bg-card/40 px-4 py-6 text-center"
+      >
+        <Cpu size={20} class="text-muted-foreground" />
+        <p class="text-[12px] font-medium text-foreground">Captions not available on Intel Mac</p>
+        <p class="max-w-60 text-[10.5px] leading-relaxed text-muted-foreground">
+          On-device transcription needs a runtime Apple no longer ships for Intel
+          Macs. Everything else in the editor works. Captions run on Apple Silicon,
+          Windows, and Linux.
+        </p>
+      </div>
+    {:else if !hasAudio}
       <!-- Nothing to transcribe: a silent recording (no audio stream on the
            video or a separate mic track) can't produce captions. -->
       <div

--- a/apps/desktop/src/constants/changelog.ts
+++ b/apps/desktop/src/constants/changelog.ts
@@ -37,6 +37,23 @@ export const KIND_META: Record<
 // RELEASES:START — auto-generated, do not edit by hand
 export const RELEASES: readonly ChangelogRelease[] = [
 	{
+		version: '0.2.10',
+		date: '2026-07-01',
+		highlights: [
+			'Animated captions: highlight the word being spoken, pop words in one at a time, or reveal short phrases.',
+			'Captions sit around the padded video frame and export with their real fonts.',
+		],
+		changes: [
+			{ kind: 'added', summary: 'Animated captions. Captions can now animate in time with speech: highlight the word being spoken karaoke-style, pop each word in one at a time, or fade in short phrases. A set of modern presets (Clean, Pill, Bold, Spotlight, Wave, Punch, Hype) ships with matching fonts, colors, and animation, and the theme picker previews each one. Controls for how words are grouped, the active-word highlight, the entrance effect, and position all live in the Captions tab.' },
+			{ kind: 'added', summary: 'The Captions tab now tells you when a recording has no audio to transcribe, instead of letting you try and fail.' },
+			{ kind: 'changed', summary: 'Captions are positioned against the whole video frame. When you add padding, top and bottom captions sit in the margin instead of overlapping the footage, and the preview matches the exported video. The position control moved next to alignment and now nudges captions in either direction over a wider range.' },
+			{ kind: 'changed', summary: 'Refreshed the built-in caption styles with modern fonts and colors.' },
+			{ kind: 'changed', summary: 'On-device captions need Apple Silicon, Windows, or Linux. On Intel Macs the Captions tab explains this and the rest of the editor works normally.' },
+			{ kind: 'fixed', summary: 'Caption fonts now render in exported video, not just the preview.' },
+			{ kind: 'fixed', summary: 'Exporting a recording that has cuts or speed changes no longer holds the last frame for several seconds or produces a file longer than the edit.' },
+		],
+	},
+	{
 		version: '0.2.9',
 		date: '2026-06-29',
 		changes: [

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -663,6 +663,9 @@ export interface DeviceCapabilities {
 	arch: string;
 	totalRamBytes: number | null;
 	gpu: GpuInfo;
+	/** Whether the on-device caption engine is in this build. False on the
+	 *  Intel-Mac build (no ONNX Runtime for x86_64-apple-darwin). */
+	captionsAvailable: boolean;
 }
 
 /** OS / arch / RAM / GPU probe used to gate which caption models are offered. */


### PR DESCRIPTION


Intel-Mac (x86_64-apple-darwin) builds failed because ort rc.12 has no ONNX Runtime prebuilt for that target (Microsoft dropped it at 1.24), and ort was pulled unconditionally by silence detection.

- Silence detection now runs Silero VAD on tract (pure Rust) instead of vad-rs, dropping the native ONNX Runtime from the always-on path. The new SileroVad mirrors the exact model I/O (input/sr/h/c -> output/hn/cn) so it's the same graph, just a different engine.
- ort is now optional and gated behind the `captions` feature; vad-rs is removed and tract-onnx added. A captions-off build pulls no ort and compiles on every target (verified: default + --no-default-features).
- CI: restore the macos-x64 target, built `--no-default-features` (no captions), and put darwin-x86_64 back in the latest.json require list.
- Device caps report `captionsAvailable` (= cfg!(feature = "captions")); the Captions tab shows a "not available on Intel Mac" notice when it's off.

Intel Macs get the full editor (silence detection included); on-device captions require Apple Silicon, Windows, or Linux.