### PR TITLE
feat: add option to hide recording panel from captures

### DIFF
--- a/apps/desktop/docs/cross-platform-support-plan.md
+++ b/apps/desktop/docs/cross-platform-support-plan.md
@@ -1,430 +1,155 @@
 # Cross-Platform Support Plan — macOS & Linux
 
-> Status: **Code-complete, verification-gated** · Created 2026-05-19 ·
-> Last updated 2026-06-08 · Owner: Kanak
+> Status: **Code-complete, verification-gated** · Owner: Kanak · Last updated 2026-07-05
 >
-> **Original framing (2026-05-19):** the app was fully functional only on
-> Windows; macOS/Linux produced a file but silently degraded several capture
-> subsystems to stubs (silent audio, no cursor track, camera errors), and
-> Linux screen capture was written but unverified.
+> Every capture subsystem — screen, system audio, microphone, camera, cursor,
+> device enumeration — is implemented and green in CI on Windows, macOS, and
+> Linux. The remaining distance to production is **runtime verification on real
+> macOS/Linux hardware**, not missing code. Windows is the shipping reference
+> platform; macOS is in active testing; Linux has not yet had a hardware pass.
 >
-> **Where we are now (2026-06-08):** every capture subsystem — screen, system
-> audio, microphone, camera, cursor, device enumeration — is *implemented* on
-> all three OSes. The remaining distance to production is **runtime
-> verification on real macOS/Linux hardware**, not missing code. macOS is in
-> active testing (a real macOS build surfaced and we fixed a post-recording
-> UI-freeze; see the 2026-06-08 hardening note). Linux has not yet had a
-> hardware pass. See the **[readiness scorecard](#readiness-scorecard--2026-06-08)**
-> for the per-OS gap.
+> This doc tracks **current state and what's left**. Implementation history
+> (what landed when, hardening passes, fixed audit findings) lives in
+> `CHANGELOG.md` — it is deliberately not duplicated here.
 
 ---
 
-<a name="readiness-scorecard--2026-06-08"></a>
-
-## 0. Readiness scorecard — 2026-06-08
+## Readiness scorecard
 
 "Code complete" = the path is written and compiles in CI for that target.
-"Production-ready" = a real user on that OS can record → edit → export without
+"Production-ready" = a real user can record → edit → export on that OS without
 hitting a known-broken path, verified on hardware.
 
 | OS | Code complete | Production-ready | What's actually left |
 |---|---|---|---|
 | **Windows** | 100% | **~100% — shipping** | Verified, in users' hands. The reference platform. |
-| **macOS** | ~95% | **~75%** | (a) Out-of-the-box **system audio** needs BlackHole/virtual driver — native ScreenCaptureKit loopback is implemented but **default-off** behind the `sckit-loopback` Cargo feature (upstream SDK-symbol issue). (b) Hardware verification of capture + the TCC permission flow + Retina/multi-monitor. (c) Deferred capture-read robustness (a stalled device can hang `stop()`). (d) Developer-ID signing + **notarization** (identity task, gates a no-warnings download). (e) First-run permissions UX. |
-| **Linux** | ~90% | **~60%** | (a) **Zero hardware verification yet** — biggest unknown. Portal+PipeWire (Wayland) and XGetImage (X11) are written + audit-fixed (F1) but never run on a real session. (b) Wayland: cursor double-render (`CursorMode::Embedded`) and a portal dialog on every record (no `restore_token` persistence). (c) X11 perf TODOs: XShm fast path unwired, ~4× over-capture (F4); window-occlusion not handled. (d) Functional sign-off on GNOME + KDE + an X11 session. |
+| **macOS** | ~95% | **~75%** | (a) Out-of-the-box **system audio** needs BlackHole/virtual driver — native ScreenCaptureKit loopback is implemented but **default-off** behind the `sckit-loopback` Cargo feature (upstream apple-metal SDK-symbol issue). (b) Hardware verification of capture + the TCC permission flow + Retina/multi-monitor. (c) Deferred capture-read timeout (a stalled device can hang `stop()`). (d) Developer-ID signing + **notarization**. (e) First-run permissions UX. |
+| **Linux** | ~90% | **~60%** | (a) **Zero hardware verification yet** — biggest unknown. Portal+PipeWire (Wayland) and XGetImage (X11) are written but never run on a real session. (b) Wayland: cursor double-render and a portal dialog on every record (no `restore_token` persistence). (c) X11 perf: XShm fast path unwired, ~4× over-capture, window-occlusion not handled. (d) Functional sign-off on GNOME + KDE + an X11 session. |
 
-**One-line answer to "how far behind?":** Windows is done. **macOS is roughly
-one focused hardware-test + audio-default + notarization cycle from a public
-beta.** **Linux is one hardware bring-up cycle behind macOS** — the code is
-there, but nothing has run on a real Linux session, so confidence is lowest.
+**One-line answer:** Windows is done. **macOS is roughly one focused
+hardware-test + audio-default + notarization cycle from a public beta.**
+**Linux is one hardware bring-up cycle behind macOS** — the code is there, but
+nothing has run on a real Linux session, so confidence is lowest.
 
-### Stability hardening landed 2026-06-08 (cross-cutting, helps macOS/Linux most)
-A pass over the recording IPC surface fixed a class of freeze/hang that only
-*manifests* on macOS/Linux (their in-process WebView renders on the same main
-thread Tauri runs sync commands on; Windows' out-of-process WebView2 masked it):
-
-- `start_recording` / `stop_recording`, `get_audio_devices`,
-  `list_recasts` / `list_exports`, `open_file_location` were **synchronous**
-  commands doing process-spawn / thread-join / device-enum / disk work on the
-  UI thread → converted to `async` + `spawn_blocking`. (`stop_recording` was
-  the post-record freeze a macOS tester reported.)
-- Encoder **stderr-pipe deadlock**: FFmpeg's progress output filled the
-  undrained ~64KB stderr pipe on long recordings → froze the encode
-  mid-capture. Now drained continuously on a side thread.
-- Recording **start-failure orphan cascade**: a partial `start()` failure left
-  capture/encoder threads (and their FFmpeg children) running forever; now torn
-  down on the error path.
-- A compile-time regression guard keeps `start`/`stop_recording` async.
-
-**Still open (deferred, needs on-device validation):** interruptible/timeout
-reads in `capture/platform/macos.rs` and `linux_x11.rs` so a device stall
-(permission revoked mid-record, hung X server) can't block `stop()`.
+> Dev-host note: the Linux capture stack (`pipewire`, `ashpd`, `x11rb`) links
+> system C libraries and cannot build on the Windows dev host; CI is the compile
+> gate, but functional capture testing needs real Linux/macOS hardware.
 
 ---
 
-## 1. Current state by platform
+## Current state by subsystem
 
-Legend: ✅ verified on hardware · 🟢 implemented, compiles in CI, **not yet
+Legend: ✅ verified on hardware · 🟢 implemented + green in CI, **not yet
 hardware-verified** · ⚠️ implemented with a known limitation · ❌ stub/no-op.
-(Updated 2026-06-08 — the rows the original plan marked "❌ empty list" for
-device enumeration are now implemented.)
 
 | Subsystem | Windows | Linux | macOS |
 |---|---|---|---|
-| Screen capture | ✅ DXGI Desktop Duplication | 🟢 Wayland (portal+PipeWire, F1 fix landed) & X11 (XGetImage) — written, awaiting hardware test | 🟢 FFmpeg AVFoundation (replaces xcap) |
-| System audio (loopback) | ✅ WASAPI | 🟢 FFmpeg pulse `.monitor` (silence fallback if no PA) | ⚠️ Default path = BlackHole/Soundflower/Loopback/VB-Cable if installed, else silence + actionable log. Native **ScreenCaptureKit loopback is now implemented** but **default-off** behind the `sckit-loopback` Cargo feature (upstream apple-metal SDK-symbol issue) |
+| Screen capture | ✅ DXGI Desktop Duplication | 🟢 Wayland (portal+PipeWire) & X11 (XGetImage) | 🟢 FFmpeg AVFoundation |
+| System audio (loopback) | ✅ WASAPI | 🟢 FFmpeg pulse `.monitor` (silence fallback if no PA) | ⚠️ BlackHole/virtual driver if installed, else silence + actionable log; native ScreenCaptureKit loopback implemented but **default-off** behind `sckit-loopback` |
 | Microphone | ✅ WASAPI | 🟢 FFmpeg pulse `default` | 🟢 FFmpeg avfoundation `:0` |
 | Camera / webcam | ✅ FFmpeg DirectShow | 🟢 FFmpeg V4L2 | 🟢 FFmpeg AVFoundation |
 | Cursor sampling | ✅ Win32 GetCursorPos | 🟢 device_query (xcb / XWayland) | 🟢 device_query (CoreGraphics) |
 | Reveal in file manager | ✅ `explorer /select,` | 🟢 D-Bus `FileManager1.ShowItems` + xdg-open fallback | 🟢 `open -R` |
 | Audio device list | ✅ WASAPI enumerate | 🟢 `pactl list short sources` (`.monitor` filtered) | 🟢 AVFoundation listing parsed |
-| Camera device list | ✅ FFmpeg `-list_devices` | 🟢 `/dev/video*` + sysfs V4L2-capture filter | 🟢 AVFoundation listing (screens filtered) |
+| Camera device list | ✅ FFmpeg `-list_devices` | 🟢 `/dev/video*` + sysfs V4L2 filter | 🟢 AVFoundation listing (screens filtered) |
 | Capture capabilities probe | ✅ `capture_capabilities` | 🟢 `capture_capabilities` | 🟢 `capture_capabilities` |
-| Window capture-exclusion | ✅ `SetWindowDisplayAffinity` | ❌ no-op (deferred) | ❌ no-op (deferred) |
+| Window capture-exclusion | ✅ `set_content_protected` (`WDA_EXCLUDEFROMCAPTURE`) | ❌ no-op (no OS API — X11/Wayland have no per-window exclusion) | 🟢 `set_content_protected` (`NSWindow.sharingType`), works vs. AVFoundation capture |
 | Video encoding | ✅ FFmpeg (NVENC/x264) | 🟢 FFmpeg (x264, hw if present) | 🟢 FFmpeg (x264, VideoToolbox if present) |
 | Delete to trash | ✅ `trash` crate | 🟢 `trash` crate | 🟢 `trash` crate |
 
-**Good news:** the architecture already has a clean per-module
-`platform/{windows,fallback,...}.rs` abstraction with `#[cfg]` dispatch, so
-each gap is an additive, isolated file — no refactor required. FFmpeg is the
-codec/format abstraction layer and is already cross-platform. **The 🟢 rows are
-the whole story now: code is written and green in CI on every target; the
-distance to ✅ is a person sitting in front of a Mac / a Linux box.**
+The architecture uses a per-module `platform/{windows,macos,linux_*,fallback}.rs`
+abstraction with `#[cfg]` dispatch, and FFmpeg as the codec/format layer, so each
+gap is an additive, isolated file — no refactor required. **The 🟢 rows are the
+whole story: code is written and green in CI on every target; the distance to ✅
+is a person sitting in front of a Mac / a Linux box.**
 
 ---
 
-## 2. Phased plan
+## What's left, by area
 
-Ordered by **value-per-effort** — cheapest, highest-confidence wins first.
+### macOS — nearest milestone (in active testing)
+- **Hardware pass:** capture + TCC permissions + Retina/multi-monitor.
+- **System-audio default decision** *(biggest out-of-the-box gap):* enable
+  `sckit-loopback` once the upstream apple-metal SDK-symbol issue clears, or
+  ship the BlackHole-guided path with clear in-app messaging. `macos_sckit.rs`
+  carries a Mac-reviewer smoke-test checklist. When enabled it shares the Screen
+  Recording TCC prompt with video, so there's no second permission cost.
+- **Deferred capture-read timeout:** interruptible/timeout reads in
+  `capture/platform/macos.rs` so a device stall (permission revoked mid-record)
+  can't block `stop()`.
+- **Permissions UX:** first launch prompts for Screen Recording / Microphone /
+  Camera implicitly; capture errors already name the relevant Settings pane. A
+  polished first-run flow with deep-links is a follow-up.
+- **Phase 5b (deferred):** swap the FFmpeg AVFoundation video source for a
+  ScreenCaptureKit `SCStream` video output (lower latency, per-window filtering,
+  native HiDPI). The audio half of SCKit is already wired, so the existing TCC
+  grant covers it; the cost is objc2 `CMSampleBuffer` → BGRA plumbing. FFmpeg
+  AVFoundation is the production bridge until then.
 
-### Phase 0 — Build & toolchain readiness *(prerequisite)*
-- **Per-push compile CI — done 2026-05-19.** `.github/workflows/ci-desktop.yml`
-  runs `tauri build --no-bundle` + clippy on Linux/macOS/Windows for every
-  push & PR, so cross-platform code stays green while it is written. The
-  release workflow (`release-desktop.yml`) already bundles all three on tags.
-- WSL note: WSL2 can *compile* the Linux code (needs Rust + the
-  `pipewire-upstream` PPA for headers ≥1.4) but **cannot test capture** —
-  WSLg ships no `xdg-desktop-portal` ScreenCast backend. CI covers the
-  compile gate; functional capture testing needs real Linux/macOS hardware.
-- Source per-platform FFmpeg + FFprobe static binaries; place under
-  `apps/desktop/binaries/` with the target-triple naming `ffmpeg.rs`
-  already expects (`ffmpeg-x86_64-apple-darwin`, `-aarch64-apple-darwin`,
-  `-x86_64-unknown-linux-gnu`, etc.). The release workflow already does this.
-- Confirm `cargo build` succeeds on each OS with the platform deps
-  (`ashpd`, `pipewire`, `x11rb` on Linux). Fix any compile breakage in the
-  `fallback.rs` stubs.
-- **Exit criteria:** an unsigned dev build launches and records *something*
-  on all three OSes.
+### Linux — one hardware bring-up behind
+- **Zero hardware verification** — the biggest unknown. Validate
+  `linux_wayland.rs` (portal dialog, PipeWire stream, frame pacing) on GNOME +
+  KDE and `linux_x11.rs` on an X11 session.
+- **Wayland cursor double-render:** `CursorMode::Embedded` burns the compositor
+  cursor into frames *and* we record positions → two cursors in export. Switch
+  to `CursorMode::Metadata` once the editor's stylized cursor is reliable on Linux.
+- **Portal dialog every record:** `PersistMode::DoNot` saves no consent. Switch
+  to `PersistMode::ExplicitlyRevoked` and persist the `restore_token` in
+  `AppConfig` for a one-time grant.
+- **X11 perf:** XShm fast path is unwired (per-frame XCB roundtrip); the pacer
+  drains ~4× per tick while `X11CaptureSource` ignores the timeout and returns a
+  fresh full-screen `GetImage` each call (~4× over-capture) — rate-limit inside
+  the source or land XShm. Window-occlusion (obscured region returns the
+  front-most window's pixels) is not handled.
+- **Portal stream lifetime:** `start_recording` stashes the portal stream before
+  `recording_manager.start()`; on a `start()` error the stashed fd lingers until
+  the next recording overwrites the slot. Stash after a successful start, or
+  clear on the error path.
 
-### Phase 1 — Linux screen capture validation *(low effort, code exists)*
-- **Pre-flight static audit — done 2026-05-19. See [Appendix A](#appendix-a)** —
-  one critical bug found before any Linux run.
-- Get a Linux machine / CI runner (this needs hardware — the `pipewire`,
-  `ashpd`, `x11rb` stack links against system C libs and cannot build on
-  the Windows dev host).
-- Fix audit finding **F1** (missing PipeWire `param_changed` handler) —
-  highest-risk, do before first run.
-- Test `capture/platform/linux_wayland.rs` on a real Wayland session
-  (GNOME + KDE): portal dialog, PipeWire stream, frame pacing.
-- Test `capture/platform/linux_x11.rs` on an X11 session.
-- Wire the XShm fast path (currently a TODO behind a feature flag) if X11
-  GetImage proves too slow.
-- **Exit criteria:** Linux screen recording verified at target FPS on both
-  session types.
+### HiDPI / fractional-scaling cursor (macOS + Linux)
+`device_query` has no cursor-visibility signal, so `visible` is always `true`
+(the frame-bounds check still hides the cursor when it leaves the recorded
+area). Under fractional scaling the editor's *stylized* cursor can be slightly
+offset from the real one; the recording itself is correct because the capture
+bakes the OS cursor. True Wayland-native tracking (libei / PipeWire cursor
+metadata) is the long-term fix.
 
-### Phase 2 — Cursor sampling *(done 2026-05-19)*
-Landed via a single shared file `cursor/platform/device_query_impl.rs`
-backed by the `device_query` crate (CoreGraphics on macOS, xcb on Linux).
-Dispatched from `cursor/platform/mod.rs` for `target_os = "macos"` and
-`"linux"`; the existing `fallback.rs` stays for other targets. Pointer
-state is sampled at 125 Hz by `cursor::spawn_cursor_capture`, identical to
-the Windows backend's contract.
+<a name="packaging-and-signing"></a>
 
-**Caveats** (documented in the impl file):
-- No cursor *visibility* signal — `device_query` doesn't expose
-  `CGCursorIsVisible` / X11 hide state, so `visible` is always `true`.
-  The cursor capture loop's frame-bounds check still hides the cursor
-  when it leaves the recorded area, so editor behaviour stays correct.
-- On Wayland, pointer queries go through XWayland (present on every
-  mainstream Wayland distro). Coords match the compositor 1:1 at
-  integer scaling; under HiDPI / fractional scaling the editor's
-  *stylized* cursor may be slightly offset from the user's actual
-  cursor. The recording itself shows the cursor correctly because the
-  portal stream uses `CursorMode::Embedded`. True Wayland-native
-  tracking (libei or PipeWire cursor metadata) is the long-term fix.
-- `DeviceState` is cached in `thread_local!` so the X11/CoreGraphics
-  handle is opened once, not per-sample.
+### Packaging and signing *(release path wired)*
+[`release-desktop.yml`](../../../.github/workflows/release-desktop.yml) builds
+and bundles MSI/NSIS (Windows), DMG + updater bundle (macOS), and AppImage +
+`.deb` (Linux) on every `v*` tag;
+[`ci-desktop.yml`](../../../.github/workflows/ci-desktop.yml) keeps each OS
+compiling on every push/PR.
 
-**Exit criteria:** zoom-trigger / idle detection works on macOS and Linux
-X11 — verified once CI compile-checks the build and a real machine
-records a session.
-
-### Phase 3 — Camera capture *(done 2026-05-19)*
-Landed as one shared file
-[`camera/platform/ffmpeg_unix.rs`](../src-tauri/src/camera/platform/ffmpeg_unix.rs)
-covering macOS (AVFoundation) and Linux (V4L2). Mirrors the existing
-`windows.rs` thread/stop-flag/graceful-stop structure exactly so the
-upstream `PlatformCameraSession` contract is unchanged. Same 1280×720@30
-defaults, same MP4 sanity check, same `q`-then-kill shutdown sequence.
-
-Device resolution falls back to the first available device when the JS
-panel sends "Default"/empty (matches the Windows path). Listing logic:
-- macOS — parses FFmpeg's `-list_devices true` stderr, skips the
-  "Capture screen N" pseudo-devices.
-- Linux — picks the lowest-numbered `/dev/video*` node up to 16.
-
-**Follow-up — done (since 2026-05-19):**
-`commands/system.rs::get_camera_devices` now enumerates on macOS (AVFoundation
-listing, "Capture screen" pseudo-devices filtered) and Linux (`/dev/video*` +
-sysfs `V4L2_CAP_VIDEO_CAPTURE` filter), so the in-app picker populates instead
-of leaning on the auto-first-device fallback. (Hardware-unverified.)
-
-### Phase 4 — Audio capture *(done 2026-05-19, with documented caveat)*
-Landed as one shared file
-[`audio/platform/ffmpeg_unix.rs`](../src-tauri/src/audio/platform/ffmpeg_unix.rs).
-FFmpeg streams raw PCM (`s16le` 48 kHz stereo) to stdout; the capture
-thread copies it into the existing `WavWriter`, honouring `pause_flag`
-exactly the way WASAPI does — drains the pipe always, only writes
-samples when not paused. A stop-watcher thread sends FFmpeg a graceful
-`q` on `stop_flag`, escalating to kill on timeout.
-
-**Loopback sources (three-tier resolution chain, top tier deferred):**
-- **macOS — ScreenCaptureKit** (`audio/platform/macos_sckit.rs`): the
-  only built-in macOS API for system audio without a virtual driver,
-  and the path every modern recorder uses. **Now implemented** against
-  the `screencapturekit` 6.0 crate (`SCShareableContent` → `SCStream`
-  with an audio handler → `CMSampleBuffer` Float32→s16le, pause
-  semantics matched to WASAPI). **Gated default-off behind the
-  `sckit-loopback` Cargo feature** because the build currently trips an
-  upstream apple-metal SDK-symbol issue on the CI SDK; the file carries
-  a Mac-reviewer smoke-test checklist. Until it's enabled by default,
-  the *effective* macOS loopback is the BlackHole/virtual-driver tier
-  below — **this is the single biggest macOS out-of-the-box gap.** When
-  on, it shares the Screen Recording TCC prompt with Phase 5 video, so
-  there is no second permission cost.
-- **macOS — BlackHole / virtual driver** (FFmpeg avfoundation): scans
-  for BlackHole / Soundflower / Loopback / VB-Cable and routes through
-  FFmpeg if present. Today's effective macOS loopback path.
-- **Linux** — `pactl get-default-sink` → `<sink>.monitor` via FFmpeg's
-  `-f pulse` input. Works on any PulseAudio or pipewire-pulse install.
-- **Silence + actionable warning** — final degrade when no tier
-  succeeds; the macOS message names BlackHole specifically.
-
-**Microphone:** AVFoundation `:0` (macOS) or `pulse default` (Linux); a
-user-supplied device id falls through if non-empty/non-"default". Mic
-failure surfaces as an error — there's no silent fallback for an
-explicitly-enabled mic.
-
-**Follow-up — done (since 2026-05-19):**
-`commands/system.rs::get_audio_devices` now enumerates on macOS (AVFoundation
-listing) and Linux (`pactl list short sources`, `.monitor` sources filtered
-out), so the mic picker populates instead of always defaulting.
-(Hardware-unverified.)
-
-### Phase 5 — macOS screen capture *(done 2026-05-19, with planned 5b)*
-Landed as
-[`capture/platform/macos.rs`](../src-tauri/src/capture/platform/macos.rs)
-using FFmpeg AVFoundation as a `CaptureSource`. A single long-lived
-FFmpeg subprocess streams raw BGRA frames over stdout; `capture_next()`
-reads exactly one frame's worth of bytes per call (same shape as
-`X11CaptureSource`). The pacer's `MAX_DRAIN` cap keeps the
-"always-Some" behaviour in check.
-
-`-vf scale=W:H` forces output dimensions to match what the encoder
-expects, regardless of the screen's native resolution; `-capture_cursor 1`
-matches the Wayland path's `CursorMode::Embedded`. macOS no longer hits
-the xcap fallback at all.
-
-**Known limitations:**
-- First "Capture screen" device only — multi-monitor users get the
-  primary display; mapping xcap monitor IDs to AVFoundation indices is
-  a follow-up.
-- No region capture on macOS; the in-app picker's region selector
-  doesn't propagate. AVFoundation captures full screen; `-vf scale=…`
-  matches dims. Cropping can be added with `-vf crop=…` later.
-- First record requires Screen Recording consent in
-  System Settings → Privacy & Security. FFmpeg will spawn but produce
-  zero frames until granted; surface this via the capture-source error
-  path.
-
-**Phase 5b (deferred):** ScreenCaptureKit *video* source. The audio
-half of SCKit is now wired (see Phase 4), so the Screen Recording TCC
-prompt the user sees on first record already grants SCKit access; a
-future iteration can swap the FFmpeg AVFoundation video source for an
-SCKit `SCStream` video output without re-prompting. Wins: lower
-latency, per-window/per-app filtering, native HiDPI handling. Cost:
-non-trivial objc2 plumbing around `CMSampleBuffer` video frame
-extraction → BGRA conversion. The FFmpeg backend is the production
-bridge until 5b lands.
-
-### Phase 6 — OS integration polish *(reveal landed 2026-05-19)*
-- **Reveal in file manager — landed.** `commands/system.rs::open_file_location`
-  now branches: Windows `explorer /select,`, macOS `open -R`, Linux
-  tries D-Bus `org.freedesktop.FileManager1.ShowItems` via `gdbus` and
-  falls back to `xdg-open` on the parent directory if D-Bus is
-  unavailable (covers GNOME/KDE/XFCE/Cinnamon natively).
-- **Window capture-exclusion — deferred.** macOS would use
-  `NSWindow.sharingType = .none`; Linux has no portable API. Both stay
-  no-op until there is a user-visible need.
-- **Permissions UX — deferred.** macOS Screen Recording / Microphone /
-  Camera TCC prompts surface implicitly on first attempt (the user gets
-  an OS dialog). A polished first-run flow with deep-links to System
-  Settings is a follow-up; right now the capture error messages name
-  the relevant Settings pane.
-
-### Phase 7 — Packaging, signing & distribution *(release path already wired)*
-[`release-desktop.yml`](../../../.github/workflows/release-desktop.yml)
-already builds and bundles MSI/NSIS (Windows), DMG + updater bundle
-(macOS), and AppImage + `.deb` (Linux) on every `v*` tag. The
-per-push CI gate added in Phase 0
-([`ci-desktop.yml`](../../../.github/workflows/ci-desktop.yml)) keeps
-each OS compiling on every change.
-
-**Still missing for a real macOS public ship:**
-- Developer ID signing + **notarization** + stapling for the DMG and
-  updater bundle (currently produces unsigned DMGs the README warns
-  users to `xattr -dr com.apple.quarantine` past).
-- Hardened-runtime entitlements declaring `com.apple.security.device.camera`,
-  `device.microphone`, and the screen-capture entitlement.
-
-These are credential/identity tasks, not code tasks — outside the scope
-of cross-platform code parity, but they gate a "no warnings" macOS
-download experience.
+**Still missing for a real macOS public ship** (credential/identity tasks, not
+code): Developer-ID signing + **notarization** + stapling for the DMG and
+updater bundle (today's DMGs are unsigned, requiring an `xattr -dr
+com.apple.quarantine` on first launch), and hardened-runtime entitlements for
+`device.camera`, `device.microphone`, and screen capture.
 
 ---
 
-## 3. Effort & risk summary
+## Milestones
 
-| Phase | Effort | Risk | Notes |
-|---|---|---|---|
-| 0 Toolchain | M | Low | Pure setup |
-| 1 Linux capture validation | S | Low | Code already written |
-| 2 Cursor sampling | S | Low | Wayland has a known limitation |
-| 3 Camera | M | Low | FFmpeg does the heavy lifting |
-| 4 Audio | L | **High** | macOS loopback is the hardest single item |
-| 5 macOS screen capture | L | Med | ScreenCaptureKit; pair with Phase 4 |
-| 6 OS integration | S | Low | Scattered small items |
-| 7 Packaging/signing | M | Med | macOS notarization is fiddly |
-
-**Critical path / biggest unknowns:** macOS system-audio loopback (Phase 4)
-and ScreenCaptureKit bring-up (Phase 5). De-risk these early with a spike
-before committing the rest of Phase 4–5.
-
-**Suggested milestones (re-sequenced 2026-06-08 — all code now landed, so these
-are *verification* milestones, not build milestones):**
-- **M1 — macOS beta** *(now the nearer milestone — macOS is already in active
-  testing):* hardware pass on capture + TCC permissions + Retina/multi-monitor;
-  decide system-audio default (enable `sckit-loopback` once the SDK-symbol issue
-  clears, or ship the BlackHole-guided path with clear in-app messaging); land
-  the deferred capture-read timeout; Developer-ID signing + notarization (Phase
-  7). Ship behind a "macOS preview" label.
-- **M2 — Linux beta:** first real hardware bring-up on GNOME + KDE (Wayland) and
-  an X11 session; fix Wayland cursor double-render + portal-every-record; X11
-  perf (XShm / over-capture) only if a tested display needs it.
+- **M1 — macOS beta** *(nearer; already in active testing):* hardware pass on
+  capture + TCC + Retina/multi-monitor; decide the system-audio default; land
+  the deferred capture-read timeout; Developer-ID signing + notarization. Ship
+  behind a "macOS preview" label.
+- **M2 — Linux beta:** first hardware bring-up on GNOME + KDE (Wayland) and an
+  X11 session; fix Wayland cursor double-render + portal-every-record; X11 perf
+  (XShm / over-capture) only if a tested display needs it.
 
 ---
 
-## 4. Key files touched
+## Key files
 
-- `apps/desktop/src-tauri/src/capture/platform/` — `macos.rs` (new),
-  validate `linux_wayland.rs` / `linux_x11.rs`
-- `apps/desktop/src-tauri/src/audio/platform/` — `macos.rs`, `linux.rs` (new)
-- `apps/desktop/src-tauri/src/camera/platform/` — `macos.rs`, `linux.rs` (new)
-- `apps/desktop/src-tauri/src/cursor/platform/` — `macos.rs`, `linux.rs` (new)
-- `apps/desktop/src-tauri/src/commands/system.rs` — device enumeration,
-  window exclusion, reveal-in-explorer per-OS branches
-- `apps/desktop/src-tauri/Cargo.toml` — macOS deps
-  (`objc2` / `core-graphics` / `screencapturekit` bindings)
-- `apps/desktop/src-tauri/tauri.conf.json` — macOS entitlements, signing
-- `apps/desktop/binaries/` — per-platform FFmpeg/FFprobe
-
----
-
-<a name="appendix-a"></a>
-
-## Appendix A — Phase 1 pre-flight audit (2026-05-19)
-
-Static review of the already-written Linux capture code. It cannot be
-compiled or run on the Windows dev host, so this is a code-reading pass to
-catch bugs before the first Linux run. Findings ranked by first-run risk.
-
-> Note: a prior design doc, `apps/desktop/docs/linux-native-recording.md`,
-> was deleted from the working tree during this session. It held the
-> original lifecycle diagram and a first-iteration debug list. The relevant
-> conclusions are folded into this appendix; recover the file from git
-> (`git checkout -- apps/desktop/docs/linux-native-recording.md`) if its
-> diagrams are still wanted.
-
-### F1 — CRITICAL *(fixed 2026-05-19)* · PipeWire format negotiation
-`linux_wayland.rs::pipewire_capture_loop` originally registered only a
-`.process()` listener and assumed the portal-reported size + BGRA format
-matched what PipeWire actually streamed. But `build_format_param` offered
-`VideoSize` as a **Range (1×1 … 7680×4320)**, so the compositor was free
-to pick a different size — every frame would then fail the
-`slice.len() < total` check and be silently dropped → **black / zero-length
-recording with no error**.
-
-**Fix landed** as two layers in [linux_wayland.rs](../src-tauri/src/capture/platform/linux_wayland.rs):
-1. `build_format_param` now pins `VideoSize` to a fixed `Rectangle`
-   instead of a Range, so PipeWire either honours the portal-reported
-   dims or fails the stream connection (an observable failure replaces a
-   silent one).
-2. A `.param_changed()` listener parses the negotiated `VideoInfoRaw`
-   and stashes the real geometry in a shared `Arc<Mutex<…>>` that
-   `process()` reads each tick. With (1) in place the negotiated dims
-   should always match portal dims; if they ever don't, the log line
-   says so loudly and `process()` adapts.
-
-### F2 — HIGH *(resolved by F1 fix)* · Encoder size mismatch
-Same root cause as F1; with F1's fixed-size pin the encoder's
-portal-reported dims will always equal PipeWire's negotiated dims, so
-this no longer exists. If F1's `param_changed` warning ever fires, the
-encoder will still be wrong for that recording — but at that point the
-log makes it visible instead of silently producing a broken file.
-
-### F3 — MEDIUM · X11 frame buffer size was unvalidated *(fixed 2026-05-19)*
-`linux_x11.rs::capture_next` handed `GetImage`'s reply straight downstream
-as BGRA. If the X server packs depth-24 at 24 bpp, or pads scanlines to a
-wider `bitmap_pad`, `reply.data.len() != width*height*4` and the encoder
-panics or renders striped frames. **Fixed:** added a length check that
-returns a clear error naming the geometry mismatch. A real stride-repack
-path is still TODO if any tested display actually trips it.
-
-### F4 — MEDIUM (perf) · X11 captures ~4× more than needed
-The pacer's drain loop (`pipeline.rs`, `MAX_DRAIN = 4`) calls
-`capture_next(0)` up to 4× per tick. `X11CaptureSource` ignores the timeout
-and does a full synchronous `GetImage` on every call, returning `Some`
-unconditionally — so 3 of every 4 full-screen captures are discarded. At
-1080p60 that is ~180 wasted full-frame copies/sec. **Fix:** rate-limit
-inside `X11CaptureSource` (record last-capture `Instant`, return `Ok(None)`
-if called again within a frame period), or land the XShm fast path.
-
-### F5 — LOW · Portal stream orphaned if `recording_manager.start()` fails
-`commands/recording.rs::start_recording` calls `stash_portal_stream()`
-*before* `recording_manager.start()`. If `start()` returns `Err`, the
-stashed stream (and its open fd) is never consumed. Not a true leak — the
-next Wayland recording overwrites the slot via `.replace()` — but the fd
-lingers. **Fix:** stash after a successful `start()`, or clear the slot on
-the error path.
-
-### F6 — LOW · pipewire version drift in docs *(fixed 2026-05-19)*
-Design doc said `pipewire = "0.8"`; Cargo.toml pins `0.9` and the code uses
-the 0.9 `Rc` API (`ContextRc`, `MainLoopRc`, `connect_fd_rc`, `StreamBox`).
-Doc references corrected before the file was deleted.
-
-### Confirmed-still-present known issues (from the original debug list)
-- **Cursor double-render:** `CursorMode::Embedded` burns the compositor
-  cursor into frames *and* our own cursor track records positions — the
-  export shows two cursors. Switch to `CursorMode::Metadata` once the
-  editor's stylized cursor is reliable on Linux.
-- **Portal dialog every Record:** `PersistMode::DoNot` saves no consent.
-  Switch to `PersistMode::ExplicitlyRevoked` + persist the `restore_token`
-  in `AppConfig` for a one-time grant.
-
-### Audit verdict
-The architecture is sound and the dispatch logic in `capture/platform/mod.rs`
-is correct. **F1 is a genuine bug that will black-screen the first Wayland
-run** — fix it before testing. F3 and F6 are fixed. F4 and F5 are
-quality/perf items that can follow the first successful capture. None of
-this needs re-architecting; Phase 1 remains low-effort once a Linux host is
-available.
+- `apps/desktop/src-tauri/src/capture/platform/` — `macos.rs`,
+  `linux_wayland.rs`, `linux_x11.rs`, `windows.rs`, `fallback.rs`
+- `apps/desktop/src-tauri/src/{audio,camera,cursor}/platform/` — per-OS backends
+- `apps/desktop/src-tauri/src/commands/system.rs` — device enumeration, window
+  capture-exclusion, reveal-in-file-manager per-OS branches
+- `apps/desktop/src-tauri/Cargo.toml` — per-OS deps (`screencapturekit`,
+  `device_query`, `ashpd`/`pipewire`/`x11rb`)
+- `apps/desktop/binaries/` — per-platform FFmpeg/FFprobe sidecars

--- a/apps/desktop/src-tauri/src/commands/editor.rs
+++ b/apps/desktop/src-tauri/src/commands/editor.rs
@@ -1015,10 +1015,13 @@ fn warped_output_duration(segs: &[SpeedSegment]) -> f64 {
 /// exports run cuts + per-segment speed through select/setpts, so the stream is
 /// the warped duration — capping at the raw trimmed span would freeze the last
 /// frame over the infinite background for the cut/sped-away time (and truncate
-/// slow-motion, where warped > raw). GIF uses a separate cut/palette path and
-/// loops, so it keeps the raw trimmed span.
+/// slow-motion, where warped > raw). GIF keeps the raw trimmed span for a plain
+/// cuts-only export (it loops and has no infinite audio/background tail to
+/// freeze), but once per-segment speed warps the stream it must follow the
+/// warped length — otherwise slow-motion (warped > raw) is truncated and a
+/// speed-up leaves a dangling tail.
 fn output_duration_cap(format: &str, duration: f64, speed_segments: &[SpeedSegment]) -> f64 {
-    if format == "gif" {
+    if format == "gif" && !has_speed_change(speed_segments) {
         duration
     } else {
         warped_output_duration(speed_segments)
@@ -1858,16 +1861,40 @@ pub async fn export_video(
             std::process::id()
         ));
 
-        // Cuts apply to GIF too, but its two-pass palette path runs before the
-        // generic (MP4/WebM-only) cut stage below, so inject the same
-        // select+setpts into both the palette pre-pass and the main pass.
+        // Cuts AND per-segment speed apply to GIF too, but its two-pass palette
+        // path runs before the generic (MP4/WebM-only) cut+speed stage below, so
+        // build the same select+setpts warp here and inject it into both the
+        // palette pre-pass and the main pass. GIF has no audio, so there's no
+        // atempo counterpart; the downstream `fps=` resamples the warped PTS to
+        // CFR (dropping/duplicating frames as the speed demands).
         let gif_cut_select: Option<String> = {
             let export_cuts = collect_export_cuts(&request.render_state, trim_start, trim_end);
-            (!export_cuts.is_empty()).then(|| {
-                format!(
-                    "select='{}',setpts=N/FRAME_RATE/TB",
-                    build_cut_select_expr(&export_cuts)
-                )
+            let gif_speed_segments = build_speed_segments(
+                duration,
+                &export_cuts,
+                &request.render_state.split_points,
+                &request.render_state.segment_speeds,
+                trim_start,
+            );
+            let gif_speed_active = has_speed_change(&gif_speed_segments);
+            let has_cuts = !export_cuts.is_empty();
+            (has_cuts || gif_speed_active).then(|| {
+                let select_prefix = if has_cuts {
+                    format!("select='{}',", build_cut_select_expr(&export_cuts))
+                } else {
+                    String::new()
+                };
+                let setpts = if gif_speed_active {
+                    // Single-quote: the warp expression contains commas the
+                    // filtergraph parser would otherwise read as separators.
+                    format!(
+                        "setpts='({})/TB'",
+                        build_speed_setpts_expr(&gif_speed_segments)
+                    )
+                } else {
+                    "setpts=N/FRAME_RATE/TB".to_string()
+                };
+                format!("{select_prefix}{setpts}")
             })
         };
         let cut_select_for_prepass = gif_cut_select.clone();
@@ -3068,14 +3095,26 @@ mod cut_export_tests {
     }
 
     #[test]
-    fn output_cap_uses_warped_length_for_video_and_raw_for_gif() {
+    fn output_cap_uses_warped_length_when_speed_is_active_incl_gif() {
         // Two kept segments, the second sped 2× → raw span 8s, warped 4 + 2 = 6s.
         let segs = vec![seg(0.0, 4.0, 1.0), seg(4.0, 8.0, 2.0)];
         // Non-GIF caps at the real content length — this is the frozen-tail fix.
         assert!((output_duration_cap("mp4", 8.0, &segs) - 6.0).abs() < 1e-9);
         assert!((output_duration_cap("webm", 8.0, &segs) - 6.0).abs() < 1e-9);
-        // GIF keeps the raw trimmed span (its own cut/palette path).
+        // GIF now warps too (its palette path applies the same select+setpts), so
+        // the cap follows the warped length — capping at the raw 8s span would
+        // leave a frozen tail on the sped-up stream.
+        assert!((output_duration_cap("gif", 8.0, &segs) - 6.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn output_cap_keeps_raw_span_for_cuts_only_gif() {
+        // No speed change (all 1×): GIF keeps the raw trimmed span (it loops and
+        // has no infinite tail to freeze), even though the kept content is shorter.
+        let segs = vec![seg(0.0, 3.0, 1.0), seg(5.0, 8.0, 1.0)];
         assert!((output_duration_cap("gif", 8.0, &segs) - 8.0).abs() < 1e-9);
+        // Non-GIF still collapses to the kept length (6s here).
+        assert!((output_duration_cap("mp4", 8.0, &segs) - 6.0).abs() < 1e-9);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands/system.rs
+++ b/apps/desktop/src-tauri/src/commands/system.rs
@@ -185,6 +185,26 @@ pub fn set_close_to_tray(
     Ok(())
 }
 
+#[tauri::command]
+pub fn get_hide_panel_from_capture(state: State<'_, AppState>) -> Result<bool, String> {
+    Ok(state.config.read().hide_panel_from_capture)
+}
+
+#[tauri::command]
+pub fn set_hide_panel_from_capture(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    enabled: bool,
+) -> Result<(), String> {
+    let snapshot = {
+        let mut config = state.config.write();
+        config.hide_panel_from_capture = enabled;
+        config.clone()
+    };
+    save_config(&app, &snapshot);
+    Ok(())
+}
+
 /// Mirror the frontend telemetry-consent state into `AppConfig` so the native
 /// crash reporter (`telemetry.rs`) can read the `errors` flag and attribute
 /// crashes to the same anonymous `install_id` as JS events. Called from
@@ -568,42 +588,34 @@ fn get_device_name(device: &windows::Win32::Media::Audio::IMMDevice) -> Option<S
 /// a black box rather than excluded entirely) — still better than the
 /// preview leaking into the recording.
 ///
-/// No-op on non-Windows platforms.
+/// Delegates to Tauri/tao's `set_content_protected`, whose per-platform
+/// behavior is:
+///   - **Windows** — `SetWindowDisplayAffinity(hwnd, WDA_EXCLUDEFROMCAPTURE)`,
+///     which removes the window entirely from every capture surface (DXGI
+///     Desktop Duplication included — the API Recast records with).
+///   - **macOS** — `NSWindow.sharingType = .none`. Recast captures the screen
+///     through FFmpeg AVFoundation, a compositor-level source that honors
+///     `sharingType`, so the window is genuinely absent from the recording.
+///     (The macOS-15 ScreenCaptureKit exception that ignores this flag does
+///     not apply to an AVFoundation capture.)
+///   - **Linux** — compile-time no-op: tao gates the implementation to
+///     macOS+Windows (`window.rs`), because neither X11 root `GetImage` nor
+///     the PipeWire portal exposes a per-window exclusion primitive. The call
+///     is harmless and would start working if tao ever adds a Wayland path.
+///
+/// Async on purpose: sync Tauri commands run on the macOS main thread, and
+/// `set_content_protected` round-trips to the event loop — doing that from the
+/// main thread would deadlock. An async command runs off it.
 #[tauri::command]
-pub fn exclude_window_from_capture(app: AppHandle, label: String) -> Result<(), String> {
+pub async fn exclude_window_from_capture(app: AppHandle, label: String) -> Result<(), String> {
     let window = app
         .get_webview_window(&label)
         .ok_or_else(|| format!("window '{label}' not found"))?;
-    #[cfg(windows)]
-    {
-        use windows::Win32::Foundation::HWND;
-        use windows::Win32::UI::WindowsAndMessaging::{
-            SetWindowDisplayAffinity, WDA_EXCLUDEFROMCAPTURE,
-        };
-        let hwnd_raw = window
-            .hwnd()
-            .map_err(|e| format!("hwnd lookup failed for '{label}': {e}"))?;
-        // Tauri's `hwnd()` returns a `windows::Win32::Foundation::HWND`
-        // already, but the inner pointer type may differ between Tauri's
-        // pinned `windows` version and ours. Reconstruct from the raw
-        // pointer to be version-agnostic.
-        let hwnd = HWND(hwnd_raw.0 as *mut std::ffi::c_void);
-        unsafe {
-            SetWindowDisplayAffinity(hwnd, WDA_EXCLUDEFROMCAPTURE)
-                .map_err(|e| format!("SetWindowDisplayAffinity failed for '{label}': {e}"))?;
-        }
-        log::info!("excluded window '{label}' from screen capture");
-        Ok(())
-    }
-    #[cfg(not(windows))]
-    {
-        // Other platforms have their own per-OS exclusion APIs (macOS:
-        // CGSWindowSetSharingState; Linux: no portable equivalent). Phase 1
-        // ships Windows-only since the recording pipeline is Windows-only
-        // today; revisit if the platform matrix expands.
-        let _ = window;
-        Ok(())
-    }
+    window
+        .set_content_protected(true)
+        .map_err(|e| format!("content protection failed for '{label}': {e}"))?;
+    log::info!("excluded window '{label}' from screen capture");
+    Ok(())
 }
 
 /// Lock a window's resize to a fixed aspect ratio and cap its width at a

--- a/apps/desktop/src-tauri/src/commands/types.rs
+++ b/apps/desktop/src-tauri/src/commands/types.rs
@@ -133,6 +133,12 @@ pub struct AppConfig {
     /// who don't want background tray presence can flip this off in Settings.
     #[serde(default = "default_close_to_tray")]
     pub close_to_tray: bool,
+    /// When true, the floating recording panel is excluded from screen capture
+    /// (Windows `WDA_EXCLUDEFROMCAPTURE`, macOS `NSWindow.sharingType = .none`)
+    /// so Recast's own controls don't appear in the recorded video. Default on.
+    /// No effect on Linux, which has no per-window exclusion API.
+    #[serde(default = "default_hide_panel_from_capture")]
+    pub hide_panel_from_capture: bool,
     /// Telemetry consent, mirrored from the frontend `consent.svelte.ts` store
     /// so the native crash reporter (`telemetry.rs`) can read it without IPC.
     ///
@@ -165,6 +171,10 @@ fn default_close_to_tray() -> bool {
     true
 }
 
+fn default_hide_panel_from_capture() -> bool {
+    true
+}
+
 fn default_telemetry_errors() -> bool {
     true
 }
@@ -175,6 +185,7 @@ impl Default for AppConfig {
             output_dir: None,
             last_source: None,
             close_to_tray: true,
+            hide_panel_from_capture: true,
             telemetry_product: false,
             telemetry_errors: true,
             install_id: None,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -370,6 +370,8 @@ pub fn run() {
             commands::open_log_dir,
             commands::get_close_to_tray,
             commands::set_close_to_tray,
+            commands::get_hide_panel_from_capture,
+            commands::set_hide_panel_from_capture,
             commands::set_telemetry_consent,
             commands::gdrive_connect,
             commands::gdrive_status,

--- a/apps/desktop/src/components/editor/properity-panel/CaptionsPanel.svelte
+++ b/apps/desktop/src/components/editor/properity-panel/CaptionsPanel.svelte
@@ -22,6 +22,7 @@
     type CaptionAnimation,
   } from "$lib/captions/animation";
   import type { CaptionStyle, EditorStore } from "$lib/stores/editor-store.svelte";
+  import { toOutputTimeTranscript } from "$lib/services/export";
   import {
     AlertTriangle,
     AlignCenter,
@@ -222,7 +223,10 @@
         filters: [{ name: format.toUpperCase(), extensions: [format] }],
       });
       if (!dest) return;
-      await exportCaptions(t, format, dest);
+      // Map onto the output timeline (trim + cuts + speed) so cues line up with
+      // the exported video, not the raw recording — same warp the export dialog
+      // and Cloud track apply.
+      await exportCaptions(toOutputTimeTranscript(store, t), format, dest);
       toast.success(`Exported ${format.toUpperCase()}`);
     } catch (e) {
       toast.error(`Export failed: ${e}`);

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -984,6 +984,20 @@ export function fetchExtensionRegistry<T = unknown>(indexUrl: string): Promise<T
       y: window.screen.availHeight - panelHeight - 40,
     });
 
+    // Keep Recast's own controls out of the recorded video. Gated on the
+    // user setting (default on); exclusion must run on `tauri://created`, once
+    // the native window handle exists. No-op on Linux (no OS support).
+    panelWin.once("tauri://created", async () => {
+      try {
+        if (await getHidePanelFromCapture()) {
+          await excludeWindowFromCapture("recording-panel");
+        }
+      } catch (err) {
+        // Non-fatal: the panel just won't be hidden from the capture.
+        console.warn("recording panel capture-exclusion failed:", err);
+      }
+    });
+
     panelWin.once("tauri://error", (e) => console.error(e));
   }
 
@@ -1044,9 +1058,20 @@ export async function openCameraPreviewWindow() {
 // These wrappers are thin — web-safe callers guard with `isTauriApp()` themselves.
 
 /** Exclude a window (by Tauri label) from screen capture (Windows
- *  `SetWindowDisplayAffinity`). No-op on platforms without an equivalent. */
+ *  `SetWindowDisplayAffinity`, macOS `NSWindow.sharingType`). No-op on Linux,
+ *  which has no per-window exclusion API. */
 export function excludeWindowFromCapture(label: string): Promise<void> {
 	return invoke<void>("exclude_window_from_capture", { label });
+}
+
+/** Whether the floating recording panel is hidden from screen recordings.
+ *  Backed by `AppConfig.hide_panel_from_capture` (default on). */
+export function getHidePanelFromCapture(): Promise<boolean> {
+	return invoke<boolean>("get_hide_panel_from_capture");
+}
+
+export function setHidePanelFromCapture(enabled: boolean): Promise<void> {
+	return invoke<void>("set_hide_panel_from_capture", { enabled });
 }
 
 /** Refresh the system tray menu/icon. `isRecording` overrides the recording

--- a/apps/desktop/src/lib/services/export.ts
+++ b/apps/desktop/src/lib/services/export.ts
@@ -173,8 +173,10 @@ export interface CaptionExportPayload {
 }
 
 /** Map a transcript onto the OUTPUT timeline (trim + cuts + per-segment speed)
- *  so sidecar timings line up with the exported video, not the raw recording. */
-function toOutputTimeTranscript(store: EditorStore, src: Transcript): Transcript {
+ *  so sidecar timings line up with the exported video, not the raw recording.
+ *  Exported so ad-hoc sidecar exports (e.g. the Captions panel's SRT/VTT
+ *  buttons) apply the same warp the export dialog and Cloud track do. */
+export function toOutputTimeTranscript(store: EditorStore, src: Transcript): Transcript {
 	const map = store.timeMap;
 	const at = (t: number) => originalToOutput(map, t);
 	const segments = src.segments

--- a/apps/desktop/src/routes/(app)/settings/+page.svelte
+++ b/apps/desktop/src/routes/(app)/settings/+page.svelte
@@ -9,9 +9,11 @@
   import {
     getCloseToTray,
     getDisplays,
+    getHidePanelFromCapture,
     getLastSource,
     getOutputDir,
     setCloseToTray,
+    setHidePanelFromCapture,
     setOutputDir,
   } from "$lib/ipc";
   import {
@@ -26,6 +28,7 @@
     Cloud,
     Cpu,
     ExternalLink,
+    EyeOff,
     FlaskConical,
     FolderOpen,
     Globe,
@@ -51,6 +54,7 @@
   import { setMode } from "@recast/ui/theme";
   import { cn } from "@recast/ui/utils";
   import { listen } from "@tauri-apps/api/event";
+  import { platform } from "@tauri-apps/plugin-os";
   import { onMount } from "svelte";
   import { cubicOut } from "svelte/easing";
   import { fly } from "svelte/transition";
@@ -88,6 +92,11 @@
   let editorWindow = $state<EditorBehavior>("navigate");
   let countdown = $state<CountdownSeconds>(3);
   let closeToTray = $state(true);
+  let hidePanelFromCapture = $state(true);
+  // Content protection is a compile-time no-op on Linux (tao gates it to
+  // macOS+Windows; X11/Wayland expose no per-window capture-exclusion API), so
+  // the toggle is shown disabled there rather than pretending it does anything.
+  const isLinux = platform() === "linux";
   // Global recording prefs, read by the recording panel via shared localStorage.
   let recordingQuality = $state<RecordingQuality>("auto");
   let recordingFps = $state<number>(60);
@@ -234,6 +243,11 @@
       // Pre-tray builds or non-Tauri preview — leave the default and let
       // the UI render the optimistic value.
     }
+    try {
+      hidePanelFromCapture = await getHidePanelFromCapture();
+    } catch {
+      // Older builds or non-Tauri preview — keep the optimistic default.
+    }
   }
 
   async function toggleCloseToTray() {
@@ -244,6 +258,17 @@
     } catch (e) {
       // Roll back on failure so the UI mirrors the actual persisted state.
       closeToTray = !next;
+      toast.error(`Could not update setting: ${e}`);
+    }
+  }
+
+  async function toggleHidePanelFromCapture() {
+    const next = !hidePanelFromCapture;
+    hidePanelFromCapture = next;
+    try {
+      await setHidePanelFromCapture(next);
+    } catch (e) {
+      hidePanelFromCapture = !next;
       toast.error(`Could not update setting: ${e}`);
     }
   }
@@ -592,6 +617,73 @@
                         </button>
                       {/each}
                     </div>
+                  </div>
+                </div>
+              </section>
+
+              <!-- Recording panel visibility -->
+              <section id="settings-panel-capture" class="flex flex-col gap-3">
+                <div class="px-1">
+                  <h2
+                    class="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.15em] text-muted-foreground/70"
+                  >
+                    <EyeOff class="size-3 text-primary" />
+                    Recording panel
+                  </h2>
+                  <p class="mt-0.5 text-[11px] text-muted-foreground/80">
+                    Whether Recast's own floating controls show up in the video.
+                  </p>
+                </div>
+                <div
+                  class="rounded-xl border border-border/60 bg-card/70 shadow-(--shadow-craft-inset) backdrop-blur"
+                >
+                  <div class="flex items-center justify-between gap-3 px-4 py-3">
+                    <div class="min-w-0">
+                      <div class="text-[12px] font-semibold text-foreground">
+                        Hide recording panel from captures
+                      </div>
+                      <div class="text-[11px] text-muted-foreground">
+                        {#if isLinux}
+                          Not available on Linux — X11 and Wayland provide no way
+                          for an app to exclude its own window from screen
+                          capture.
+                        {:else if hidePanelFromCapture}
+                          The floating Recast panel is kept out of your
+                          recordings. Applies the next time the panel opens.
+                        {:else}
+                          The floating Recast panel appears in your recordings
+                          like any other window.
+                        {/if}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-label="Hide recording panel from captures"
+                      aria-checked={!isLinux && hidePanelFromCapture}
+                      disabled={isLinux}
+                      onclick={toggleHidePanelFromCapture}
+                      class={cn(
+                        "flex h-5 w-9 shrink-0 items-center rounded-full transition-colors",
+                        isLinux
+                          ? "cursor-not-allowed bg-input opacity-50 ring-1 ring-inset ring-border/50"
+                          : cn(
+                              "cursor-pointer",
+                              hidePanelFromCapture
+                                ? "bg-primary"
+                                : "bg-input ring-1 ring-inset ring-border/50",
+                            ),
+                      )}
+                    >
+                      <span
+                        class={cn(
+                          "size-4 rounded-full bg-card shadow-sm transition-transform",
+                          !isLinux && hidePanelFromCapture
+                            ? "translate-x-4.5"
+                            : "translate-x-0.5",
+                        )}
+                      ></span>
+                    </button>
                   </div>
                 </div>
               </section>
@@ -1152,34 +1244,31 @@
                     <Button
                       href="/whats-new"
                       variant="outline"
-                      size="sm"
-                      class="h-8 gap-1.5"
+                      size="xs"
                     >
-                      <Sparkles class="size-3.5 text-primary" />
-                      <span class="text-[11.5px]">What's new</span>
-                      <ArrowUpRight class="size-3 text-muted-foreground" />
+                      <Sparkles class="text-primary" />
+                      <span>What's new</span>
+                      <ArrowUpRight class="text-muted-foreground" />
                     </Button>
                     <Button
                       href={config.website}
                       target="_blank"
                       variant="outline"
-                      size="sm"
-                      class="h-8 gap-1.5"
+                      size="xs"
                     >
-                      <Globe class="size-3.5" />
-                      <span class="text-[11.5px]">Website</span>
-                      <ArrowUpRight class="size-3 text-muted-foreground" />
+                      <Globe />
+                      <span>Website</span>
+                      <ArrowUpRight class="text-muted-foreground" />
                     </Button>
                     <Button
                       href={config.github}
                       target="_blank"
                       variant="outline"
-                      size="sm"
-                      class="h-8 gap-1.5"
+                      size="xs"
                     >
-                      <GithubBrand class="size-3.5" />
-                      <span class="text-[11.5px]">GitHub</span>
-                      <ArrowUpRight class="size-3 text-muted-foreground" />
+                      <GithubBrand />
+                      <span>GitHub</span>
+                      <ArrowUpRight class="text-muted-foreground" />
                     </Button>
                   </div>
                 </div>

--- a/changelog-section.md
+++ b/changelog-section.md
@@ -1,0 +1,15 @@
+### Highlights
+- Scene animations: give any clip an entrance and exit — fade, slide, scale, pop, shrink, or rotate — that plays in the preview and renders in the exported video.
+- Exports are roughly 3.5× faster. A 46-second recording that took 5m42s now finishes in about 1m37s.
+
+### Added
+- Scene animations. Each clip can animate into and out of view — fade, slide, scale, pop, shrink, or rotate — with full easing control per side. A project-wide motion tone (Subtle, Balanced, Energetic) tunes the intensity across the whole timeline, and a Push transition can carry motion across a cut where content was removed. Animations play in the preview and render in the exported video.
+
+### Changed
+- Export defaults to 60fps for recordings above 60fps (Original, 30, and 24 stay selectable). It's imperceptible for a screen recording and roughly halves export time.
+- The background image is blurred once at export instead of on every frame, which more than halved the encode time on its own.
+- The export dialog names each prep step, rendering the cursor and annotation layer and then encoding, so it never sits on a blank "Preparing…".
+
+### Fixed
+- Scene animations now render in exported video, not just the preview.
+- Export progress and the time-remaining estimate are measured against the real output length, so the bar no longer stalls short of or overshoots 100% on projects with cuts or speed changes.

--- a/packages/ui/src/components/ui/button/button.svelte
+++ b/packages/ui/src/components/ui/button/button.svelte
@@ -32,7 +32,7 @@
 				secondary:
 					"border-secondary bg-secondary text-secondary-foreground border-border/30 shadow-craft-sm hover:bg-muted/50",
 				outline:
-					"border-accent bg-accent shadow-craft-sm hover:bg-accent/10 hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50",
+					"border-border text-foreground",
 				ghost:
 					"border-transparent hover:bg-muted/40 hover:text-accent-foreground dark:hover:bg-accent/50",
 				link: "text-primary underline-offset-4 hover:underline hover:scale-100",
@@ -52,9 +52,9 @@
 				raw: "border-0 p-0 h-auto w-auto hover:scale-100 active:scale-100",
 			},
 			size: {
-				default: "h-9 rounded-xl px-5 py-2.5 text-sm",
-				lg: "h-11 rounded-2xl px-8 text-base font-semibold",
-				sm: "h-8 rounded-lg px-3 text-xs",
+				default: "h-9 rounded-xl px-5 py-2.5 text-sm font-medium gap-2 [&_svg:not([class*='size-'])]:size-4",
+				lg: "h-11 rounded-2xl px-8 text-base font-semibold gap-2 [&_svg:not([class*='size-'])]:size-5",
+				sm: "h-8 rounded-lg px-3 text-xs gap-1.5 [&_svg:not([class*='size-'])]:size-3",
 				xs: "h-6 rounded-md px-2 text-[11px] gap-1.5 [&_svg:not([class*='size-'])]:size-3",
 				icon: "size-9 rounded-xl",
 				"icon-sm": "size-8 rounded-lg",

--- a/scripts/release/build-release-body.sh
+++ b/scripts/release/build-release-body.sh
@@ -35,6 +35,21 @@ PREV_TAG="${PREV_TAG:-}"
 body_file="${1:-$(mktemp)}"
 version="${TAG#v}"
 
+# 0. Product intro — a release page is often reached from a search result or a
+# direct link, not the in-app updater, so lead with what Recast is and which
+# platforms are stable vs. beta before the download list.
+{
+  echo "**Recast** is an offline-first screen recorder and editor. Record your"
+  echo "screen, then polish it with zoom, cursor smoothing, captions, and"
+  echo "annotations before exporting. Recording, editing, and export run fully"
+  echo "on your machine; nothing is uploaded unless you choose to share it."
+  echo
+  echo "> **Platform status:** Windows is stable. macOS (Apple Silicon & Intel)"
+  echo "> and Linux are in **beta**; read the platform notes below before you"
+  echo "> install."
+  echo
+} > "$body_file"
+
 # 1. What's new — curated CHANGELOG section, or fall back to GH auto-notes.
 found="false"
 if node scripts/extract-changelog.mjs "$version" --out changelog-section.md > /dev/null 2>&1; then
@@ -44,10 +59,9 @@ if node scripts/extract-changelog.mjs "$version" --out changelog-section.md > /d
     echo
     cat changelog-section.md
     echo
-  } > "$body_file"
+  } >> "$body_file"
 else
   echo "::warning::No CHANGELOG.md section for ${version}; falling back to auto-generated notes."
-  : > "$body_file"
 fi
 
 # 2. Downloads — point users at the right asset for their platform.
@@ -60,8 +74,8 @@ fi
   echo "| Windows 10/11 (x64) — Store package | \`recast_${version}_x64.msix\` |"
   echo "| macOS (Apple Silicon) — beta | \`recast_${version}_aarch64.dmg\` · or \`brew install --cask kanakkholwal/recast/recast\` |"
   echo "| macOS (Intel) — beta | \`recast_${version}_x64.dmg\` · or \`brew install --cask kanakkholwal/recast/recast\` |"
-  echo "| Linux (x64) — universal | \`recast_${version}_amd64.AppImage\` |"
-  echo "| Linux (x64) — Debian/Ubuntu | \`recast_${version}_amd64.deb\` |"
+  echo "| Linux (x64) — universal, beta | \`recast_${version}_amd64.AppImage\` |"
+  echo "| Linux (x64) — Debian/Ubuntu, beta | \`recast_${version}_amd64.deb\` |"
   echo
   echo "All assets ship with [GitHub artifact attestations](https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) for build provenance."
   echo
@@ -110,7 +124,7 @@ fi
   echo
   echo "After that, first launch will prompt for **Screen Recording**, **Microphone**, and **Camera** permission in System Settings → Privacy & Security. Grant the ones you intend to record from and restart the app."
   echo
-  echo "Once we ship a notarized build (tracked under [Phase 7 of the cross-platform plan](https://github.com/${REPO}/blob/main/apps/desktop/docs/cross-platform-support-plan.md#phase-7--packaging-signing--distribution-release-path-already-wired)) this step will go away."
+  echo "Once we ship a notarized build (tracked under [Packaging and signing in the cross-platform plan](https://github.com/${REPO}/blob/main/apps/desktop/docs/cross-platform-support-plan.md#packaging-and-signing)) this step will go away."
   echo
 } >> "$body_file"
 
@@ -119,7 +133,7 @@ fi
   echo "## System requirements"
   echo
   echo "- **Windows**: Windows 10 1809+ or Windows 11, x64. WebView2 Runtime (bundled by the installer)."
-  echo "- **macOS**: macOS 11 Big Sur or later. Universal screen recording, microphone, and accessibility permissions are required at first launch."
+  echo "- **macOS**: macOS 13 Ventura or later, Apple Silicon or Intel. Screen Recording, Microphone, and Camera permissions are requested at first launch (grant the ones you record from)."
   echo "- **Linux**: glibc 2.35+ (Ubuntu 22.04 / Fedora 36 / Debian 12 or newer). PipeWire 0.3+ recommended for system audio capture."
   echo
 } >> "$body_file"


### PR DESCRIPTION
- Introduced `hide_panel_from_capture` setting in AppConfig to control visibility of the recording panel in screen captures.
- Implemented commands to get and set the `hide_panel_from_capture` state.
- Updated the UI to allow users to toggle the setting, with appropriate messaging for Linux users.
- Adjusted export functionality to ensure captions align with the output timeline.
- Enhanced export performance and added scene animations for clips.
- Improved export dialog feedback and progress tracking.