### PR TITLE
fix(macos): strip Apple Quarantine from downloaded FFmpeg binaries

### DIFF
--- a/.changeset/good-moose-behave.md
+++ b/.changeset/good-moose-behave.md
@@ -1,0 +1,6 @@
+---
+"recast-desktop": patch
+kind: fixed
+---
+
+fix(macos): strip Apple Quarantine from downloaded FFmpeg binaries to prevent fallback to system PATH

--- a/scripts/release/download-ffmpeg-macos.sh
+++ b/scripts/release/download-ffmpeg-macos.sh
@@ -37,4 +37,5 @@ cp ffmpeg-extract/ffprobe "$dest/ffprobe-aarch64-apple-darwin" || true
 cp ffmpeg-extract/ffmpeg "$dest/ffmpeg-x86_64-apple-darwin" || true
 cp ffmpeg-extract/ffprobe "$dest/ffprobe-x86_64-apple-darwin" || true
 chmod +x "$dest"/ffmpeg-* "$dest"/ffprobe-* || true
+xattr -rc "$dest"/ffmpeg-* "$dest"/ffprobe-* || true
 rm -rf ffmpeg.zip ffprobe.zip ffmpeg-extract


### PR DESCRIPTION
### FIxes #91 
### What this PR does
Fixes the bug where macOS Apple Silicon users experience a crash (`No such filter: 'ass'`) during Captions Export.

### The Root Cause
The `evermeet.cx` binaries *do* contain `libass` and `fontconfig`. However, when this script downloads them via `curl`, macOS tags them with the Apple Quarantine attribute. 
When the app boots, `is_usable_pair()` tries to execute them, but macOS blocks it. Because the bundled binary fails the check, the app silently falls back to the system `PATH` (which usually lacks the subtitle filters).

### The Fix
Added `xattr -rc` to the download script. This strips the quarantine attribute immediately after downloading, ensuring the app is actually allowed to execute the fully-loaded bundled binaries instead of falling back to the system!